### PR TITLE
fix: incorrect annotation file format are now properly supported

### DIFF
--- a/.changeset/twelve-socks-sniff.md
+++ b/.changeset/twelve-socks-sniff.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-converter': patch
+---
+
+Fix an issue with incorrect annotation format

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -1356,7 +1356,7 @@ export function convert(rawMetadata: RawMetadata): ConvertedMetadata {
         const currentTarget = targetSplit.slice(1).reduce((currentObj, path) => {
             return currentObj?.[path];
         }, objectMap[baseObj]);
-        if (!currentTarget) {
+        if (!currentTarget || typeof currentTarget !== 'object') {
             ANNOTATION_ERRORS.push({
                 message: 'The following annotation target was not found on the service ' + currentTargetName
             });

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -371,6 +371,8 @@ describe('Annotation Converter', () => {
         const parsedEDMX = parse(await loadFixture('v4/pathError.xml'));
         const convertedTypes = convert(parsedEDMX);
         expect(convertedTypes.entitySets[0].annotations).not.toBeNull();
+        expect(convertedTypes.diagnostics).not.toBeNull();
+        expect(convertedTypes.diagnostics.length).toEqual(1);
     });
     it('dummy bound action', async () => {
         const parsedEDMX = parse(await loadFixture('v4/v4Meta.xml'));

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -372,7 +372,9 @@ describe('Annotation Converter', () => {
         const convertedTypes = convert(parsedEDMX);
         expect(convertedTypes.entitySets[0].annotations).not.toBeNull();
         expect(convertedTypes.diagnostics).not.toBeNull();
-        expect(convertedTypes.diagnostics.length).toEqual(1);
+        expect(convertedTypes.diagnostics[0].message).toEqual(
+            'The following annotation target was not found on the service IncidentService.Incidents@com.sap.vocabularies.UI.v1.Facets/1/Target'
+        );
     });
     it('dummy bound action', async () => {
         const parsedEDMX = parse(await loadFixture('v4/v4Meta.xml'));

--- a/packages/annotation-converter/test/fixtures/v4/pathError.xml
+++ b/packages/annotation-converter/test/fixtures/v4/pathError.xml
@@ -467,6 +467,9 @@
 				<Annotation Term="Common.Text" Path="name"/>
 				<Annotation Term="Common.Label" String="{i18n>IncidentStatus}"/>
 			</Annotations>
+			<Annotations Target="IncidentService.ThisIsNotARealIncident">
+				<Annotation Term="Common.Text" Path="name"/>
+			</Annotations>
 			<Annotations Target="IncidentService.Incidents">
 				<Annotation Term="Analytics.AggregatedProperties">
 					<Collection>
@@ -502,6 +505,21 @@
 							<PropertyValue Property="Label" String="sec form"/>
 							<PropertyValue Property="ID" String="secform"/>
 							<PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#secform"/>
+						</Record>
+						<Record Type="UI.ReferenceFacet">
+							<PropertyValue Property="Label" String="sec form"/>
+							<PropertyValue Property="ID" String="secform"/>
+							<PropertyValue Property="Target" String="@UI.FieldGroup#secform22">
+								<Annotation Term="Core.Messages">
+									<Collection>
+										<Record>
+											<PropertyValue Property="code" String="SY-530"></PropertyValue>
+											<PropertyValue Property="message" String="An exception was raised"></PropertyValue>
+											<PropertyValue Property="severity" String="error"></PropertyValue>
+										</Record>
+									</Collection>
+								</Annotation>
+							</PropertyValue>
 						</Record>
 					</Collection>
 				</Annotation>


### PR DESCRIPTION
In case the Target resolved to a string the code was not considering this as an error