### PR TITLE
fix: embedded annotation should not be taken to top level

### DIFF
--- a/.changeset/wise-items-laugh.md
+++ b/.changeset/wise-items-laugh.md
@@ -1,0 +1,7 @@
+---
+"@sap-ux/annotation-converter": patch
+"@sap-ux/edmx-parser": patch
+"@sap-ux/vocabularies-types": patch
+---
+
+fix: embedded annotation should not be taken to top level

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -532,13 +532,14 @@ describe('Annotation Converter', () => {
 
     it('merge data properly', async () => {
         const parsedMetadata = parse(await loadFixture('merge/metadata.xml'));
-        const parsedAnnotations = parse(await loadFixture('merge/annotations.xml'));
+        const parsedAnnotations = parse(await loadFixture('merge/annotations.xml'), 'annotation.xml');
         const convertedTypes = convert(merge(parsedMetadata, parsedAnnotations));
         expect(convertedTypes.entityTypes[0].annotations?.UI?.LineItem?.length).toEqual(2);
         expect(
             convertedTypes.entityTypes[0].annotations?.UI?.LineItem?.[0]?.annotations?.UI?.Importance
         ).toBeUndefined();
-        const convertedMetadataTypes = convert(parsedMetadata);
+        const parsedMetadata2 = parse(await loadFixture('merge/metadata.xml'));
+        const convertedMetadataTypes = convert(parsedMetadata2);
         expect(convertedMetadataTypes.entityTypes[0].annotations?.UI?.LineItem?.length).toEqual(11);
         expect(
             convertedMetadataTypes.entityTypes[0].annotations?.UI?.LineItem?.[0]?.annotations?.UI?.Importance?.toString()

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -529,4 +529,19 @@ describe('Annotation Converter', () => {
             (convertedTypes.entityTypes[1].entityProperties[48].targetType as TypeDefinition).underlyingType
         ).toEqual('Edm.String');
     });
+
+    it('merge data properly', async () => {
+        const parsedMetadata = parse(await loadFixture('merge/metadata.xml'));
+        const parsedAnnotations = parse(await loadFixture('merge/annotations.xml'));
+        const convertedTypes = convert(merge(parsedMetadata, parsedAnnotations));
+        expect(convertedTypes.entityTypes[0].annotations?.UI?.LineItem?.length).toEqual(2);
+        expect(
+            convertedTypes.entityTypes[0].annotations?.UI?.LineItem?.[0]?.annotations?.UI?.Importance
+        ).toBeUndefined();
+        const convertedMetadataTypes = convert(parsedMetadata);
+        expect(convertedMetadataTypes.entityTypes[0].annotations?.UI?.LineItem?.length).toEqual(11);
+        expect(
+            convertedMetadataTypes.entityTypes[0].annotations?.UI?.LineItem?.[0]?.annotations?.UI?.Importance?.toString()
+        ).toEqual('UI.ImportanceType/High');
+    });
 });

--- a/packages/annotation-converter/test/fixtures/merge/annotations.xml
+++ b/packages/annotation-converter/test/fixtures/merge/annotations.xml
@@ -13,7 +13,7 @@
     </edmx:Reference>
     <edmx:DataServices>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="sap.fe.core.ActionVisibility.LocalService">
-            <Annotations Target="sap.fe.core.ActionVisibility.RootElement">
+            <Annotations Target="ActionVisibility.RootElement">
                 <Annotation Term="UI.LineItem">
                     <Collection>
                         <Record Type="UI.DataField">

--- a/packages/annotation-converter/test/fixtures/merge/annotations.xml
+++ b/packages/annotation-converter/test/fixtures/merge/annotations.xml
@@ -1,0 +1,76 @@
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+        <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1" />
+    </edmx:Reference>
+    <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1" />
+    </edmx:Reference>
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+        <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1" />
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/fe/core/mock/action-visibility/$metadata">
+        <edmx:Include Alias="ActionVisibility" Namespace="sap.fe.core.ActionVisibility" />
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="sap.fe.core.ActionVisibility.LocalService">
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="Prop1"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="ID"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1" />
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1" />
+                            <PropertyValue Property="Determining" Bool="true" />
+                            <Annotation Term="UI.Hidden" Path="isBoundAction1Hidden" />
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2" />
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2" />
+                            <PropertyValue Property="Determining" Bool="true" />
+                            <Annotation Term="UI.Hidden" Path="isBoundAction2Hidden" />
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Header Action 1" />
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundHeaderAction1" />
+                            <PropertyValue Property="Determining" Bool="false" />
+                            <Annotation Term="UI.Hidden">
+                                <Eq>
+                                    <Path>isBoundAction1Hidden</Path>
+                                    <Bool>true</Bool>
+                                </Eq>
+                            </Annotation>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Header Action 2" />
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundHeaderAction2" />
+                            <PropertyValue Property="Determining" Bool="false" />
+                            <Annotation Term="UI.Hidden">
+                                <Not>
+                                    <Path>isBoundAction2Hidden</Path>
+                                </Not>
+                            </Annotation>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction1Hidden" />
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction2Hidden" />
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction3Hidden" />
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/annotation-converter/test/fixtures/merge/metadata.xml
+++ b/packages/annotation-converter/test/fixtures/merge/metadata.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+        <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml">
+        <edmx:Include Alias="Measures" Namespace="Org.OData.Measures.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+        <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema Namespace="sap.fe.core.ActionVisibility" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+            <EntityContainer Name="EntityContainer">
+                <EntitySet Name="RootElement" EntityType="sap.fe.core.ActionVisibility.RootElement">
+                    <NavigationPropertyBinding Path="Sibling" Target="RootElement"/>
+                    <NavigationPropertyBinding Path="_Elements" Target="SubElement"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="RootElement"/>
+                </EntitySet>
+                <EntitySet Name="SubElement" EntityType="sap.fe.core.ActionVisibility.SubElement">
+                    <NavigationPropertyBinding Path="owner" Target="RootElement"/>
+                    <NavigationPropertyBinding Path="Sibling" Target="SubElement"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="SubElement"/>
+                </EntitySet>
+            </EntityContainer>
+            <EntityType Name="RootElement">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+                <Property Name="Prop1" Type="Edm.String"/>
+                <Property Name="Prop2" Type="Edm.String"/>
+                <Property Name="isBoundAction1Hidden" Type="Edm.Boolean"/>
+                <Property Name="isBoundAction2Hidden" Type="Edm.Boolean"/>
+                <Property Name="isBoundAction3Hidden" Type="Edm.Boolean"/>
+                <Property Name="Sibling_ID" Type="Edm.Int32"/>
+                <NavigationProperty Name="Sibling" Type="sap.fe.core.ActionVisibility.RootElement">
+                    <ReferentialConstraint Property="Sibling_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <NavigationProperty Name="_Elements" Type="Collection(sap.fe.core.ActionVisibility.SubElement)" Partner="owner">
+                    <OnDelete Action="Cascade"/>
+                </NavigationProperty>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="sap.fe.core.ActionVisibility.DraftAdministrativeData" ContainsTarget="true"/>
+                <NavigationProperty Name="SiblingEntity" Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </EntityType>
+            <EntityType Name="SubElement">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+                <Property Name="SubProp1" Type="Edm.String"/>
+                <Property Name="SubProp2" Type="Edm.String"/>
+                <Property Name="isBoundAction3Hidden" Type="Edm.Boolean"/>
+                <Property Name="isBoundAction4Hidden" Type="Edm.Boolean"/>
+                <Property Name="owner_ID" Type="Edm.Int32"/>
+                <NavigationProperty Name="owner" Type="sap.fe.core.ActionVisibility.RootElement" Partner="_Elements">
+                    <ReferentialConstraint Property="owner_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <Property Name="sibling_ID" Type="Edm.Int32"/>
+                <NavigationProperty Name="Sibling" Type="sap.fe.core.ActionVisibility.SubElement">
+                    <ReferentialConstraint Property="sibling_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <Property Name="quantity" Type="Edm.Double"/>
+                <Property Name="quantityUoM" Type="Edm.String"/>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="sap.fe.core.ActionVisibility.DraftAdministrativeData" ContainsTarget="true"/>
+                <NavigationProperty Name="SiblingEntity" Type="sap.fe.core.ActionVisibility.SubElement"/>
+            </EntityType>
+            <EntityType Name="DraftAdministrativeData">
+                <Key>
+                    <PropertyRef Name="DraftUUID"/>
+                </Key>
+                <Property Name="DraftUUID" Type="Edm.Guid" Nullable="false"/>
+                <Property Name="CreationDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="CreatedByUser" Type="Edm.String" MaxLength="256"/>
+                <Property Name="DraftIsCreatedByMe" Type="Edm.Boolean"/>
+                <Property Name="LastChangeDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="LastChangedByUser" Type="Edm.String" MaxLength="256"/>
+                <Property Name="InProcessByUser" Type="Edm.String" MaxLength="256"/>
+                <Property Name="DraftIsProcessedByMe" Type="Edm.Boolean"/>
+            </EntityType>
+            <Action Name="boundAction1" IsBound="true" EntitySetPath="self">
+                <Parameter Name="self" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="boundAction2" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="boundAction3" IsBound="true" EntitySetPath="self">
+                <Parameter Name="self" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.SubElement"/>
+                <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.SubElement"/>
+            </Action>
+            <Action Name="draftActivate" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="draftEdit" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <Parameter Name="PreserveChanges" Type="Edm.Boolean"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="ID"/>
+                            <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="Prop1"/>
+                            <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/Low"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Menu Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.menuAction1"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Menu Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.menuAction2"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 3"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction3"/>
+                            <Annotation Term="UI.Hidden" Path="_Elements/isBoundAction3Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1 Inline"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1"/>
+                            <PropertyValue Property="Inline" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="Sibling/isBoundAction1Hidden"/>
+                            <PropertyValue Property="Label" String="Sibling isBoundAction2 Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2"/>
+                            <PropertyValue Property="Inline" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="Sibling/isBoundAction2Hidden"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.HeaderInfo">
+                    <Record Type="UI.HeaderInfoType">
+                        <PropertyValue Property="TypeName" String="Root Element"/>
+                        <PropertyValue Property="TypeNamePlural" String="Root Elements"/>
+                        <PropertyValue Property="Title">
+                            <Record Type="UI.DataField">
+                                <PropertyValue Property="Value" Path="Prop1"/>
+                            </Record>
+                        </PropertyValue>
+                        <PropertyValue Property="Description">
+                            <Record Type="UI.DataField">
+                                <PropertyValue Property="Value" Path="Prop2"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.CollectionFacet">
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="Label" String="Identification"/>
+                                        <PropertyValue Property="Target" AnnotationPath="@UI.Identification"/>
+                                    </Record>
+                                    <Record Type="UI.CollectionFacet">
+                                        <PropertyValue Property="ID" String="GeneralInformation"/>
+                                        <PropertyValue Property="Label" String="General Information"/>
+                                        <PropertyValue Property="Facets">
+                                            <Collection>
+                                                <Record Type="UI.ReferenceFacet">
+                                                    <PropertyValue Property="Label" String="General Information"/>
+                                                    <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#GeneralInformation"/>
+                                                </Record>
+                                            </Collection>
+                                        </PropertyValue>
+                                    </Record>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="ID" String="SubElements"/>
+                                        <PropertyValue Property="Label" String="Sub Elements"/>
+                                        <PropertyValue Property="Target" AnnotationPath="_Elements/@UI.LineItem"/>
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1"/>
+                            <PropertyValue Property="Determining" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2"/>
+                            <PropertyValue Property="Determining" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Header Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundHeaderAction1"/>
+                            <PropertyValue Property="Determining" Bool="false"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Header Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundHeaderAction2"/>
+                            <PropertyValue Property="Determining" Bool="false"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction3Hidden"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="GeneralInformation">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Label" String="General Information"/>
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="ID"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Prop1"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Prop2"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.EntityContainer/RootElement">
+                <Annotation Term="Common.DraftRoot">
+                    <Record Type="Common.DraftRootType">
+                        <PropertyValue Property="ActivationAction" String="sap.fe.core.ActionVisibility.draftActivate"/>
+                        <PropertyValue Property="EditAction" String="sap.fe.core.ActionVisibility.draftEdit"/>
+                        <PropertyValue Property="PreparationAction" String="sap.fe.core.ActionVisibility.draftPrepare"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/ID">
+                <Annotation Term="Core.Computed" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/Prop1">
+                <Annotation Term="Common.Label" String="First Prop"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/Prop2">
+                <Annotation Term="Common.Label" String="Second Propyour "/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/isBoundAction1Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 1 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/isBoundAction2Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 2 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/isBoundAction3Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 3 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/IsActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/HasActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/HasDraftEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/DraftAdministrativeData">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="SubProp1"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="owner/isBoundAction1Hidden"/>
+                            <PropertyValue Property="Label" String="Owner -&gt; boundAction1 Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1"/>
+                            <Annotation Term="UI.Hidden" Path="owner/isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Menu Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.menuAction1"/>
+                            <Annotation Term="UI.Hidden" Path="owner/isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="owner/Sibling/isBoundAction2Hidden"/>
+                            <PropertyValue Property="Label" String="Owner -&gt; Sibling boundAction2 Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2"/>
+                            <Annotation Term="UI.Hidden" Path="owner/Sibling/isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Menu Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.menuAction2"/>
+                            <Annotation Term="UI.Hidden" Path="owner/Sibling/isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction3Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 3 Inline"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction3"/>
+                            <PropertyValue Property="Inline" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction3Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="Sibling/isBoundAction4Hidden"/>
+                            <PropertyValue Property="Label" String="Sibling boundAction4 Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 4"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction4"/>
+                            <PropertyValue Property="Inline" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="Sibling/isBoundAction4Hidden"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.EntityContainer/SubElement">
+                <Annotation Term="Common.DraftNode">
+                    <Record Type="Common.DraftNodeType">
+                        <PropertyValue Property="PreparationAction" String="sap.fe.core.ActionVisibility.draftPrepare"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/ID">
+                <Annotation Term="Core.Computed" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/isBoundAction3Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 3 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/isBoundAction4Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 4 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/quantity">
+                <Annotation Term="Measures.Unit" Path="quantityUoM"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/IsActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/HasActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/HasDraftEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/DraftAdministrativeData">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData">
+                <Annotation Term="Common.Label" String="{i18n>Draft_DraftAdministrativeData}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftUUID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Common.Label" String="{i18n>Draft_DraftUUID}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/CreationDateTime">
+                <Annotation Term="Common.Label" String="{i18n>Draft_CreationDateTime}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/CreatedByUser">
+                <Annotation Term="Common.Label" String="{i18n>Draft_CreatedByUser}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsCreatedByMe">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Common.Label" String="{i18n>Draft_DraftIsCreatedByMe}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangeDateTime">
+                <Annotation Term="Common.Label" String="{i18n>Draft_LastChangeDateTime}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangedByUser">
+                <Annotation Term="Common.Label" String="{i18n>Draft_LastChangedByUser}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/InProcessByUser">
+                <Annotation Term="Common.Label" String="{i18n>Draft_InProcessByUser}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsProcessedByMe">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Common.Label" String="{i18n>Draft_DraftIsProcessedByMe}"/>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/annotation-converter/test/fixtures/merge/metadata.xml
+++ b/packages/annotation-converter/test/fixtures/merge/metadata.xml
@@ -13,7 +13,7 @@
         <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
     </edmx:Reference>
     <edmx:DataServices>
-        <Schema Namespace="sap.fe.core.ActionVisibility" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Schema Namespace="sap.fe.core.ActionVisibility" xmlns="http://docs.oasis-open.org/odata/ns/edm" Alias="ActionVisibilityRoot">
             <EntityContainer Name="EntityContainer">
                 <EntitySet Name="RootElement" EntityType="sap.fe.core.ActionVisibility.RootElement">
                     <NavigationPropertyBinding Path="Sibling" Target="RootElement"/>
@@ -120,7 +120,7 @@
                 <Parameter Name="PreserveChanges" Type="Edm.Boolean"/>
                 <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
             </Action>
-            <Annotations Target="sap.fe.core.ActionVisibility.RootElement">
+            <Annotations Target="ActionVisibilityRoot.RootElement">
                 <Annotation Term="UI.LineItem">
                     <Collection>
                         <Record Type="UI.DataField">

--- a/packages/annotation-converter/test/writeback.spec.ts
+++ b/packages/annotation-converter/test/writeback.spec.ts
@@ -14,7 +14,7 @@ const FilterDefaultValue = Object.assign('String', {
 describe('Writeback capabilities', () => {
     it('can revert Apply expression', async () => {
         const parsedEDMX = parse(await loadFixture('v2/metadataWithApply.xml'));
-        const rawData: any = (parsedEDMX.schema.annotations.serviceFile?.[83]?.annotations?.[3]?.collection?.[2] as any)
+        const rawData: any = (parsedEDMX.schema.annotations.serviceFile?.[77]?.annotations?.[3]?.collection?.[2] as any)
             ?.propertyValues;
         const convertedTypes = convert(parsedEDMX);
         const dfWithUrlApply: any = convertedTypes.entityTypes[1].annotations?.UI?.LineItem?.[2];
@@ -53,7 +53,7 @@ describe('Writeback capabilities', () => {
             defaultReferences,
             convertedTypes.entityTypes[0].annotations?.UI?.LineItem
         ) as any;
-        const target = parsedEDMX.schema.annotations.serviceFile[11].annotations[2] as any;
+        const target = parsedEDMX.schema.annotations.serviceFile[0].annotations[2] as any;
         delete target.fullyQualifiedName;
         expect(transformedFilterDefaultValue).not.toBeUndefined();
         expect(transformedFilterDefaultValue.collection.length).toEqual(target.collection.length);
@@ -70,7 +70,7 @@ describe('Writeback capabilities', () => {
             defaultReferences,
             convertedTypes.entityTypes['13'].entityProperties['8']?.annotations?.Common?.ValueList
         ) as any;
-        const target = parsedEDMX.schema.annotations.serviceFile['224'].annotations['3'] as any;
+        const target = parsedEDMX.schema.annotations.serviceFile['186'].annotations['3'] as any;
         delete target.fullyQualifiedName;
         expect(transformedFilterDefaultValue).not.toBeUndefined();
         expect(JSON.stringify(transformedFilterDefaultValue)).toStrictEqual(JSON.stringify(target));
@@ -84,7 +84,7 @@ describe('Writeback capabilities', () => {
             defaultReferences,
             convertedTypes.entityTypes[0].annotations?.UI?.SelectionFields
         ) as any;
-        const target = parsedEDMX.schema.annotations.serviceFile[11].annotations[1] as any;
+        const target = parsedEDMX.schema.annotations.serviceFile[0].annotations[1] as any;
         delete target.fullyQualifiedName;
         expect(transformedFilterDefaultValue).not.toBeUndefined();
         expect(JSON.stringify(transformedFilterDefaultValue)).toStrictEqual(JSON.stringify(target));
@@ -98,7 +98,7 @@ describe('Writeback capabilities', () => {
             defaultReferences,
             (convertedTypes.entityTypes['39']?.annotations?.Common as any)?.['SideEffects#ShipToPartyChange']
         ) as any;
-        const target = parsedEDMX.schema.annotations.serviceFile['301'].annotations['5'] as any;
+        const target = parsedEDMX.schema.annotations.serviceFile['203'].annotations['5'] as any;
         delete target.fullyQualifiedName;
         expect(transformedFilterDefaultValue).not.toBeUndefined();
         expect(JSON.stringify(transformedFilterDefaultValue)).toStrictEqual(JSON.stringify(target));
@@ -113,7 +113,7 @@ describe('Writeback capabilities', () => {
                 'SideEffects#MaterialDetailsModelYearChange'
             ]
         ) as any;
-        const target = parsedEDMX.schema.annotations.serviceFile['177'].annotations['2'] as any;
+        const target = parsedEDMX.schema.annotations.serviceFile['139'].annotations['2'] as any;
         delete target.fullyQualifiedName;
         expect(transformedFilterDefaultValue).not.toBeUndefined();
         expect(JSON.stringify(transformedFilterDefaultValue)).toStrictEqual(JSON.stringify(target));
@@ -127,7 +127,7 @@ describe('Writeback capabilities', () => {
             defaultReferences,
             convertedTypes.entitySets['38'].annotations?.Capabilities?.NavigationRestrictions
         ) as any;
-        const target = parsedEDMX.schema.annotations.serviceFile['302'].annotations['0'] as any;
+        const target = parsedEDMX.schema.annotations.serviceFile['204'].annotations['0'] as any;
         delete target.fullyQualifiedName;
         expect(transformedFilterDefaultValue).not.toBeUndefined();
         expect(JSON.stringify(transformedFilterDefaultValue)).toStrictEqual(JSON.stringify(target));
@@ -142,7 +142,7 @@ describe('Writeback capabilities', () => {
             defaultReferences,
             (convertedTypes.entityTypes['41']?.annotations?.UI as any)['SelectionPresentationVariant#SPVPath']
         ) as any;
-        const target = parsedEDMX.schema.annotations.serviceFile['395'].annotations['37'] as any;
+        const target = parsedEDMX.schema.annotations.serviceFile['245'].annotations['37'] as any;
         delete target.fullyQualifiedName;
         expect(transformedFilterDefaultValue).not.toBeUndefined();
         expect(JSON.stringify(transformedFilterDefaultValue)).toStrictEqual(JSON.stringify(target));
@@ -172,7 +172,7 @@ describe('Writeback capabilities', () => {
             defaultReferences,
             (convertedTypes.entityTypes['15'].annotations.UI as any)['DataPoint#Progress2']
         ) as any;
-        const target = parsedEDMX.schema.annotations.serviceFile['82'].annotations['2'] as any;
+        const target = parsedEDMX.schema.annotations.serviceFile['71'].annotations['2'] as any;
         delete target.fullyQualifiedName;
         expect(transformedFilterDefaultValue).not.toBeUndefined();
         expect(JSON.stringify(transformedFilterDefaultValue)).toStrictEqual(JSON.stringify(target));
@@ -187,7 +187,7 @@ describe('Writeback capabilities', () => {
     });
     it('can deal with Null', async () => {
         const parsedEDMX = parse(await loadFixture('v4/v4Meta.xml'));
-        const target = Object.assign({}, parsedEDMX.schema.annotations.serviceFile['451'].annotations['0'] as any);
+        const target = Object.assign({}, parsedEDMX.schema.annotations.serviceFile['293'].annotations['0'] as any);
         target.value = Object.assign({}, target.value);
         const convertedTypes = convert(parsedEDMX);
 

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -606,13 +606,14 @@ function parseRecord(
     annotationsLists: AnnotationList[]
 ): AnnotationRecord {
     const recordAnnotations = parseAnnotations(ensureArray(record.Annotation), currentTarget, annotationsLists);
-    if (recordAnnotations && recordAnnotations.length > 0) {
-        annotationsLists.push(createAnnotationList(currentTarget, recordAnnotations));
-    }
-    return {
+    const outRecord: AnnotationRecord = {
         type: record._attributes ? unalias(record._attributes.Type) : undefined,
         propertyValues: parsePropertyValues(ensureArray(record.PropertyValue), currentTarget, annotationsLists)
     };
+    if (recordAnnotations && recordAnnotations.length > 0) {
+        outRecord.annotations = recordAnnotations;
+    }
+    return outRecord;
 }
 
 /**
@@ -907,7 +908,7 @@ function parseAnnotation(
             annotationsLists
         );
         if (annotationAnnotations && annotationAnnotations.length > 0) {
-            annotationsLists.push(createAnnotationList(currentAnnotationTarget, annotationAnnotations));
+            outAnnotation.annotations = annotationAnnotations;
         }
     }
     const keys = Object.keys(annotation).filter((keyValue) => keyValue !== '_attributes' && keyValue !== 'Annotation');
@@ -974,7 +975,8 @@ function parseSchema(edmSchema: EDMX.Schema, identification: string): RawSchema 
     let singletons: RawSingleton[] = [];
     let associationSets: RawAssociationSet[] = [];
     let entityContainer: RawEntityContainer = {
-        _type: 'EntityContainer'
+        _type: 'EntityContainer',
+        fullyQualifiedName: ''
     };
     let actions: RawAction[] = [];
     if (edmSchema.EntityContainer) {

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -1002,7 +1002,7 @@ function parseSchema(edmSchema: EDMX.Schema, identification: string): RawSchema 
             parseFunctionImport(
                 ensureArray(edmSchema.EntityContainer.FunctionImport),
                 entitySets,
-                entityContainer.fullyQualifiedName as string
+                entityContainer.fullyQualifiedName
             )
         );
     }

--- a/packages/edmx-parser/src/utils.ts
+++ b/packages/edmx-parser/src/utils.ts
@@ -96,7 +96,8 @@ export class MergedRawMetadata implements RawMetadataInstance {
     _singletons: RawSingleton[] = [];
     _actions: RawAction[] = [];
     _entityContainer: RawEntityContainer = {
-        _type: 'EntityContainer'
+        _type: 'EntityContainer',
+        fullyQualifiedName: ''
     };
     _entityTypes: RawEntityType[] = [];
     _complexTypes: RawComplexType[] = [];

--- a/packages/edmx-parser/test/__snapshots__/merge.spec.ts.snap
+++ b/packages/edmx-parser/test/__snapshots__/merge.spec.ts.snap
@@ -1,0 +1,4529 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Merger can parse an edmx file 1`] = `
+MergedRawMetadata {
+  "_actions": Array [
+    Object {
+      "_type": "Action",
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction1(sap.fe.core.ActionVisibility.RootElement)",
+      "isBound": true,
+      "isFunction": false,
+      "name": "boundAction1",
+      "parameters": Array [
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction1(sap.fe.core.ActionVisibility.RootElement)/self",
+          "isEntitySet": true,
+          "name": "self",
+          "type": "sap.fe.core.ActionVisibility.RootElement",
+        },
+      ],
+      "returnType": "sap.fe.core.ActionVisibility.RootElement",
+      "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+    },
+    Object {
+      "_type": "Action",
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction2(sap.fe.core.ActionVisibility.RootElement)",
+      "isBound": true,
+      "isFunction": false,
+      "name": "boundAction2",
+      "parameters": Array [
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction2(sap.fe.core.ActionVisibility.RootElement)/in",
+          "isEntitySet": true,
+          "name": "in",
+          "type": "sap.fe.core.ActionVisibility.RootElement",
+        },
+      ],
+      "returnType": "sap.fe.core.ActionVisibility.RootElement",
+      "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+    },
+    Object {
+      "_type": "Action",
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction3(sap.fe.core.ActionVisibility.RootElement)",
+      "isBound": true,
+      "isFunction": false,
+      "name": "boundAction3",
+      "parameters": Array [
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction3(sap.fe.core.ActionVisibility.RootElement)/self",
+          "isEntitySet": true,
+          "name": "self",
+          "type": "sap.fe.core.ActionVisibility.RootElement",
+        },
+      ],
+      "returnType": "sap.fe.core.ActionVisibility.RootElement",
+      "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+    },
+    Object {
+      "_type": "Action",
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)",
+      "isBound": true,
+      "isFunction": false,
+      "name": "draftPrepare",
+      "parameters": Array [
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)/in",
+          "isEntitySet": true,
+          "name": "in",
+          "type": "sap.fe.core.ActionVisibility.RootElement",
+        },
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)/SideEffectsQualifier",
+          "isEntitySet": false,
+          "name": "SideEffectsQualifier",
+          "type": "Edm.String",
+        },
+      ],
+      "returnType": "sap.fe.core.ActionVisibility.RootElement",
+      "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+    },
+    Object {
+      "_type": "Action",
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)",
+      "isBound": true,
+      "isFunction": false,
+      "name": "draftPrepare",
+      "parameters": Array [
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)/in",
+          "isEntitySet": true,
+          "name": "in",
+          "type": "sap.fe.core.ActionVisibility.SubElement",
+        },
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)/SideEffectsQualifier",
+          "isEntitySet": false,
+          "name": "SideEffectsQualifier",
+          "type": "Edm.String",
+        },
+      ],
+      "returnType": "sap.fe.core.ActionVisibility.SubElement",
+      "sourceType": "sap.fe.core.ActionVisibility.SubElement",
+    },
+    Object {
+      "_type": "Action",
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftActivate(sap.fe.core.ActionVisibility.RootElement)",
+      "isBound": true,
+      "isFunction": false,
+      "name": "draftActivate",
+      "parameters": Array [
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftActivate(sap.fe.core.ActionVisibility.RootElement)/in",
+          "isEntitySet": true,
+          "name": "in",
+          "type": "sap.fe.core.ActionVisibility.RootElement",
+        },
+      ],
+      "returnType": "sap.fe.core.ActionVisibility.RootElement",
+      "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+    },
+    Object {
+      "_type": "Action",
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)",
+      "isBound": true,
+      "isFunction": false,
+      "name": "draftEdit",
+      "parameters": Array [
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)/in",
+          "isEntitySet": true,
+          "name": "in",
+          "type": "sap.fe.core.ActionVisibility.RootElement",
+        },
+        Object {
+          "_type": "ActionParameter",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)/PreserveChanges",
+          "isEntitySet": false,
+          "name": "PreserveChanges",
+          "type": "Edm.Boolean",
+        },
+      ],
+      "returnType": "sap.fe.core.ActionVisibility.RootElement",
+      "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+    },
+  ],
+  "_annotations": Object {
+    "annoFile": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "collection": Array [
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "Prop1",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "ID",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+            ],
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.LineItem",
+          },
+          Object {
+            "collection": Array [
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Determining",
+                    "value": Object {
+                      "Bool": true,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Determining",
+                    "value": Object {
+                      "Bool": true,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "type": "Unknown",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Header Action 1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundHeaderAction1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Determining",
+                    "value": Object {
+                      "Bool": false,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "type": "Unknown",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Header Action 2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundHeaderAction2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Determining",
+                    "value": Object {
+                      "Bool": false,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "isBoundAction3Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+            ],
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Identification",
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement",
+      },
+    ],
+    "serviceFile": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "collection": Array [
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Importance",
+                    "value": Object {
+                      "EnumMember": "UI.ImportanceType/High",
+                      "type": "EnumMember",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "ID",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Importance",
+                    "value": Object {
+                      "EnumMember": "UI.ImportanceType/Low",
+                      "type": "EnumMember",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "Prop1",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction1",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction2",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Menu Action 1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.menuAction1",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Menu Action 2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.menuAction2",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "_Elements/isBoundAction3Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 3",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction3",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 1 Inline",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Inline",
+                    "value": Object {
+                      "Bool": true,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "Sibling/isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Sibling isBoundAction2 Hidden",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "Sibling/isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Inline",
+                    "value": Object {
+                      "Bool": true,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+            ],
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.LineItem",
+          },
+          Object {
+            "qualifier": undefined,
+            "record": Object {
+              "propertyValues": Array [
+                Object {
+                  "name": "TypeName",
+                  "value": Object {
+                    "String": "Root Element",
+                    "type": "String",
+                  },
+                },
+                Object {
+                  "name": "TypeNamePlural",
+                  "value": Object {
+                    "String": "Root Elements",
+                    "type": "String",
+                  },
+                },
+                Object {
+                  "name": "Title",
+                  "value": Object {
+                    "Record": Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "Prop1",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    "type": "Record",
+                  },
+                },
+                Object {
+                  "name": "Description",
+                  "value": Object {
+                    "Record": Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "Prop2",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    "type": "Record",
+                  },
+                },
+              ],
+              "type": "com.sap.vocabularies.UI.v1.HeaderInfoType",
+            },
+            "term": "com.sap.vocabularies.UI.v1.HeaderInfo",
+          },
+          Object {
+            "collection": Array [
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Facets",
+                    "value": Object {
+                      "Collection": Array [
+                        Object {
+                          "propertyValues": Array [
+                            Object {
+                              "name": "Label",
+                              "value": Object {
+                                "String": "Identification",
+                                "type": "String",
+                              },
+                            },
+                            Object {
+                              "name": "Target",
+                              "value": Object {
+                                "AnnotationPath": "@UI.Identification",
+                                "type": "AnnotationPath",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                        },
+                        Object {
+                          "propertyValues": Array [
+                            Object {
+                              "name": "ID",
+                              "value": Object {
+                                "String": "GeneralInformation",
+                                "type": "String",
+                              },
+                            },
+                            Object {
+                              "name": "Label",
+                              "value": Object {
+                                "String": "General Information",
+                                "type": "String",
+                              },
+                            },
+                            Object {
+                              "name": "Facets",
+                              "value": Object {
+                                "Collection": Array [
+                                  Object {
+                                    "propertyValues": Array [
+                                      Object {
+                                        "name": "Label",
+                                        "value": Object {
+                                          "String": "General Information",
+                                          "type": "String",
+                                        },
+                                      },
+                                      Object {
+                                        "name": "Target",
+                                        "value": Object {
+                                          "AnnotationPath": "@UI.FieldGroup#GeneralInformation",
+                                          "type": "AnnotationPath",
+                                        },
+                                      },
+                                    ],
+                                    "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                                  },
+                                ],
+                                "type": "Collection",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.CollectionFacet",
+                        },
+                        Object {
+                          "propertyValues": Array [
+                            Object {
+                              "name": "ID",
+                              "value": Object {
+                                "String": "SubElements",
+                                "type": "String",
+                              },
+                            },
+                            Object {
+                              "name": "Label",
+                              "value": Object {
+                                "String": "Sub Elements",
+                                "type": "String",
+                              },
+                            },
+                            Object {
+                              "name": "Target",
+                              "value": Object {
+                                "AnnotationPath": "_Elements/@UI.LineItem",
+                                "type": "AnnotationPath",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.CollectionFacet",
+              },
+            ],
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Facets",
+          },
+          Object {
+            "collection": Array [
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Determining",
+                    "value": Object {
+                      "Bool": true,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Determining",
+                    "value": Object {
+                      "Bool": true,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Header Action 1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundHeaderAction1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Determining",
+                    "value": Object {
+                      "Bool": false,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Header Action 2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundHeaderAction2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Determining",
+                    "value": Object {
+                      "Bool": false,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "isBoundAction3Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+            ],
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Identification",
+          },
+          Object {
+            "qualifier": "GeneralInformation",
+            "record": Object {
+              "propertyValues": Array [
+                Object {
+                  "name": "Label",
+                  "value": Object {
+                    "String": "General Information",
+                    "type": "String",
+                  },
+                },
+                Object {
+                  "name": "Data",
+                  "value": Object {
+                    "Collection": Array [
+                      Object {
+                        "propertyValues": Array [
+                          Object {
+                            "name": "Value",
+                            "value": Object {
+                              "Path": "ID",
+                              "type": "Path",
+                            },
+                          },
+                        ],
+                        "type": "com.sap.vocabularies.UI.v1.DataField",
+                      },
+                      Object {
+                        "propertyValues": Array [
+                          Object {
+                            "name": "Value",
+                            "value": Object {
+                              "Path": "Prop1",
+                              "type": "Path",
+                            },
+                          },
+                        ],
+                        "type": "com.sap.vocabularies.UI.v1.DataField",
+                      },
+                      Object {
+                        "propertyValues": Array [
+                          Object {
+                            "name": "Value",
+                            "value": Object {
+                              "Path": "Prop2",
+                              "type": "Path",
+                            },
+                          },
+                        ],
+                        "type": "com.sap.vocabularies.UI.v1.DataField",
+                      },
+                    ],
+                    "type": "Collection",
+                  },
+                },
+              ],
+              "type": "com.sap.vocabularies.UI.v1.FieldGroupType",
+            },
+            "term": "com.sap.vocabularies.UI.v1.FieldGroup",
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "record": Object {
+              "propertyValues": Array [
+                Object {
+                  "name": "ActivationAction",
+                  "value": Object {
+                    "String": "sap.fe.core.ActionVisibility.draftActivate",
+                    "type": "String",
+                  },
+                },
+                Object {
+                  "name": "EditAction",
+                  "value": Object {
+                    "String": "sap.fe.core.ActionVisibility.draftEdit",
+                    "type": "String",
+                  },
+                },
+                Object {
+                  "name": "PreparationAction",
+                  "value": Object {
+                    "String": "sap.fe.core.ActionVisibility.draftPrepare",
+                    "type": "String",
+                  },
+                },
+              ],
+              "type": "com.sap.vocabularies.Common.v1.DraftRootType",
+            },
+            "term": "com.sap.vocabularies.Common.v1.DraftRoot",
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "Org.OData.Core.V1.Computed",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/ID",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "First Prop",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/Prop1",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "Second Propyour ",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/Prop2",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "Bound Action 1 Hidden",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/isBoundAction1Hidden",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "Bound Action 2 Hidden",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/isBoundAction2Hidden",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "Bound Action 3 Hidden",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/isBoundAction3Hidden",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/IsActiveEntity",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/HasActiveEntity",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/HasDraftEntity",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.RootElement/DraftAdministrativeData",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "collection": Array [
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "SubProp1",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "owner/isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Owner -> boundAction1 Hidden",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "owner/isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction1",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "owner/isBoundAction1Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Menu Action 1",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.menuAction1",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "owner/Sibling/isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Owner -> Sibling boundAction2 Hidden",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "owner/Sibling/isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction2",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "owner/Sibling/isBoundAction2Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Menu Action 2",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.menuAction2",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "isBoundAction3Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "isBoundAction3Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 3 Inline",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction3",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Inline",
+                    "value": Object {
+                      "Bool": true,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+              Object {
+                "propertyValues": Array [
+                  Object {
+                    "name": "Value",
+                    "value": Object {
+                      "Path": "Sibling/isBoundAction4Hidden",
+                      "type": "Path",
+                    },
+                  },
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Sibling boundAction4 Hidden",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataField",
+              },
+              Object {
+                "annotations": Array [
+                  Object {
+                    "qualifier": undefined,
+                    "term": "com.sap.vocabularies.UI.v1.Hidden",
+                    "value": Object {
+                      "Path": "Sibling/isBoundAction4Hidden",
+                      "type": "Path",
+                    },
+                  },
+                ],
+                "propertyValues": Array [
+                  Object {
+                    "name": "Label",
+                    "value": Object {
+                      "String": "Bound Action 4",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Action",
+                    "value": Object {
+                      "String": "sap.fe.core.ActionVisibility.boundAction4",
+                      "type": "String",
+                    },
+                  },
+                  Object {
+                    "name": "Inline",
+                    "value": Object {
+                      "Bool": true,
+                      "type": "Bool",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+              },
+            ],
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.LineItem",
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.SubElement",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "record": Object {
+              "propertyValues": Array [
+                Object {
+                  "name": "PreparationAction",
+                  "value": Object {
+                    "String": "sap.fe.core.ActionVisibility.draftPrepare",
+                    "type": "String",
+                  },
+                },
+              ],
+              "type": "com.sap.vocabularies.Common.v1.DraftNodeType",
+            },
+            "term": "com.sap.vocabularies.Common.v1.DraftNode",
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "Org.OData.Core.V1.Computed",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.SubElement/ID",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "Bound Action 3 Hidden",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.SubElement/isBoundAction3Hidden",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "Bound Action 4 Hidden",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.SubElement/isBoundAction4Hidden",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "Org.OData.Measures.V1.Unit",
+            "value": Object {
+              "Path": "quantityUoM",
+              "type": "Path",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.SubElement/quantity",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.SubElement/IsActiveEntity",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.SubElement/HasActiveEntity",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.SubElement/HasDraftEntity",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.SubElement/DraftAdministrativeData",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "{i18n>Draft_DraftAdministrativeData}",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "{i18n>Draft_DraftUUID}",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftUUID",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "{i18n>Draft_CreationDateTime}",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/CreationDateTime",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "{i18n>Draft_CreatedByUser}",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/CreatedByUser",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "{i18n>Draft_DraftIsCreatedByMe}",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsCreatedByMe",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "{i18n>Draft_LastChangeDateTime}",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangeDateTime",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "{i18n>Draft_LastChangedByUser}",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangedByUser",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "{i18n>Draft_InProcessByUser}",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/InProcessByUser",
+      },
+      Object {
+        "annotations": Array [
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.UI.v1.Hidden",
+            "value": Object {
+              "Bool": true,
+              "type": "Bool",
+            },
+          },
+          Object {
+            "qualifier": undefined,
+            "term": "com.sap.vocabularies.Common.v1.Label",
+            "value": Object {
+              "String": "{i18n>Draft_DraftIsProcessedByMe}",
+              "type": "String",
+            },
+          },
+        ],
+        "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsProcessedByMe",
+      },
+    ],
+  },
+  "_associationSets": Array [],
+  "_associations": Array [],
+  "_complexTypes": Array [],
+  "_entityContainer": Object {
+    "_type": "EntityContainer",
+    "fullyQualifiedName": "",
+    "name": "EntityContainer",
+  },
+  "_entitySets": Array [
+    Object {
+      "_type": "EntitySet",
+      "entityTypeName": "sap.fe.core.ActionVisibility.RootElement",
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+      "name": "RootElement",
+      "navigationPropertyBinding": Object {
+        "Sibling": [Circular],
+        "SiblingEntity": [Circular],
+        "_Elements": Object {
+          "_type": "EntitySet",
+          "entityTypeName": "sap.fe.core.ActionVisibility.SubElement",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+          "name": "SubElement",
+          "navigationPropertyBinding": Object {
+            "Sibling": [Circular],
+            "SiblingEntity": [Circular],
+            "owner": [Circular],
+          },
+        },
+      },
+    },
+    Object {
+      "_type": "EntitySet",
+      "entityTypeName": "sap.fe.core.ActionVisibility.SubElement",
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+      "name": "SubElement",
+      "navigationPropertyBinding": Object {
+        "Sibling": [Circular],
+        "SiblingEntity": [Circular],
+        "owner": Object {
+          "_type": "EntitySet",
+          "entityTypeName": "sap.fe.core.ActionVisibility.RootElement",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+          "name": "RootElement",
+          "navigationPropertyBinding": Object {
+            "Sibling": [Circular],
+            "SiblingEntity": [Circular],
+            "_Elements": [Circular],
+          },
+        },
+      },
+    },
+  ],
+  "_entityTypes": Array [
+    Object {
+      "_type": "EntityType",
+      "actions": Object {},
+      "entityProperties": Array [
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/ID",
+          "name": "ID",
+          "nullable": false,
+          "type": "Edm.Int32",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/Prop1",
+          "name": "Prop1",
+          "type": "Edm.String",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/Prop2",
+          "name": "Prop2",
+          "type": "Edm.String",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/isBoundAction1Hidden",
+          "name": "isBoundAction1Hidden",
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/isBoundAction2Hidden",
+          "name": "isBoundAction2Hidden",
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/isBoundAction3Hidden",
+          "name": "isBoundAction3Hidden",
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/Sibling_ID",
+          "name": "Sibling_ID",
+          "type": "Edm.Int32",
+        },
+        Object {
+          "_type": "Property",
+          "defaultValue": true,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/IsActiveEntity",
+          "name": "IsActiveEntity",
+          "nullable": false,
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "defaultValue": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/HasActiveEntity",
+          "name": "HasActiveEntity",
+          "nullable": false,
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "defaultValue": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/HasDraftEntity",
+          "name": "HasDraftEntity",
+          "nullable": false,
+          "type": "Edm.Boolean",
+        },
+      ],
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement",
+      "keys": Array [
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/ID",
+          "name": "ID",
+          "nullable": false,
+          "type": "Edm.Int32",
+        },
+        Object {
+          "_type": "Property",
+          "defaultValue": true,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/IsActiveEntity",
+          "name": "IsActiveEntity",
+          "nullable": false,
+          "type": "Edm.Boolean",
+        },
+      ],
+      "name": "RootElement",
+      "navigationProperties": Array [
+        Object {
+          "_type": "NavigationProperty",
+          "containsTarget": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/Sibling",
+          "isCollection": false,
+          "name": "Sibling",
+          "partner": undefined,
+          "referentialConstraint": Array [
+            Object {
+              "sourceProperty": "Sibling_ID",
+              "sourceTypeName": "RootElement",
+              "targetProperty": "ID",
+              "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+            },
+          ],
+          "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+        },
+        Object {
+          "_type": "NavigationProperty",
+          "containsTarget": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/_Elements",
+          "isCollection": true,
+          "name": "_Elements",
+          "partner": "owner",
+          "referentialConstraint": Array [],
+          "targetTypeName": "sap.fe.core.ActionVisibility.SubElement",
+        },
+        Object {
+          "_type": "NavigationProperty",
+          "containsTarget": true,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/DraftAdministrativeData",
+          "isCollection": false,
+          "name": "DraftAdministrativeData",
+          "partner": undefined,
+          "referentialConstraint": Array [],
+          "targetTypeName": "sap.fe.core.ActionVisibility.DraftAdministrativeData",
+        },
+        Object {
+          "_type": "NavigationProperty",
+          "containsTarget": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/SiblingEntity",
+          "isCollection": false,
+          "name": "SiblingEntity",
+          "partner": undefined,
+          "referentialConstraint": Array [],
+          "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+        },
+      ],
+    },
+    Object {
+      "_type": "EntityType",
+      "actions": Object {},
+      "entityProperties": Array [
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/ID",
+          "name": "ID",
+          "nullable": false,
+          "type": "Edm.Int32",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/SubProp1",
+          "name": "SubProp1",
+          "type": "Edm.String",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/SubProp2",
+          "name": "SubProp2",
+          "type": "Edm.String",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/isBoundAction3Hidden",
+          "name": "isBoundAction3Hidden",
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/isBoundAction4Hidden",
+          "name": "isBoundAction4Hidden",
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/owner_ID",
+          "name": "owner_ID",
+          "type": "Edm.Int32",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/sibling_ID",
+          "name": "sibling_ID",
+          "type": "Edm.Int32",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/quantity",
+          "name": "quantity",
+          "type": "Edm.Double",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/quantityUoM",
+          "name": "quantityUoM",
+          "type": "Edm.String",
+        },
+        Object {
+          "_type": "Property",
+          "defaultValue": true,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/IsActiveEntity",
+          "name": "IsActiveEntity",
+          "nullable": false,
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "defaultValue": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/HasActiveEntity",
+          "name": "HasActiveEntity",
+          "nullable": false,
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "defaultValue": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/HasDraftEntity",
+          "name": "HasDraftEntity",
+          "nullable": false,
+          "type": "Edm.Boolean",
+        },
+      ],
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement",
+      "keys": Array [
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/ID",
+          "name": "ID",
+          "nullable": false,
+          "type": "Edm.Int32",
+        },
+        Object {
+          "_type": "Property",
+          "defaultValue": true,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/IsActiveEntity",
+          "name": "IsActiveEntity",
+          "nullable": false,
+          "type": "Edm.Boolean",
+        },
+      ],
+      "name": "SubElement",
+      "navigationProperties": Array [
+        Object {
+          "_type": "NavigationProperty",
+          "containsTarget": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/owner",
+          "isCollection": false,
+          "name": "owner",
+          "partner": "_Elements",
+          "referentialConstraint": Array [
+            Object {
+              "sourceProperty": "owner_ID",
+              "sourceTypeName": "SubElement",
+              "targetProperty": "ID",
+              "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+            },
+          ],
+          "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+        },
+        Object {
+          "_type": "NavigationProperty",
+          "containsTarget": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/Sibling",
+          "isCollection": false,
+          "name": "Sibling",
+          "partner": undefined,
+          "referentialConstraint": Array [
+            Object {
+              "sourceProperty": "sibling_ID",
+              "sourceTypeName": "SubElement",
+              "targetProperty": "ID",
+              "targetTypeName": "sap.fe.core.ActionVisibility.SubElement",
+            },
+          ],
+          "targetTypeName": "sap.fe.core.ActionVisibility.SubElement",
+        },
+        Object {
+          "_type": "NavigationProperty",
+          "containsTarget": true,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/DraftAdministrativeData",
+          "isCollection": false,
+          "name": "DraftAdministrativeData",
+          "partner": undefined,
+          "referentialConstraint": Array [],
+          "targetTypeName": "sap.fe.core.ActionVisibility.DraftAdministrativeData",
+        },
+        Object {
+          "_type": "NavigationProperty",
+          "containsTarget": false,
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/SiblingEntity",
+          "isCollection": false,
+          "name": "SiblingEntity",
+          "partner": undefined,
+          "referentialConstraint": Array [],
+          "targetTypeName": "sap.fe.core.ActionVisibility.SubElement",
+        },
+      ],
+    },
+    Object {
+      "_type": "EntityType",
+      "actions": Object {},
+      "entityProperties": Array [
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftUUID",
+          "name": "DraftUUID",
+          "nullable": false,
+          "type": "Edm.Guid",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/CreationDateTime",
+          "name": "CreationDateTime",
+          "precision": 7,
+          "type": "Edm.DateTimeOffset",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/CreatedByUser",
+          "maxLength": 256,
+          "name": "CreatedByUser",
+          "type": "Edm.String",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsCreatedByMe",
+          "name": "DraftIsCreatedByMe",
+          "type": "Edm.Boolean",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangeDateTime",
+          "name": "LastChangeDateTime",
+          "precision": 7,
+          "type": "Edm.DateTimeOffset",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangedByUser",
+          "maxLength": 256,
+          "name": "LastChangedByUser",
+          "type": "Edm.String",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/InProcessByUser",
+          "maxLength": 256,
+          "name": "InProcessByUser",
+          "type": "Edm.String",
+        },
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsProcessedByMe",
+          "name": "DraftIsProcessedByMe",
+          "type": "Edm.Boolean",
+        },
+      ],
+      "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData",
+      "keys": Array [
+        Object {
+          "_type": "Property",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftUUID",
+          "name": "DraftUUID",
+          "nullable": false,
+          "type": "Edm.Guid",
+        },
+      ],
+      "name": "DraftAdministrativeData",
+      "navigationProperties": Array [],
+    },
+  ],
+  "_namespace": "sap.fe.core.ActionVisibility",
+  "_parserOutput": Array [
+    RawMetadataInstance {
+      "identification": "serviceFile",
+      "references": Array [
+        Object {
+          "alias": "Common",
+          "namespace": "com.sap.vocabularies.Common.v1",
+          "uri": "https://sap.github.io/odata-vocabularies/vocabularies/Common.xml",
+        },
+        Object {
+          "alias": "Core",
+          "namespace": "Org.OData.Core.V1",
+          "uri": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml",
+        },
+        Object {
+          "alias": "Measures",
+          "namespace": "Org.OData.Measures.V1",
+          "uri": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml",
+        },
+        Object {
+          "alias": "UI",
+          "namespace": "com.sap.vocabularies.UI.v1",
+          "uri": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml",
+        },
+      ],
+      "schema": Object {
+        "actions": Array [
+          Object {
+            "_type": "Action",
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction1(sap.fe.core.ActionVisibility.RootElement)",
+            "isBound": true,
+            "isFunction": false,
+            "name": "boundAction1",
+            "parameters": Array [
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction1(sap.fe.core.ActionVisibility.RootElement)/self",
+                "isEntitySet": true,
+                "name": "self",
+                "type": "sap.fe.core.ActionVisibility.RootElement",
+              },
+            ],
+            "returnType": "sap.fe.core.ActionVisibility.RootElement",
+            "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+          },
+          Object {
+            "_type": "Action",
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction2(sap.fe.core.ActionVisibility.RootElement)",
+            "isBound": true,
+            "isFunction": false,
+            "name": "boundAction2",
+            "parameters": Array [
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction2(sap.fe.core.ActionVisibility.RootElement)/in",
+                "isEntitySet": true,
+                "name": "in",
+                "type": "sap.fe.core.ActionVisibility.RootElement",
+              },
+            ],
+            "returnType": "sap.fe.core.ActionVisibility.RootElement",
+            "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+          },
+          Object {
+            "_type": "Action",
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction3(sap.fe.core.ActionVisibility.RootElement)",
+            "isBound": true,
+            "isFunction": false,
+            "name": "boundAction3",
+            "parameters": Array [
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction3(sap.fe.core.ActionVisibility.RootElement)/self",
+                "isEntitySet": true,
+                "name": "self",
+                "type": "sap.fe.core.ActionVisibility.RootElement",
+              },
+            ],
+            "returnType": "sap.fe.core.ActionVisibility.RootElement",
+            "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+          },
+          Object {
+            "_type": "Action",
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)",
+            "isBound": true,
+            "isFunction": false,
+            "name": "draftPrepare",
+            "parameters": Array [
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)/in",
+                "isEntitySet": true,
+                "name": "in",
+                "type": "sap.fe.core.ActionVisibility.RootElement",
+              },
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)/SideEffectsQualifier",
+                "isEntitySet": false,
+                "name": "SideEffectsQualifier",
+                "type": "Edm.String",
+              },
+            ],
+            "returnType": "sap.fe.core.ActionVisibility.RootElement",
+            "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+          },
+          Object {
+            "_type": "Action",
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)",
+            "isBound": true,
+            "isFunction": false,
+            "name": "draftPrepare",
+            "parameters": Array [
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)/in",
+                "isEntitySet": true,
+                "name": "in",
+                "type": "sap.fe.core.ActionVisibility.SubElement",
+              },
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)/SideEffectsQualifier",
+                "isEntitySet": false,
+                "name": "SideEffectsQualifier",
+                "type": "Edm.String",
+              },
+            ],
+            "returnType": "sap.fe.core.ActionVisibility.SubElement",
+            "sourceType": "sap.fe.core.ActionVisibility.SubElement",
+          },
+          Object {
+            "_type": "Action",
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftActivate(sap.fe.core.ActionVisibility.RootElement)",
+            "isBound": true,
+            "isFunction": false,
+            "name": "draftActivate",
+            "parameters": Array [
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftActivate(sap.fe.core.ActionVisibility.RootElement)/in",
+                "isEntitySet": true,
+                "name": "in",
+                "type": "sap.fe.core.ActionVisibility.RootElement",
+              },
+            ],
+            "returnType": "sap.fe.core.ActionVisibility.RootElement",
+            "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+          },
+          Object {
+            "_type": "Action",
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)",
+            "isBound": true,
+            "isFunction": false,
+            "name": "draftEdit",
+            "parameters": Array [
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)/in",
+                "isEntitySet": true,
+                "name": "in",
+                "type": "sap.fe.core.ActionVisibility.RootElement",
+              },
+              Object {
+                "_type": "ActionParameter",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)/PreserveChanges",
+                "isEntitySet": false,
+                "name": "PreserveChanges",
+                "type": "Edm.Boolean",
+              },
+            ],
+            "returnType": "sap.fe.core.ActionVisibility.RootElement",
+            "sourceType": "sap.fe.core.ActionVisibility.RootElement",
+          },
+        ],
+        "annotations": Object {
+          "serviceFile": Array [
+            Object {
+              "annotations": Array [
+                Object {
+                  "collection": Array [
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Importance",
+                          "value": Object {
+                            "EnumMember": "UI.ImportanceType/High",
+                            "type": "EnumMember",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "ID",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Importance",
+                          "value": Object {
+                            "EnumMember": "UI.ImportanceType/Low",
+                            "type": "EnumMember",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "Prop1",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction1",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction2",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Menu Action 1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.menuAction1",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Menu Action 2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.menuAction2",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "_Elements/isBoundAction3Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 3",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction3",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 1 Inline",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Inline",
+                          "value": Object {
+                            "Bool": true,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "Sibling/isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Sibling isBoundAction2 Hidden",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "Sibling/isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Inline",
+                          "value": Object {
+                            "Bool": true,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                  ],
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.LineItem",
+                },
+                Object {
+                  "qualifier": undefined,
+                  "record": Object {
+                    "propertyValues": Array [
+                      Object {
+                        "name": "TypeName",
+                        "value": Object {
+                          "String": "Root Element",
+                          "type": "String",
+                        },
+                      },
+                      Object {
+                        "name": "TypeNamePlural",
+                        "value": Object {
+                          "String": "Root Elements",
+                          "type": "String",
+                        },
+                      },
+                      Object {
+                        "name": "Title",
+                        "value": Object {
+                          "Record": Object {
+                            "propertyValues": Array [
+                              Object {
+                                "name": "Value",
+                                "value": Object {
+                                  "Path": "Prop1",
+                                  "type": "Path",
+                                },
+                              },
+                            ],
+                            "type": "com.sap.vocabularies.UI.v1.DataField",
+                          },
+                          "type": "Record",
+                        },
+                      },
+                      Object {
+                        "name": "Description",
+                        "value": Object {
+                          "Record": Object {
+                            "propertyValues": Array [
+                              Object {
+                                "name": "Value",
+                                "value": Object {
+                                  "Path": "Prop2",
+                                  "type": "Path",
+                                },
+                              },
+                            ],
+                            "type": "com.sap.vocabularies.UI.v1.DataField",
+                          },
+                          "type": "Record",
+                        },
+                      },
+                    ],
+                    "type": "com.sap.vocabularies.UI.v1.HeaderInfoType",
+                  },
+                  "term": "com.sap.vocabularies.UI.v1.HeaderInfo",
+                },
+                Object {
+                  "collection": Array [
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Facets",
+                          "value": Object {
+                            "Collection": Array [
+                              Object {
+                                "propertyValues": Array [
+                                  Object {
+                                    "name": "Label",
+                                    "value": Object {
+                                      "String": "Identification",
+                                      "type": "String",
+                                    },
+                                  },
+                                  Object {
+                                    "name": "Target",
+                                    "value": Object {
+                                      "AnnotationPath": "@UI.Identification",
+                                      "type": "AnnotationPath",
+                                    },
+                                  },
+                                ],
+                                "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                              },
+                              Object {
+                                "propertyValues": Array [
+                                  Object {
+                                    "name": "ID",
+                                    "value": Object {
+                                      "String": "GeneralInformation",
+                                      "type": "String",
+                                    },
+                                  },
+                                  Object {
+                                    "name": "Label",
+                                    "value": Object {
+                                      "String": "General Information",
+                                      "type": "String",
+                                    },
+                                  },
+                                  Object {
+                                    "name": "Facets",
+                                    "value": Object {
+                                      "Collection": Array [
+                                        Object {
+                                          "propertyValues": Array [
+                                            Object {
+                                              "name": "Label",
+                                              "value": Object {
+                                                "String": "General Information",
+                                                "type": "String",
+                                              },
+                                            },
+                                            Object {
+                                              "name": "Target",
+                                              "value": Object {
+                                                "AnnotationPath": "@UI.FieldGroup#GeneralInformation",
+                                                "type": "AnnotationPath",
+                                              },
+                                            },
+                                          ],
+                                          "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                                        },
+                                      ],
+                                      "type": "Collection",
+                                    },
+                                  },
+                                ],
+                                "type": "com.sap.vocabularies.UI.v1.CollectionFacet",
+                              },
+                              Object {
+                                "propertyValues": Array [
+                                  Object {
+                                    "name": "ID",
+                                    "value": Object {
+                                      "String": "SubElements",
+                                      "type": "String",
+                                    },
+                                  },
+                                  Object {
+                                    "name": "Label",
+                                    "value": Object {
+                                      "String": "Sub Elements",
+                                      "type": "String",
+                                    },
+                                  },
+                                  Object {
+                                    "name": "Target",
+                                    "value": Object {
+                                      "AnnotationPath": "_Elements/@UI.LineItem",
+                                      "type": "AnnotationPath",
+                                    },
+                                  },
+                                ],
+                                "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                              },
+                            ],
+                            "type": "Collection",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.CollectionFacet",
+                    },
+                  ],
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Facets",
+                },
+                Object {
+                  "collection": Array [
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Determining",
+                          "value": Object {
+                            "Bool": true,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Determining",
+                          "value": Object {
+                            "Bool": true,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Header Action 1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundHeaderAction1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Determining",
+                          "value": Object {
+                            "Bool": false,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Header Action 2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundHeaderAction2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Determining",
+                          "value": Object {
+                            "Bool": false,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "isBoundAction3Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                  ],
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Identification",
+                },
+                Object {
+                  "qualifier": "GeneralInformation",
+                  "record": Object {
+                    "propertyValues": Array [
+                      Object {
+                        "name": "Label",
+                        "value": Object {
+                          "String": "General Information",
+                          "type": "String",
+                        },
+                      },
+                      Object {
+                        "name": "Data",
+                        "value": Object {
+                          "Collection": Array [
+                            Object {
+                              "propertyValues": Array [
+                                Object {
+                                  "name": "Value",
+                                  "value": Object {
+                                    "Path": "ID",
+                                    "type": "Path",
+                                  },
+                                },
+                              ],
+                              "type": "com.sap.vocabularies.UI.v1.DataField",
+                            },
+                            Object {
+                              "propertyValues": Array [
+                                Object {
+                                  "name": "Value",
+                                  "value": Object {
+                                    "Path": "Prop1",
+                                    "type": "Path",
+                                  },
+                                },
+                              ],
+                              "type": "com.sap.vocabularies.UI.v1.DataField",
+                            },
+                            Object {
+                              "propertyValues": Array [
+                                Object {
+                                  "name": "Value",
+                                  "value": Object {
+                                    "Path": "Prop2",
+                                    "type": "Path",
+                                  },
+                                },
+                              ],
+                              "type": "com.sap.vocabularies.UI.v1.DataField",
+                            },
+                          ],
+                          "type": "Collection",
+                        },
+                      },
+                    ],
+                    "type": "com.sap.vocabularies.UI.v1.FieldGroupType",
+                  },
+                  "term": "com.sap.vocabularies.UI.v1.FieldGroup",
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "record": Object {
+                    "propertyValues": Array [
+                      Object {
+                        "name": "ActivationAction",
+                        "value": Object {
+                          "String": "sap.fe.core.ActionVisibility.draftActivate",
+                          "type": "String",
+                        },
+                      },
+                      Object {
+                        "name": "EditAction",
+                        "value": Object {
+                          "String": "sap.fe.core.ActionVisibility.draftEdit",
+                          "type": "String",
+                        },
+                      },
+                      Object {
+                        "name": "PreparationAction",
+                        "value": Object {
+                          "String": "sap.fe.core.ActionVisibility.draftPrepare",
+                          "type": "String",
+                        },
+                      },
+                    ],
+                    "type": "com.sap.vocabularies.Common.v1.DraftRootType",
+                  },
+                  "term": "com.sap.vocabularies.Common.v1.DraftRoot",
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "Org.OData.Core.V1.Computed",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/ID",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "First Prop",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/Prop1",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "Second Propyour ",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/Prop2",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "Bound Action 1 Hidden",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/isBoundAction1Hidden",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "Bound Action 2 Hidden",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/isBoundAction2Hidden",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "Bound Action 3 Hidden",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/isBoundAction3Hidden",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/IsActiveEntity",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/HasActiveEntity",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/HasDraftEntity",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement/DraftAdministrativeData",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "collection": Array [
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "SubProp1",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "owner/isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Owner -> boundAction1 Hidden",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "owner/isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction1",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "owner/isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Menu Action 1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.menuAction1",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "owner/Sibling/isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Owner -> Sibling boundAction2 Hidden",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "owner/Sibling/isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction2",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "owner/Sibling/isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Menu Action 2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.menuAction2",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "isBoundAction3Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "isBoundAction3Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 3 Inline",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction3",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Inline",
+                          "value": Object {
+                            "Bool": true,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "Sibling/isBoundAction4Hidden",
+                            "type": "Path",
+                          },
+                        },
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Sibling boundAction4 Hidden",
+                            "type": "String",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "Sibling/isBoundAction4Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 4",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction4",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Inline",
+                          "value": Object {
+                            "Bool": true,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                  ],
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.LineItem",
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.SubElement",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "record": Object {
+                    "propertyValues": Array [
+                      Object {
+                        "name": "PreparationAction",
+                        "value": Object {
+                          "String": "sap.fe.core.ActionVisibility.draftPrepare",
+                          "type": "String",
+                        },
+                      },
+                    ],
+                    "type": "com.sap.vocabularies.Common.v1.DraftNodeType",
+                  },
+                  "term": "com.sap.vocabularies.Common.v1.DraftNode",
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "Org.OData.Core.V1.Computed",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.SubElement/ID",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "Bound Action 3 Hidden",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.SubElement/isBoundAction3Hidden",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "Bound Action 4 Hidden",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.SubElement/isBoundAction4Hidden",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "Org.OData.Measures.V1.Unit",
+                  "value": Object {
+                    "Path": "quantityUoM",
+                    "type": "Path",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.SubElement/quantity",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.SubElement/IsActiveEntity",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.SubElement/HasActiveEntity",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.SubElement/HasDraftEntity",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.SubElement/DraftAdministrativeData",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "{i18n>Draft_DraftAdministrativeData}",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "{i18n>Draft_DraftUUID}",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftUUID",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "{i18n>Draft_CreationDateTime}",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/CreationDateTime",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "{i18n>Draft_CreatedByUser}",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/CreatedByUser",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "{i18n>Draft_DraftIsCreatedByMe}",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsCreatedByMe",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "{i18n>Draft_LastChangeDateTime}",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangeDateTime",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "{i18n>Draft_LastChangedByUser}",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangedByUser",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "{i18n>Draft_InProcessByUser}",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/InProcessByUser",
+            },
+            Object {
+              "annotations": Array [
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Hidden",
+                  "value": Object {
+                    "Bool": true,
+                    "type": "Bool",
+                  },
+                },
+                Object {
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.Common.v1.Label",
+                  "value": Object {
+                    "String": "{i18n>Draft_DraftIsProcessedByMe}",
+                    "type": "String",
+                  },
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsProcessedByMe",
+            },
+          ],
+        },
+        "associationSets": Array [],
+        "associations": Array [],
+        "complexTypes": Array [],
+        "entityContainer": Object {
+          "_type": "EntityContainer",
+          "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer",
+          "name": "EntityContainer",
+        },
+        "entitySets": Array [
+          Object {
+            "_type": "EntitySet",
+            "entityTypeName": "sap.fe.core.ActionVisibility.RootElement",
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+            "name": "RootElement",
+            "navigationPropertyBinding": Object {
+              "Sibling": [Circular],
+              "SiblingEntity": [Circular],
+              "_Elements": Object {
+                "_type": "EntitySet",
+                "entityTypeName": "sap.fe.core.ActionVisibility.SubElement",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+                "name": "SubElement",
+                "navigationPropertyBinding": Object {
+                  "Sibling": [Circular],
+                  "SiblingEntity": [Circular],
+                  "owner": [Circular],
+                },
+              },
+            },
+          },
+          Object {
+            "_type": "EntitySet",
+            "entityTypeName": "sap.fe.core.ActionVisibility.SubElement",
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+            "name": "SubElement",
+            "navigationPropertyBinding": Object {
+              "Sibling": [Circular],
+              "SiblingEntity": [Circular],
+              "owner": Object {
+                "_type": "EntitySet",
+                "entityTypeName": "sap.fe.core.ActionVisibility.RootElement",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+                "name": "RootElement",
+                "navigationPropertyBinding": Object {
+                  "Sibling": [Circular],
+                  "SiblingEntity": [Circular],
+                  "_Elements": [Circular],
+                },
+              },
+            },
+          },
+        ],
+        "entityTypes": Array [
+          Object {
+            "_type": "EntityType",
+            "actions": Object {},
+            "entityProperties": Array [
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/ID",
+                "name": "ID",
+                "nullable": false,
+                "type": "Edm.Int32",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/Prop1",
+                "name": "Prop1",
+                "type": "Edm.String",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/Prop2",
+                "name": "Prop2",
+                "type": "Edm.String",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/isBoundAction1Hidden",
+                "name": "isBoundAction1Hidden",
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/isBoundAction2Hidden",
+                "name": "isBoundAction2Hidden",
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/isBoundAction3Hidden",
+                "name": "isBoundAction3Hidden",
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/Sibling_ID",
+                "name": "Sibling_ID",
+                "type": "Edm.Int32",
+              },
+              Object {
+                "_type": "Property",
+                "defaultValue": true,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/IsActiveEntity",
+                "name": "IsActiveEntity",
+                "nullable": false,
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "defaultValue": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/HasActiveEntity",
+                "name": "HasActiveEntity",
+                "nullable": false,
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "defaultValue": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/HasDraftEntity",
+                "name": "HasDraftEntity",
+                "nullable": false,
+                "type": "Edm.Boolean",
+              },
+            ],
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement",
+            "keys": Array [
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/ID",
+                "name": "ID",
+                "nullable": false,
+                "type": "Edm.Int32",
+              },
+              Object {
+                "_type": "Property",
+                "defaultValue": true,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/IsActiveEntity",
+                "name": "IsActiveEntity",
+                "nullable": false,
+                "type": "Edm.Boolean",
+              },
+            ],
+            "name": "RootElement",
+            "navigationProperties": Array [
+              Object {
+                "_type": "NavigationProperty",
+                "containsTarget": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/Sibling",
+                "isCollection": false,
+                "name": "Sibling",
+                "partner": undefined,
+                "referentialConstraint": Array [
+                  Object {
+                    "sourceProperty": "Sibling_ID",
+                    "sourceTypeName": "RootElement",
+                    "targetProperty": "ID",
+                    "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+                  },
+                ],
+                "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+              },
+              Object {
+                "_type": "NavigationProperty",
+                "containsTarget": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/_Elements",
+                "isCollection": true,
+                "name": "_Elements",
+                "partner": "owner",
+                "referentialConstraint": Array [],
+                "targetTypeName": "sap.fe.core.ActionVisibility.SubElement",
+              },
+              Object {
+                "_type": "NavigationProperty",
+                "containsTarget": true,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/DraftAdministrativeData",
+                "isCollection": false,
+                "name": "DraftAdministrativeData",
+                "partner": undefined,
+                "referentialConstraint": Array [],
+                "targetTypeName": "sap.fe.core.ActionVisibility.DraftAdministrativeData",
+              },
+              Object {
+                "_type": "NavigationProperty",
+                "containsTarget": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.RootElement/SiblingEntity",
+                "isCollection": false,
+                "name": "SiblingEntity",
+                "partner": undefined,
+                "referentialConstraint": Array [],
+                "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+              },
+            ],
+          },
+          Object {
+            "_type": "EntityType",
+            "actions": Object {},
+            "entityProperties": Array [
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/ID",
+                "name": "ID",
+                "nullable": false,
+                "type": "Edm.Int32",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/SubProp1",
+                "name": "SubProp1",
+                "type": "Edm.String",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/SubProp2",
+                "name": "SubProp2",
+                "type": "Edm.String",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/isBoundAction3Hidden",
+                "name": "isBoundAction3Hidden",
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/isBoundAction4Hidden",
+                "name": "isBoundAction4Hidden",
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/owner_ID",
+                "name": "owner_ID",
+                "type": "Edm.Int32",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/sibling_ID",
+                "name": "sibling_ID",
+                "type": "Edm.Int32",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/quantity",
+                "name": "quantity",
+                "type": "Edm.Double",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/quantityUoM",
+                "name": "quantityUoM",
+                "type": "Edm.String",
+              },
+              Object {
+                "_type": "Property",
+                "defaultValue": true,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/IsActiveEntity",
+                "name": "IsActiveEntity",
+                "nullable": false,
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "defaultValue": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/HasActiveEntity",
+                "name": "HasActiveEntity",
+                "nullable": false,
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "defaultValue": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/HasDraftEntity",
+                "name": "HasDraftEntity",
+                "nullable": false,
+                "type": "Edm.Boolean",
+              },
+            ],
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement",
+            "keys": Array [
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/ID",
+                "name": "ID",
+                "nullable": false,
+                "type": "Edm.Int32",
+              },
+              Object {
+                "_type": "Property",
+                "defaultValue": true,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/IsActiveEntity",
+                "name": "IsActiveEntity",
+                "nullable": false,
+                "type": "Edm.Boolean",
+              },
+            ],
+            "name": "SubElement",
+            "navigationProperties": Array [
+              Object {
+                "_type": "NavigationProperty",
+                "containsTarget": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/owner",
+                "isCollection": false,
+                "name": "owner",
+                "partner": "_Elements",
+                "referentialConstraint": Array [
+                  Object {
+                    "sourceProperty": "owner_ID",
+                    "sourceTypeName": "SubElement",
+                    "targetProperty": "ID",
+                    "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+                  },
+                ],
+                "targetTypeName": "sap.fe.core.ActionVisibility.RootElement",
+              },
+              Object {
+                "_type": "NavigationProperty",
+                "containsTarget": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/Sibling",
+                "isCollection": false,
+                "name": "Sibling",
+                "partner": undefined,
+                "referentialConstraint": Array [
+                  Object {
+                    "sourceProperty": "sibling_ID",
+                    "sourceTypeName": "SubElement",
+                    "targetProperty": "ID",
+                    "targetTypeName": "sap.fe.core.ActionVisibility.SubElement",
+                  },
+                ],
+                "targetTypeName": "sap.fe.core.ActionVisibility.SubElement",
+              },
+              Object {
+                "_type": "NavigationProperty",
+                "containsTarget": true,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/DraftAdministrativeData",
+                "isCollection": false,
+                "name": "DraftAdministrativeData",
+                "partner": undefined,
+                "referentialConstraint": Array [],
+                "targetTypeName": "sap.fe.core.ActionVisibility.DraftAdministrativeData",
+              },
+              Object {
+                "_type": "NavigationProperty",
+                "containsTarget": false,
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.SubElement/SiblingEntity",
+                "isCollection": false,
+                "name": "SiblingEntity",
+                "partner": undefined,
+                "referentialConstraint": Array [],
+                "targetTypeName": "sap.fe.core.ActionVisibility.SubElement",
+              },
+            ],
+          },
+          Object {
+            "_type": "EntityType",
+            "actions": Object {},
+            "entityProperties": Array [
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftUUID",
+                "name": "DraftUUID",
+                "nullable": false,
+                "type": "Edm.Guid",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/CreationDateTime",
+                "name": "CreationDateTime",
+                "precision": 7,
+                "type": "Edm.DateTimeOffset",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/CreatedByUser",
+                "maxLength": 256,
+                "name": "CreatedByUser",
+                "type": "Edm.String",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsCreatedByMe",
+                "name": "DraftIsCreatedByMe",
+                "type": "Edm.Boolean",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangeDateTime",
+                "name": "LastChangeDateTime",
+                "precision": 7,
+                "type": "Edm.DateTimeOffset",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangedByUser",
+                "maxLength": 256,
+                "name": "LastChangedByUser",
+                "type": "Edm.String",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/InProcessByUser",
+                "maxLength": 256,
+                "name": "InProcessByUser",
+                "type": "Edm.String",
+              },
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsProcessedByMe",
+                "name": "DraftIsProcessedByMe",
+                "type": "Edm.Boolean",
+              },
+            ],
+            "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData",
+            "keys": Array [
+              Object {
+                "_type": "Property",
+                "fullyQualifiedName": "sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftUUID",
+                "name": "DraftUUID",
+                "nullable": false,
+                "type": "Edm.Guid",
+              },
+            ],
+            "name": "DraftAdministrativeData",
+            "navigationProperties": Array [],
+          },
+        ],
+        "namespace": "sap.fe.core.ActionVisibility",
+        "singletons": Array [],
+        "typeDefinitions": Array [],
+      },
+      "version": "4.0",
+    },
+    RawMetadataInstance {
+      "identification": "annoFile",
+      "references": Array [
+        Object {
+          "alias": "Common",
+          "namespace": "com.sap.vocabularies.Common.v1",
+          "uri": "https://sap.github.io/odata-vocabularies/vocabularies/Common.xml",
+        },
+        Object {
+          "alias": "Core",
+          "namespace": "Org.OData.Core.V1",
+          "uri": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml",
+        },
+        Object {
+          "alias": "UI",
+          "namespace": "com.sap.vocabularies.UI.v1",
+          "uri": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml",
+        },
+        Object {
+          "alias": "ActionVisibility",
+          "namespace": "sap.fe.core.ActionVisibility",
+          "uri": "/sap/fe/core/mock/action-visibility/$metadata",
+        },
+      ],
+      "schema": Object {
+        "actions": Array [],
+        "annotations": Object {
+          "annoFile": Array [
+            Object {
+              "annotations": Array [
+                Object {
+                  "collection": Array [
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "Prop1",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "ID",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                  ],
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.LineItem",
+                },
+                Object {
+                  "collection": Array [
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Determining",
+                          "value": Object {
+                            "Bool": true,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "Path": "isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Action 2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundAction2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Determining",
+                          "value": Object {
+                            "Bool": true,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "type": "Unknown",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Header Action 1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundHeaderAction1",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Determining",
+                          "value": Object {
+                            "Bool": false,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "annotations": Array [
+                        Object {
+                          "qualifier": undefined,
+                          "term": "com.sap.vocabularies.UI.v1.Hidden",
+                          "value": Object {
+                            "type": "Unknown",
+                          },
+                        },
+                      ],
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Label",
+                          "value": Object {
+                            "String": "Bound Header Action 2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Action",
+                          "value": Object {
+                            "String": "sap.fe.core.ActionVisibility.boundHeaderAction2",
+                            "type": "String",
+                          },
+                        },
+                        Object {
+                          "name": "Determining",
+                          "value": Object {
+                            "Bool": false,
+                            "type": "Bool",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "isBoundAction1Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "isBoundAction2Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                    Object {
+                      "propertyValues": Array [
+                        Object {
+                          "name": "Value",
+                          "value": Object {
+                            "Path": "isBoundAction3Hidden",
+                            "type": "Path",
+                          },
+                        },
+                      ],
+                      "type": "com.sap.vocabularies.UI.v1.DataField",
+                    },
+                  ],
+                  "qualifier": undefined,
+                  "term": "com.sap.vocabularies.UI.v1.Identification",
+                },
+              ],
+              "target": "sap.fe.core.ActionVisibility.RootElement",
+            },
+          ],
+        },
+        "associationSets": Array [],
+        "associations": Array [],
+        "complexTypes": Array [],
+        "entityContainer": Object {
+          "_type": "EntityContainer",
+          "fullyQualifiedName": "",
+        },
+        "entitySets": Array [],
+        "entityTypes": Array [],
+        "namespace": "sap.fe.core.ActionVisibility.LocalService",
+        "singletons": Array [],
+        "typeDefinitions": Array [],
+      },
+      "version": "4.0",
+    },
+  ],
+  "_references": Array [
+    Object {
+      "alias": "Common",
+      "namespace": "com.sap.vocabularies.Common.v1",
+      "uri": "https://sap.github.io/odata-vocabularies/vocabularies/Common.xml",
+    },
+    Object {
+      "alias": "Core",
+      "namespace": "Org.OData.Core.V1",
+      "uri": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml",
+    },
+    Object {
+      "alias": "Measures",
+      "namespace": "Org.OData.Measures.V1",
+      "uri": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml",
+    },
+    Object {
+      "alias": "UI",
+      "namespace": "com.sap.vocabularies.UI.v1",
+      "uri": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml",
+    },
+    Object {
+      "alias": "Common",
+      "namespace": "com.sap.vocabularies.Common.v1",
+      "uri": "https://sap.github.io/odata-vocabularies/vocabularies/Common.xml",
+    },
+    Object {
+      "alias": "Core",
+      "namespace": "Org.OData.Core.V1",
+      "uri": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml",
+    },
+    Object {
+      "alias": "UI",
+      "namespace": "com.sap.vocabularies.UI.v1",
+      "uri": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml",
+    },
+    Object {
+      "alias": "ActionVisibility",
+      "namespace": "sap.fe.core.ActionVisibility",
+      "uri": "/sap/fe/core/mock/action-visibility/$metadata",
+    },
+  ],
+  "_singletons": Array [],
+  "_typeDefinitions": Array [],
+  "identification": "mergedParserInstance",
+  "version": "4.0",
+}
+`;

--- a/packages/edmx-parser/test/fixtures/merge/annotations.xml
+++ b/packages/edmx-parser/test/fixtures/merge/annotations.xml
@@ -1,0 +1,76 @@
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+        <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1" />
+    </edmx:Reference>
+    <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1" />
+    </edmx:Reference>
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+        <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1" />
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/fe/core/mock/action-visibility/$metadata">
+        <edmx:Include Alias="ActionVisibility" Namespace="sap.fe.core.ActionVisibility" />
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="sap.fe.core.ActionVisibility.LocalService">
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="Prop1"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="ID"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1" />
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1" />
+                            <PropertyValue Property="Determining" Bool="true" />
+                            <Annotation Term="UI.Hidden" Path="isBoundAction1Hidden" />
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2" />
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2" />
+                            <PropertyValue Property="Determining" Bool="true" />
+                            <Annotation Term="UI.Hidden" Path="isBoundAction2Hidden" />
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Header Action 1" />
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundHeaderAction1" />
+                            <PropertyValue Property="Determining" Bool="false" />
+                            <Annotation Term="UI.Hidden">
+                                <Eq>
+                                    <Path>isBoundAction1Hidden</Path>
+                                    <Bool>true</Bool>
+                                </Eq>
+                            </Annotation>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Header Action 2" />
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundHeaderAction2" />
+                            <PropertyValue Property="Determining" Bool="false" />
+                            <Annotation Term="UI.Hidden">
+                                <Not>
+                                    <Path>isBoundAction2Hidden</Path>
+                                </Not>
+                            </Annotation>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction1Hidden" />
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction2Hidden" />
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction3Hidden" />
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/edmx-parser/test/fixtures/merge/metadata.xml
+++ b/packages/edmx-parser/test/fixtures/merge/metadata.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+        <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml">
+        <edmx:Include Alias="Measures" Namespace="Org.OData.Measures.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+        <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema Namespace="sap.fe.core.ActionVisibility" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+            <EntityContainer Name="EntityContainer">
+                <EntitySet Name="RootElement" EntityType="sap.fe.core.ActionVisibility.RootElement">
+                    <NavigationPropertyBinding Path="Sibling" Target="RootElement"/>
+                    <NavigationPropertyBinding Path="_Elements" Target="SubElement"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="RootElement"/>
+                </EntitySet>
+                <EntitySet Name="SubElement" EntityType="sap.fe.core.ActionVisibility.SubElement">
+                    <NavigationPropertyBinding Path="owner" Target="RootElement"/>
+                    <NavigationPropertyBinding Path="Sibling" Target="SubElement"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="SubElement"/>
+                </EntitySet>
+            </EntityContainer>
+            <EntityType Name="RootElement">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+                <Property Name="Prop1" Type="Edm.String"/>
+                <Property Name="Prop2" Type="Edm.String"/>
+                <Property Name="isBoundAction1Hidden" Type="Edm.Boolean"/>
+                <Property Name="isBoundAction2Hidden" Type="Edm.Boolean"/>
+                <Property Name="isBoundAction3Hidden" Type="Edm.Boolean"/>
+                <Property Name="Sibling_ID" Type="Edm.Int32"/>
+                <NavigationProperty Name="Sibling" Type="sap.fe.core.ActionVisibility.RootElement">
+                    <ReferentialConstraint Property="Sibling_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <NavigationProperty Name="_Elements" Type="Collection(sap.fe.core.ActionVisibility.SubElement)" Partner="owner">
+                    <OnDelete Action="Cascade"/>
+                </NavigationProperty>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="sap.fe.core.ActionVisibility.DraftAdministrativeData" ContainsTarget="true"/>
+                <NavigationProperty Name="SiblingEntity" Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </EntityType>
+            <EntityType Name="SubElement">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+                <Property Name="SubProp1" Type="Edm.String"/>
+                <Property Name="SubProp2" Type="Edm.String"/>
+                <Property Name="isBoundAction3Hidden" Type="Edm.Boolean"/>
+                <Property Name="isBoundAction4Hidden" Type="Edm.Boolean"/>
+                <Property Name="owner_ID" Type="Edm.Int32"/>
+                <NavigationProperty Name="owner" Type="sap.fe.core.ActionVisibility.RootElement" Partner="_Elements">
+                    <ReferentialConstraint Property="owner_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <Property Name="sibling_ID" Type="Edm.Int32"/>
+                <NavigationProperty Name="Sibling" Type="sap.fe.core.ActionVisibility.SubElement">
+                    <ReferentialConstraint Property="sibling_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <Property Name="quantity" Type="Edm.Double"/>
+                <Property Name="quantityUoM" Type="Edm.String"/>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="sap.fe.core.ActionVisibility.DraftAdministrativeData" ContainsTarget="true"/>
+                <NavigationProperty Name="SiblingEntity" Type="sap.fe.core.ActionVisibility.SubElement"/>
+            </EntityType>
+            <EntityType Name="DraftAdministrativeData">
+                <Key>
+                    <PropertyRef Name="DraftUUID"/>
+                </Key>
+                <Property Name="DraftUUID" Type="Edm.Guid" Nullable="false"/>
+                <Property Name="CreationDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="CreatedByUser" Type="Edm.String" MaxLength="256"/>
+                <Property Name="DraftIsCreatedByMe" Type="Edm.Boolean"/>
+                <Property Name="LastChangeDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="LastChangedByUser" Type="Edm.String" MaxLength="256"/>
+                <Property Name="InProcessByUser" Type="Edm.String" MaxLength="256"/>
+                <Property Name="DraftIsProcessedByMe" Type="Edm.Boolean"/>
+            </EntityType>
+            <Action Name="boundAction1" IsBound="true" EntitySetPath="self">
+                <Parameter Name="self" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="boundAction2" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="boundAction3" IsBound="true" EntitySetPath="self">
+                <Parameter Name="self" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.SubElement"/>
+                <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.SubElement"/>
+            </Action>
+            <Action Name="draftActivate" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Action Name="draftEdit" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
+                <Parameter Name="PreserveChanges" Type="Edm.Boolean"/>
+                <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+            </Action>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="ID"/>
+                            <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="Prop1"/>
+                            <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/Low"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Menu Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.menuAction1"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Menu Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.menuAction2"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 3"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction3"/>
+                            <Annotation Term="UI.Hidden" Path="_Elements/isBoundAction3Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1 Inline"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1"/>
+                            <PropertyValue Property="Inline" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="Sibling/isBoundAction1Hidden"/>
+                            <PropertyValue Property="Label" String="Sibling isBoundAction2 Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2"/>
+                            <PropertyValue Property="Inline" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="Sibling/isBoundAction2Hidden"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.HeaderInfo">
+                    <Record Type="UI.HeaderInfoType">
+                        <PropertyValue Property="TypeName" String="Root Element"/>
+                        <PropertyValue Property="TypeNamePlural" String="Root Elements"/>
+                        <PropertyValue Property="Title">
+                            <Record Type="UI.DataField">
+                                <PropertyValue Property="Value" Path="Prop1"/>
+                            </Record>
+                        </PropertyValue>
+                        <PropertyValue Property="Description">
+                            <Record Type="UI.DataField">
+                                <PropertyValue Property="Value" Path="Prop2"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.CollectionFacet">
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="Label" String="Identification"/>
+                                        <PropertyValue Property="Target" AnnotationPath="@UI.Identification"/>
+                                    </Record>
+                                    <Record Type="UI.CollectionFacet">
+                                        <PropertyValue Property="ID" String="GeneralInformation"/>
+                                        <PropertyValue Property="Label" String="General Information"/>
+                                        <PropertyValue Property="Facets">
+                                            <Collection>
+                                                <Record Type="UI.ReferenceFacet">
+                                                    <PropertyValue Property="Label" String="General Information"/>
+                                                    <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#GeneralInformation"/>
+                                                </Record>
+                                            </Collection>
+                                        </PropertyValue>
+                                    </Record>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="ID" String="SubElements"/>
+                                        <PropertyValue Property="Label" String="Sub Elements"/>
+                                        <PropertyValue Property="Target" AnnotationPath="_Elements/@UI.LineItem"/>
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1"/>
+                            <PropertyValue Property="Determining" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2"/>
+                            <PropertyValue Property="Determining" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Header Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundHeaderAction1"/>
+                            <PropertyValue Property="Determining" Bool="false"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Header Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundHeaderAction2"/>
+                            <PropertyValue Property="Determining" Bool="false"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction3Hidden"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="GeneralInformation">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Label" String="General Information"/>
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="ID"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Prop1"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Prop2"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.EntityContainer/RootElement">
+                <Annotation Term="Common.DraftRoot">
+                    <Record Type="Common.DraftRootType">
+                        <PropertyValue Property="ActivationAction" String="sap.fe.core.ActionVisibility.draftActivate"/>
+                        <PropertyValue Property="EditAction" String="sap.fe.core.ActionVisibility.draftEdit"/>
+                        <PropertyValue Property="PreparationAction" String="sap.fe.core.ActionVisibility.draftPrepare"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/ID">
+                <Annotation Term="Core.Computed" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/Prop1">
+                <Annotation Term="Common.Label" String="First Prop"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/Prop2">
+                <Annotation Term="Common.Label" String="Second Propyour "/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/isBoundAction1Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 1 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/isBoundAction2Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 2 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/isBoundAction3Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 3 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/IsActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/HasActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/HasDraftEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.RootElement/DraftAdministrativeData">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="SubProp1"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="owner/isBoundAction1Hidden"/>
+                            <PropertyValue Property="Label" String="Owner -&gt; boundAction1 Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction1"/>
+                            <Annotation Term="UI.Hidden" Path="owner/isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Menu Action 1"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.menuAction1"/>
+                            <Annotation Term="UI.Hidden" Path="owner/isBoundAction1Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="owner/Sibling/isBoundAction2Hidden"/>
+                            <PropertyValue Property="Label" String="Owner -&gt; Sibling boundAction2 Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction2"/>
+                            <Annotation Term="UI.Hidden" Path="owner/Sibling/isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Menu Action 2"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.menuAction2"/>
+                            <Annotation Term="UI.Hidden" Path="owner/Sibling/isBoundAction2Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="isBoundAction3Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 3 Inline"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction3"/>
+                            <PropertyValue Property="Inline" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="isBoundAction3Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="Sibling/isBoundAction4Hidden"/>
+                            <PropertyValue Property="Label" String="Sibling boundAction4 Hidden"/>
+                        </Record>
+                        <Record Type="UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Bound Action 4"/>
+                            <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundAction4"/>
+                            <PropertyValue Property="Inline" Bool="true"/>
+                            <Annotation Term="UI.Hidden" Path="Sibling/isBoundAction4Hidden"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.EntityContainer/SubElement">
+                <Annotation Term="Common.DraftNode">
+                    <Record Type="Common.DraftNodeType">
+                        <PropertyValue Property="PreparationAction" String="sap.fe.core.ActionVisibility.draftPrepare"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/ID">
+                <Annotation Term="Core.Computed" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/isBoundAction3Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 3 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/isBoundAction4Hidden">
+                <Annotation Term="Common.Label" String="Bound Action 4 Hidden"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/quantity">
+                <Annotation Term="Measures.Unit" Path="quantityUoM"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/IsActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/HasActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/HasDraftEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.SubElement/DraftAdministrativeData">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData">
+                <Annotation Term="Common.Label" String="{i18n>Draft_DraftAdministrativeData}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftUUID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Common.Label" String="{i18n>Draft_DraftUUID}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/CreationDateTime">
+                <Annotation Term="Common.Label" String="{i18n>Draft_CreationDateTime}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/CreatedByUser">
+                <Annotation Term="Common.Label" String="{i18n>Draft_CreatedByUser}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsCreatedByMe">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Common.Label" String="{i18n>Draft_DraftIsCreatedByMe}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangeDateTime">
+                <Annotation Term="Common.Label" String="{i18n>Draft_LastChangeDateTime}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/LastChangedByUser">
+                <Annotation Term="Common.Label" String="{i18n>Draft_LastChangedByUser}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/InProcessByUser">
+                <Annotation Term="Common.Label" String="{i18n>Draft_InProcessByUser}"/>
+            </Annotations>
+            <Annotations Target="sap.fe.core.ActionVisibility.DraftAdministrativeData/DraftIsProcessedByMe">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Common.Label" String="{i18n>Draft_DraftIsProcessedByMe}"/>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/edmx-parser/test/merge.spec.ts
+++ b/packages/edmx-parser/test/merge.spec.ts
@@ -1,0 +1,14 @@
+import { loadFixture } from './fixturesHelper';
+import { parse, merge } from '../src';
+import type { RawMetadata } from '@sap-ux/vocabularies-types';
+
+describe('Merger', function () {
+    it('can parse an edmx file', async () => {
+        const xmlFile = await loadFixture('merge/metadata.xml');
+        const schema: RawMetadata = parse(xmlFile);
+        const annoFile = await loadFixture('merge/annotations.xml');
+        const annoSchema: RawMetadata = parse(annoFile, 'annoFile');
+        const mergeSchema = merge(schema, annoSchema);
+        expect(mergeSchema).toMatchSnapshot();
+    });
+});

--- a/packages/fe-mockserver-core/test/__snapshots__/middleware.test.ts.snap
+++ b/packages/fe-mockserver-core/test/__snapshots__/middleware.test.ts.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`V4 Requestor can create data through a call 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+<head>
+<meta charset=\\"utf-8\\">
+<title>Error</title>
+</head>
+<body>
+<pre>Cannot POST /tenant-002/sap/fe/core/mock/action/RootElement</pre>
+</body>
+</html>
+"
+`;
+
+exports[`V4 Requestor can get the metadata 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+<head>
+<meta charset=\\"utf-8\\">
+<title>Error</title>
+</head>
+<body>
+<pre>Cannot GET /sap/fe/core/mock/action/$metadata</pre>
+</body>
+</html>
+"
+`;
+
+exports[`V4 Requestor can get the serviceCatalog 1`] = `"{\\"d\\":{\\"results\\":[{\\"ID\\":\\"action\\"}]}}"`;
+
+exports[`V4 Requestor can get the serviceCatalog 2`] = `"{\\"d\\":{\\"results\\":[{\\"TechnicalName\\":\\"action\\",\\"Version\\":2}]}}"`;
+
+exports[`V4 Requestor can get updated the sticky header timeout 1`] = `""`;
+
+exports[`V4 Requestor can get updated the sticky header timeout for a tenant 1`] = `null`;
+
+exports[`V4 Requestor can reload the data 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+<head>
+<meta charset=\\"utf-8\\">
+<title>Error</title>
+</head>
+<body>
+<pre>Cannot POST /sap/fe/core/mock/action/$metadata/reload</pre>
+</body>
+</html>
+"
+`;
+
+exports[`V4 Requestor can update data through a call 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+<head>
+<meta charset=\\"utf-8\\">
+<title>Error</title>
+</head>
+<body>
+<pre>Cannot POST /tenant-001/sap/fe/core/mock/action/RootElement</pre>
+</body>
+</html>
+"
+`;
+
+exports[`V4 Requestor can update data through a call 2`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+<head>
+<meta charset=\\"utf-8\\">
+<title>Error</title>
+</head>
+<body>
+<pre>Cannot PATCH /tenant-001/sap/fe/core/mock/action/RootElement(ID=556)</pre>
+</body>
+</html>
+"
+`;

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -345,7 +345,7 @@ export type BaseNavigationProperty = {
     annotations: NavigationPropertyAnnotations;
     isCollection: boolean;
     containsTarget: boolean;
-    referentialConstraint?: ReferentialConstraint[];
+    referentialConstraint: ReferentialConstraint[];
 };
 export type SingleNavigationProperty = BaseNavigationProperty & {
     isCollection: false;
@@ -392,7 +392,7 @@ export type Singleton = {
 export type EntityContainer = {
     _type: 'EntityContainer';
     name?: string;
-    fullyQualifiedName?: string;
+    fullyQualifiedName: string;
     annotations: EntityContainerAnnotations;
 };
 

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -309,6 +309,10 @@ export type Property = {
     isKey: boolean;
 };
 
+export type RecordComplexType = {
+    annotations?: RecordAnnotations;
+};
+
 export type ComplexType = {
     _type: 'ComplexType';
     name: SimpleIdentifier;

--- a/packages/vocabularies-types/utils/generate_types.ts
+++ b/packages/vocabularies-types/utils/generate_types.ts
@@ -249,7 +249,7 @@ async function generateTypes(targetFolder: string) {
         vocabularyDef += 'import AnnotationTerm = Edm.AnnotationTerm;\n';
         vocabularyDef += 'import PropertyAnnotationValue = Edm.PropertyAnnotationValue;\n';
         vocabularyDef += 'import EnumValue = Edm.EnumValue;\n';
-        vocabularyDef += 'import ComplexType = Edm.ComplexType;\n';
+        vocabularyDef += 'import ComplexType = Edm.RecordComplexType;\n';
         // vocabularyDef += "    import AnnotationRecord = Edm.AnnotationRecord;\n";
         vocabularyDef += '\n';
         const vocabularyDefinition: SchemaWrapper = vocabularyData.content[vocabularyData.namespace];


### PR DESCRIPTION
Currently annotation of record or other annotations are always pulled from their node and brought back at the top of the service.
This doesn't work in case there are annotation overrides defined that would replace their source. We then end up with incoherent data.