### PR TITLE
fix: make sure property 'annotations' is defined on all entity types

### DIFF
--- a/.changeset/silly-falcons-count.md
+++ b/.changeset/silly-falcons-count.md
@@ -1,5 +1,6 @@
 ---
 '@sap-ux/annotation-converter': patch
+'@sap-ux/vocabularies-types': patch
 ---
 
 Ensure converted entity types comply to the type definition

--- a/.changeset/silly-falcons-count.md
+++ b/.changeset/silly-falcons-count.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-converter': patch
+---
+
+Ensure converted entity types comply to the type definition

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -100,6 +100,7 @@ function buildObjectMap(rawMetadata: RawMetadata): Record<string, any> {
         objectMap[typeDefinition.fullyQualifiedName] = typeDefinition;
     });
     rawMetadata.schema.entityTypes.forEach((entityType) => {
+        (entityType as EntityType).annotations = {}; // 'annotations' property is mandatory
         objectMap[entityType.fullyQualifiedName] = entityType;
         entityType.entityProperties.forEach((property) => {
             objectMap[property.fullyQualifiedName] = property;
@@ -150,8 +151,10 @@ function combinePath(currentTarget: string, path: string): string {
         return currentTarget + '/' + path;
     }
 }
+
 const ALL_ANNOTATION_ERRORS: any = {};
 let ANNOTATION_ERRORS: { message: string }[] = [];
+
 /**
  * @param path
  * @param oErrorMsg
@@ -532,6 +535,7 @@ function parseRecordType(recordDefinition: AnnotationRecord, context: Conversion
     }
     return targetType;
 }
+
 function parseRecord(
     recordDefinition: AnnotationRecord,
     currentFQN: string,
@@ -871,6 +875,7 @@ function prepareNavigationProperties(
         return outNavProp;
     });
 }
+
 /**
  * @param entityTypes
  * @param associations
@@ -1109,6 +1114,7 @@ function ensureAnnotations(currentTarget: any, vocAlias: string) {
         currentTarget.annotations._annotations = {};
     }
 }
+
 function processAnnotations(
     currentContext: ConversionContext,
     annotationList: AnnotationList,
@@ -1298,6 +1304,7 @@ function mergeAnnotations(rawMetadata: RawMetadata): Record<string, AnnotationLi
     });
     return annotationListPerTarget;
 }
+
 /**
  * Convert a RawMetadata into an object representation to be used to easily navigate a metadata object and its annotation.
  *

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -5,6 +5,7 @@ import type {
     ActionParameter,
     Annotation,
     AnnotationPath,
+    ConvertedMetadata,
     EntitySet,
     EntityType,
     EnumValue,
@@ -548,5 +549,27 @@ describe('Annotation Converter', () => {
         expect(
             convertedMetadataTypes.entityTypes[0].annotations?.UI?.LineItem?.[0]?.annotations?.UI?.Importance?.toString()
         ).toEqual('UI.ImportanceType/High');
+    });
+
+    function checkAnnotationObject(convertedTypes: ConvertedMetadata) {
+        convertedTypes.entityTypes.forEach((entityType) => {
+            expect(entityType).toHaveProperty('annotations');
+            expect(entityType.annotations).not.toBeUndefined();
+            expect(entityType.annotations).not.toBeNull();
+        });
+    }
+
+    it('should return type-compliant entity types (no containment)', async () => {
+        const parsedMetadata = parse(await loadFixture('v4/AnnoNoContainment.xml'));
+        const convertedTypes = convert(parsedMetadata);
+
+        checkAnnotationObject(convertedTypes);
+    });
+
+    it('should return type-compliant entity types (with containments)', async () => {
+        const parsedMetadata = parse(await loadFixture('v4/AnnoWithContainment.xml'));
+        const convertedTypes = convert(parsedMetadata);
+
+        checkAnnotationObject(convertedTypes);
     });
 });

--- a/packages/annotation-converter/test/fixtures/v4/AnnoNoContainment.xml
+++ b/packages/annotation-converter/test/fixtures/v4/AnnoNoContainment.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+    <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="sap.fe.test.JestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="MyEntities" EntityType="sap.fe.test.JestService.MyEntities">
+          <NavigationPropertyBinding Path="myText" Target="MyEntityTexts"/>
+        </EntitySet>
+        <EntitySet Name="MyEntityTexts" EntityType="sap.fe.test.JestService.MyEntityTexts"/>
+      </EntityContainer>
+      <EntityType Name="MyEntities">
+        <Key>
+          <PropertyRef Name="myPrimaryKey"/>
+        </Key>
+        <Property Name="myPrimaryKey" Type="Edm.String" Nullable="false"/>
+        <NavigationProperty Name="myText" Type="sap.fe.test.JestService.MyEntityTexts">
+          <OnDelete Action="Cascade"/>
+          <ReferentialConstraint Property="ID" ReferencedProperty="myPrimaryKey"/>
+        </NavigationProperty>
+      </EntityType>
+      <EntityType Name="MyEntityTexts">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false"/>
+        <Property Name="name" Type="Edm.String"/>
+      </EntityType>
+      <Annotations Target="sap.fe.test.JestService.MyEntities/myPrimaryKey">
+        <Annotation Term="Common.Text" Path="myText/name">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextFirst"/>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="sap.fe.test.JestService.MyEntityTexts/ID">
+        <Annotation Term="Common.Text" Path="name"/>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/annotation-converter/test/fixtures/v4/AnnoWithContainment.xml
+++ b/packages/annotation-converter/test/fixtures/v4/AnnoWithContainment.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+    <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="sap.fe.test.JestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="MyEntities" EntityType="sap.fe.test.JestService.MyEntities"/>
+      </EntityContainer>
+      <EntityType Name="MyEntities">
+        <Key>
+          <PropertyRef Name="myPrimaryKey"/>
+        </Key>
+        <Property Name="myPrimaryKey" Type="Edm.String" Nullable="false"/>
+        <NavigationProperty Name="myText" Type="sap.fe.test.JestService.MyEntityTexts" ContainsTarget="true">
+          <ReferentialConstraint Property="ID" ReferencedProperty="myPrimaryKey"/>
+        </NavigationProperty>
+      </EntityType>
+      <EntityType Name="MyEntityTexts">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false"/>
+        <Property Name="name" Type="Edm.String"/>
+      </EntityType>
+      <Annotations Target="sap.fe.test.JestService.MyEntities/myPrimaryKey">
+        <Annotation Term="Common.Text" Path="myText/name">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextFirst"/>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="sap.fe.test.JestService.MyEntityTexts/ID">
+        <Annotation Term="Common.Text" Path="name"/>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -219,7 +219,7 @@ export type Time = string;
 export type Binary = string;
 export type Decimal = IDecimal | Number;
 export type Double = IDecimal | Number;
-
+export type Untyped = any;
 export type Date = string;
 export type Guid = any;
 export type Duration = any;


### PR DESCRIPTION
After conversion, entity types sometimes did not have a property `annotations`. This violated the type definition (`EntityType`), which does not allow undefined or null as values for `annotations`.