### PR TITLE
fix: $select query option involving paths to complex type members now returns correct data

### DIFF
--- a/.changeset/dull-birds-call.md
+++ b/.changeset/dull-birds-call.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Fixes an issue that resulted in empty objects being returned if the query contains a path in a $select option

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
@@ -1,7 +1,7 @@
 [
     {
         "ID": 1,
-        "Prop1": "First Prop",
+        "Prop1": "SomethingElse",
         "Prop2": "Second Prop",
         "isBoundAction1Hidden": false,
         "isBoundAction2Hidden": false,

--- a/packages/fe-mockserver-core/test/unit/v4/__snapshots__/dataAccess.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/v4/__snapshots__/dataAccess.test.ts.snap
@@ -32,6 +32,251 @@ Object {
 }
 `;
 
+exports[`Data Access $select handling with structured complex types can read /A 1`] = `
+Array [
+  Object {
+    "ID": "A1",
+    "complex": Object {
+      "value1": 1,
+      "value2": 2,
+    },
+  },
+]
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1') 1`] = `
+Object {
+  "ID": "A1",
+  "complex": Object {
+    "value1": 1,
+    "value2": 2,
+  },
+}
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')/b 1`] = `
+Array [
+  Object {
+    "UID": "B1",
+    "a_ID": "A1",
+    "complex": Object {
+      "value1": true,
+      "value2": false,
+    },
+  },
+]
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')/b('B1')?$select=complex 1`] = `
+Object {
+  "UID": "B1",
+  "complex": Object {
+    "value1": true,
+    "value2": false,
+  },
+}
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')/b('B1')?$select=complex/value1 1`] = `
+Object {
+  "UID": "B1",
+  "complex": Object {
+    "value1": true,
+    "value2": false,
+  },
+}
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')/b?$select=complex 1`] = `
+Array [
+  Object {
+    "UID": "B1",
+    "complex": Object {
+      "value1": true,
+      "value2": false,
+    },
+  },
+]
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')/b?$select=complex/value1 1`] = `
+Array [
+  Object {
+    "UID": "B1",
+    "complex": Object {
+      "value1": true,
+      "value2": false,
+    },
+  },
+]
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')?$expand=b 1`] = `
+Object {
+  "ID": "A1",
+  "b": Array [
+    Object {
+      "UID": "B1",
+      "a_ID": "A1",
+      "complex": Object {
+        "value1": true,
+        "value2": false,
+      },
+    },
+  ],
+  "complex": Object {
+    "value1": 1,
+    "value2": 2,
+  },
+}
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')?$expand=b($select=complex) 1`] = `
+Object {
+  "ID": "A1",
+  "b": Array [
+    Object {
+      "UID": "B1",
+      "complex": Object {
+        "value1": true,
+        "value2": false,
+      },
+    },
+  ],
+  "complex": Object {
+    "value1": 1,
+    "value2": 2,
+  },
+}
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')?$expand=b($select=complex/value1) 1`] = `
+Object {
+  "ID": "A1",
+  "b": Array [
+    Object {
+      "UID": "B1",
+      "complex": Object {
+        "value1": true,
+        "value2": false,
+      },
+    },
+  ],
+  "complex": Object {
+    "value1": 1,
+    "value2": 2,
+  },
+}
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')?$select=complex 1`] = `
+Object {
+  "ID": "A1",
+  "complex": Object {
+    "value1": 1,
+    "value2": 2,
+  },
+}
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A('A1')?$select=complex/value1 1`] = `
+Object {
+  "ID": "A1",
+  "complex": Object {
+    "value1": 1,
+    "value2": 2,
+  },
+}
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A?$expand=b 1`] = `
+Array [
+  Object {
+    "ID": "A1",
+    "b": Array [
+      Object {
+        "UID": "B1",
+        "a_ID": "A1",
+        "complex": Object {
+          "value1": true,
+          "value2": false,
+        },
+      },
+    ],
+    "complex": Object {
+      "value1": 1,
+      "value2": 2,
+    },
+  },
+]
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A?$expand=b($select=complex) 1`] = `
+Array [
+  Object {
+    "ID": "A1",
+    "b": Array [
+      Object {
+        "UID": "B1",
+        "complex": Object {
+          "value1": true,
+          "value2": false,
+        },
+      },
+    ],
+    "complex": Object {
+      "value1": 1,
+      "value2": 2,
+    },
+  },
+]
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A?$expand=b($select=complex/value1) 1`] = `
+Array [
+  Object {
+    "ID": "A1",
+    "b": Array [
+      Object {
+        "UID": "B1",
+        "complex": Object {
+          "value1": true,
+          "value2": false,
+        },
+      },
+    ],
+    "complex": Object {
+      "value1": 1,
+      "value2": 2,
+    },
+  },
+]
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A?$select=complex 1`] = `
+Array [
+  Object {
+    "ID": "A1",
+    "complex": Object {
+      "value1": 1,
+      "value2": 2,
+    },
+  },
+]
+`;
+
+exports[`Data Access $select handling with structured complex types can read /A?$select=complex/value1 1`] = `
+Array [
+  Object {
+    "ID": "A1",
+    "complex": Object {
+      "value1": 1,
+      "value2": 2,
+    },
+  },
+]
+`;
+
 exports[`Data Access v4metadata - GET with $filter involving a navigation property that is null for some elements 1`] = `
 Array [
   Object {

--- a/packages/fe-mockserver-core/test/unit/v4/__snapshots__/multiLevelExpand.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/v4/__snapshots__/multiLevelExpand.test.ts.snap
@@ -108,7 +108,9 @@ Array [
   Object {
     "ID": "A-0",
     "_toOne": Object {
+      "ID": "B-0",
       "_toOne": Object {
+        "ID": "C-0",
         "value": "C",
       },
       "value": "B",
@@ -119,7 +121,9 @@ Array [
   Object {
     "ID": "A-1",
     "_toOne": Object {
+      "ID": "B-1",
       "_toOne": Object {
+        "ID": "C-1",
         "value": "C1",
       },
       "value": "B1",
@@ -129,7 +133,9 @@ Array [
   Object {
     "ID": "A-2",
     "_toOne": Object {
+      "ID": "B-2-1",
       "_toOne": Object {
+        "ID": "C-0",
         "value": "C",
       },
       "value": "B21",
@@ -139,7 +145,9 @@ Array [
   Object {
     "ID": "A-3",
     "_toOne": Object {
+      "ID": "B-3",
       "_toOne": Object {
+        "ID": "C-2",
         "value": "C2",
       },
       "value": "B3",
@@ -155,6 +163,7 @@ Array [
   Object {
     "ID": "A-0",
     "_toOne": Object {
+      "ID": "B-0",
       "_toOne": Object {
         "ID": "C-0",
         "_back_ID": "B-0",
@@ -168,6 +177,7 @@ Array [
   Object {
     "ID": "A-1",
     "_toOne": Object {
+      "ID": "B-1",
       "_toOne": Object {
         "ID": "C-1",
         "value": "C1",
@@ -179,6 +189,7 @@ Array [
   Object {
     "ID": "A-2",
     "_toOne": Object {
+      "ID": "B-2-1",
       "_toOne": Object {
         "ID": "C-0",
         "_back_ID": "B-0",
@@ -191,6 +202,7 @@ Array [
   Object {
     "ID": "A-3",
     "_toOne": Object {
+      "ID": "B-3",
       "_toOne": Object {
         "ID": "C-2",
         "value": "C2",
@@ -208,67 +220,10 @@ Array [
   Object {
     "ID": "A-0",
     "_toOne": Object {
-      "_toMany": Array [
-        Object {
-          "value": "C",
-        },
-      ],
-      "value": "B",
-    },
-    "_toOne_ID": "B-0",
-    "value": "A",
-  },
-  Object {
-    "ID": "A-1",
-    "_toOne": Object {
-      "_toMany": Array [],
-      "value": "B1",
-    },
-    "value": "A1",
-  },
-  Object {
-    "ID": "A-2",
-    "_toOne": Object {
-      "_toMany": Array [
-        Object {
-          "value": "C21",
-        },
-        Object {
-          "value": "C22",
-        },
-      ],
-      "value": "B21",
-    },
-    "value": "A2",
-  },
-  Object {
-    "ID": "A-3",
-    "_toOne": Object {
-      "_toMany": Array [
-        Object {
-          "value": "C2",
-        },
-        Object {
-          "value": "C3",
-        },
-      ],
-      "value": "B3",
-    },
-    "_toOne_ID": "B-3",
-    "value": "A3",
-  },
-]
-`;
-
-exports[`Data Access with $expand spanning multiple levels List: 2 levels, 1:1 (with $select) --> 1:n 1`] = `
-Array [
-  Object {
-    "ID": "A-0",
-    "_toOne": Object {
+      "ID": "B-0",
       "_toMany": Array [
         Object {
           "ID": "C-0",
-          "_back_ID": "B-0",
           "value": "C",
         },
       ],
@@ -280,6 +235,7 @@ Array [
   Object {
     "ID": "A-1",
     "_toOne": Object {
+      "ID": "B-1",
       "_toMany": Array [],
       "value": "B1",
     },
@@ -288,6 +244,7 @@ Array [
   Object {
     "ID": "A-2",
     "_toOne": Object {
+      "ID": "B-2-1",
       "_toMany": Array [
         Object {
           "ID": "C-2-1",
@@ -305,6 +262,74 @@ Array [
   Object {
     "ID": "A-3",
     "_toOne": Object {
+      "ID": "B-3",
+      "_toMany": Array [
+        Object {
+          "ID": "C-2",
+          "value": "C2",
+        },
+        Object {
+          "ID": "C-3",
+          "value": "C3",
+        },
+      ],
+      "value": "B3",
+    },
+    "_toOne_ID": "B-3",
+    "value": "A3",
+  },
+]
+`;
+
+exports[`Data Access with $expand spanning multiple levels List: 2 levels, 1:1 (with $select) --> 1:n 1`] = `
+Array [
+  Object {
+    "ID": "A-0",
+    "_toOne": Object {
+      "ID": "B-0",
+      "_toMany": Array [
+        Object {
+          "ID": "C-0",
+          "_back_ID": "B-0",
+          "value": "C",
+        },
+      ],
+      "value": "B",
+    },
+    "_toOne_ID": "B-0",
+    "value": "A",
+  },
+  Object {
+    "ID": "A-1",
+    "_toOne": Object {
+      "ID": "B-1",
+      "_toMany": Array [],
+      "value": "B1",
+    },
+    "value": "A1",
+  },
+  Object {
+    "ID": "A-2",
+    "_toOne": Object {
+      "ID": "B-2-1",
+      "_toMany": Array [
+        Object {
+          "ID": "C-2-1",
+          "value": "C21",
+        },
+        Object {
+          "ID": "C-2-2",
+          "value": "C22",
+        },
+      ],
+      "value": "B21",
+    },
+    "value": "A2",
+  },
+  Object {
+    "ID": "A-3",
+    "_toOne": Object {
+      "ID": "B-3",
       "_toMany": Array [
         Object {
           "ID": "C-2",
@@ -331,6 +356,7 @@ Array [
       "ID": "B-0",
       "_back_ID": "A-0",
       "_toOne": Object {
+        "ID": "C-0",
         "value": "C",
       },
       "_toOne_ID": "C-0",
@@ -344,6 +370,7 @@ Array [
     "_toOne": Object {
       "ID": "B-1",
       "_toOne": Object {
+        "ID": "C-1",
         "value": "C1",
       },
       "value": "B1",
@@ -355,6 +382,7 @@ Array [
     "_toOne": Object {
       "ID": "B-2-1",
       "_toOne": Object {
+        "ID": "C-0",
         "value": "C",
       },
       "_toOne_ID": "C-0",
@@ -368,6 +396,7 @@ Array [
       "ID": "B-3",
       "_back_ID": "A-3",
       "_toOne": Object {
+        "ID": "C-2",
         "value": "C2",
       },
       "value": "B3",
@@ -448,6 +477,7 @@ Array [
       "_back_ID": "A-0",
       "_toMany": Array [
         Object {
+          "ID": "C-0",
           "value": "C",
         },
       ],
@@ -472,9 +502,11 @@ Array [
       "ID": "B-2-1",
       "_toMany": Array [
         Object {
+          "ID": "C-2-1",
           "value": "C21",
         },
         Object {
+          "ID": "C-2-2",
           "value": "C22",
         },
       ],
@@ -490,9 +522,11 @@ Array [
       "_back_ID": "A-3",
       "_toMany": Array [
         Object {
+          "ID": "C-2",
           "value": "C2",
         },
         Object {
+          "ID": "C-3",
           "value": "C3",
         },
       ],
@@ -581,7 +615,9 @@ Array [
     "ID": "A-0",
     "_toMany": Array [
       Object {
+        "ID": "B-0",
         "_toOne": Object {
+          "ID": "C-0",
           "value": "C",
         },
         "value": "B",
@@ -594,13 +630,17 @@ Array [
     "ID": "A-1",
     "_toMany": Array [
       Object {
+        "ID": "B-1",
         "_toOne": Object {
+          "ID": "C-1",
           "value": "C1",
         },
         "value": "B1",
       },
       Object {
+        "ID": "B-2",
         "_toOne": Object {
+          "ID": "C-1",
           "value": "C1",
         },
         "value": "B2",
@@ -612,13 +652,17 @@ Array [
     "ID": "A-2",
     "_toMany": Array [
       Object {
+        "ID": "B-2-1",
         "_toOne": Object {
+          "ID": "C-0",
           "value": "C",
         },
         "value": "B21",
       },
       Object {
+        "ID": "B-2-2",
         "_toOne": Object {
+          "ID": "C-0",
           "value": "C",
         },
         "value": "B22",
@@ -630,7 +674,9 @@ Array [
     "ID": "A-3",
     "_toMany": Array [
       Object {
+        "ID": "B-3",
         "_toOne": Object {
+          "ID": "C-2",
           "value": "C2",
         },
         "value": "B3",
@@ -648,6 +694,7 @@ Array [
     "ID": "A-0",
     "_toMany": Array [
       Object {
+        "ID": "B-0",
         "_toOne": Object {
           "ID": "C-0",
           "_back_ID": "B-0",
@@ -663,6 +710,7 @@ Array [
     "ID": "A-1",
     "_toMany": Array [
       Object {
+        "ID": "B-1",
         "_toOne": Object {
           "ID": "C-1",
           "value": "C1",
@@ -670,6 +718,7 @@ Array [
         "value": "B1",
       },
       Object {
+        "ID": "B-2",
         "_toOne": Object {
           "ID": "C-1",
           "value": "C1",
@@ -683,6 +732,7 @@ Array [
     "ID": "A-2",
     "_toMany": Array [
       Object {
+        "ID": "B-2-1",
         "_toOne": Object {
           "ID": "C-0",
           "_back_ID": "B-0",
@@ -691,6 +741,7 @@ Array [
         "value": "B21",
       },
       Object {
+        "ID": "B-2-2",
         "_toOne": Object {
           "ID": "C-0",
           "_back_ID": "B-0",
@@ -705,6 +756,7 @@ Array [
     "ID": "A-3",
     "_toMany": Array [
       Object {
+        "ID": "B-3",
         "_toOne": Object {
           "ID": "C-2",
           "value": "C2",
@@ -724,8 +776,10 @@ Array [
     "ID": "A-0",
     "_toMany": Array [
       Object {
+        "ID": "B-0",
         "_toMany": Array [
           Object {
+            "ID": "C-0",
             "value": "C",
           },
         ],
@@ -739,17 +793,21 @@ Array [
     "ID": "A-1",
     "_toMany": Array [
       Object {
+        "ID": "B-1",
         "_toMany": Array [
           Object {
+            "ID": "C-1-1",
             "value": "C11",
           },
           Object {
+            "ID": "C-1-2",
             "value": "C12",
           },
         ],
         "value": "B1",
       },
       Object {
+        "ID": "B-2",
         "_toMany": Array [],
         "value": "B2",
       },
@@ -760,10 +818,12 @@ Array [
     "ID": "A-2",
     "_toMany": Array [
       Object {
+        "ID": "B-2-1",
         "_toMany": Array [],
         "value": "B21",
       },
       Object {
+        "ID": "B-2-2",
         "_toMany": Array [],
         "value": "B22",
       },
@@ -774,11 +834,14 @@ Array [
     "ID": "A-3",
     "_toMany": Array [
       Object {
+        "ID": "B-3",
         "_toMany": Array [
           Object {
+            "ID": "C-2",
             "value": "C2",
           },
           Object {
+            "ID": "C-3",
             "value": "C3",
           },
         ],
@@ -797,6 +860,7 @@ Array [
     "ID": "A-0",
     "_toMany": Array [
       Object {
+        "ID": "B-0",
         "_toMany": Array [
           Object {
             "ID": "C-0",
@@ -814,6 +878,7 @@ Array [
     "ID": "A-1",
     "_toMany": Array [
       Object {
+        "ID": "B-1",
         "_toMany": Array [
           Object {
             "ID": "C-1-1",
@@ -827,6 +892,7 @@ Array [
         "value": "B1",
       },
       Object {
+        "ID": "B-2",
         "_toMany": Array [],
         "value": "B2",
       },
@@ -837,10 +903,12 @@ Array [
     "ID": "A-2",
     "_toMany": Array [
       Object {
+        "ID": "B-2-1",
         "_toMany": Array [],
         "value": "B21",
       },
       Object {
+        "ID": "B-2-2",
         "_toMany": Array [],
         "value": "B22",
       },
@@ -851,6 +919,7 @@ Array [
     "ID": "A-3",
     "_toMany": Array [
       Object {
+        "ID": "B-3",
         "_toMany": Array [
           Object {
             "ID": "C-2",
@@ -879,6 +948,7 @@ Array [
         "ID": "B-0",
         "_back_ID": "A-0",
         "_toOne": Object {
+          "ID": "C-0",
           "value": "C",
         },
         "_toOne_ID": "C-0",
@@ -894,6 +964,7 @@ Array [
       Object {
         "ID": "B-1",
         "_toOne": Object {
+          "ID": "C-1",
           "value": "C1",
         },
         "value": "B1",
@@ -901,6 +972,7 @@ Array [
       Object {
         "ID": "B-2",
         "_toOne": Object {
+          "ID": "C-1",
           "value": "C1",
         },
         "value": "B2",
@@ -914,6 +986,7 @@ Array [
       Object {
         "ID": "B-2-1",
         "_toOne": Object {
+          "ID": "C-0",
           "value": "C",
         },
         "_toOne_ID": "C-0",
@@ -922,6 +995,7 @@ Array [
       Object {
         "ID": "B-2-2",
         "_toOne": Object {
+          "ID": "C-0",
           "value": "C",
         },
         "_toOne_ID": "C-0",
@@ -937,6 +1011,7 @@ Array [
         "ID": "B-3",
         "_back_ID": "A-3",
         "_toOne": Object {
+          "ID": "C-2",
           "value": "C2",
         },
         "value": "B3",
@@ -1045,6 +1120,7 @@ Array [
         "_back_ID": "A-0",
         "_toMany": Array [
           Object {
+            "ID": "C-0",
             "value": "C",
           },
         ],
@@ -1062,9 +1138,11 @@ Array [
         "ID": "B-1",
         "_toMany": Array [
           Object {
+            "ID": "C-1-1",
             "value": "C11",
           },
           Object {
+            "ID": "C-1-2",
             "value": "C12",
           },
         ],
@@ -1104,9 +1182,11 @@ Array [
         "_back_ID": "A-3",
         "_toMany": Array [
           Object {
+            "ID": "C-2",
             "value": "C2",
           },
           Object {
+            "ID": "C-3",
             "value": "C3",
           },
         ],

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -817,9 +817,7 @@ describe('Data Access', () => {
 
             const edmx = await metadataProvider.loadMetadata(join(baseDir, '/service.cds'));
             metadata = await ODataMetadata.parse(edmx, baseUrl + '/$metadata');
-
             dataAccess = new DataAccess({ mockdataPath: baseDir } as ServiceConfig, metadata, fileLoader);
-            metadata = await ODataMetadata.parse(edmx, baseUrl + '/$metadata');
         });
         test('1:1 - key property names are equal', async () => {
             const odataRequest = new ODataRequest({ method: 'GET', url: `/A('1')?$expand=_sameId` }, dataAccess);
@@ -839,6 +837,142 @@ describe('Data Access', () => {
         test('1:* - key property names are different', async () => {
             const odataRequest = new ODataRequest(
                 { method: 'GET', url: `/A('1')?$expand=_differentIdMany` },
+                dataAccess
+            );
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+    });
+
+    describe('$select handling with structured complex types', () => {
+        let dataAccess!: DataAccess;
+        let metadata!: ODataMetadata;
+
+        beforeAll(async () => {
+            const baseDir = join(__dirname, 'services', 'complexType');
+            const edmx = readFileSync(join(baseDir, 'metadata.xml'), 'utf8');
+
+            metadata = await ODataMetadata.parse(edmx, `/TestService/$metadata`);
+            dataAccess = new DataAccess({ mockdataPath: baseDir } as ServiceConfig, metadata, fileLoader);
+        });
+
+        test(`can read /A`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A('A1')` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A?$expand=b`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A?$expand=b` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')?$expand=b`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A('A1')?$expand=b` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')/b`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A('A1')/b` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A?$select=complex`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A?$select=complex` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A?$select=complex/value1`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A?$select=complex/value1` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')?$select=complex`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A('A1')?$select=complex` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')?$select=complex/value1`, async () => {
+            const odataRequest = new ODataRequest(
+                { method: 'GET', url: `/A('A1')?$select=complex/value1` },
+                dataAccess
+            );
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A?$expand=b($select=complex)`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A?$expand=b($select=complex)` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A?$expand=b($select=complex/value1)`, async () => {
+            const odataRequest = new ODataRequest(
+                { method: 'GET', url: `/A?$expand=b($select=complex/value1)` },
+                dataAccess
+            );
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')?$expand=b($select=complex)`, async () => {
+            const odataRequest = new ODataRequest(
+                { method: 'GET', url: `/A('A1')?$expand=b($select=complex)` },
+                dataAccess
+            );
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')?$expand=b($select=complex/value1)`, async () => {
+            const odataRequest = new ODataRequest(
+                { method: 'GET', url: `/A('A1')?$expand=b($select=complex/value1)` },
+                dataAccess
+            );
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')/b?$select=complex`, async () => {
+            const odataRequest = new ODataRequest({ method: 'GET', url: `/A('A1')/b?$select=complex` }, dataAccess);
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')/b?$select=complex/value1`, async () => {
+            const odataRequest = new ODataRequest(
+                { method: 'GET', url: `/A('A1')/b?$select=complex/value1` },
+                dataAccess
+            );
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')/b('B1')?$select=complex`, async () => {
+            const odataRequest = new ODataRequest(
+                { method: 'GET', url: `/A('A1')/b('B1')?$select=complex` },
+                dataAccess
+            );
+            const data = await dataAccess.getData(odataRequest);
+            expect(data).toMatchSnapshot();
+        });
+
+        test(`can read /A('A1')/b('B1')?$select=complex/value1`, async () => {
+            const odataRequest = new ODataRequest(
+                { method: 'GET', url: `/A('A1')/b('B1')?$select=complex/value1` },
                 dataAccess
             );
             const data = await dataAccess.getData(odataRequest);

--- a/packages/fe-mockserver-core/test/unit/v4/services/complexType/A.json
+++ b/packages/fe-mockserver-core/test/unit/v4/services/complexType/A.json
@@ -1,0 +1,6 @@
+[
+    {
+        "ID": "A1",
+        "complex": { "value1": 1, "value2": 2 }
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/v4/services/complexType/B.json
+++ b/packages/fe-mockserver-core/test/unit/v4/services/complexType/B.json
@@ -1,0 +1,7 @@
+[
+    {
+        "UID": "B1",
+        "a_ID": "A1",
+        "complex": { "value1": true, "value2": false }
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/v4/services/complexType/complexType.cds
+++ b/packages/fe-mockserver-core/test/unit/v4/services/complexType/complexType.cds
@@ -1,0 +1,22 @@
+service TestService {
+    entity A {
+        key ID         : String;
+
+            complex    : {
+                value1 : Integer;
+                value2 : Integer;
+            };
+
+            b          : Association to many B
+                             on ID = b.a_ID;
+    }
+
+    entity B {
+        key UID        : String;
+            a_ID       : String;
+            complex    : {
+                value1 : Boolean;
+                value2 : Boolean;
+            }
+    }
+}

--- a/packages/fe-mockserver-core/test/unit/v4/services/complexType/metadata.xml
+++ b/packages/fe-mockserver-core/test/unit/v4/services/complexType/metadata.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="A" EntityType="TestService.A">
+          <NavigationPropertyBinding Path="b" Target="B"/>
+        </EntitySet>
+        <EntitySet Name="B" EntityType="TestService.B"/>
+      </EntityContainer>
+      <EntityType Name="A">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false"/>
+        <Property Name="complex" Type="TestService.A_complex"/>
+        <NavigationProperty Name="b" Type="Collection(TestService.B)">
+          <ReferentialConstraint Property="ID" ReferencedProperty="a_ID"/>
+        </NavigationProperty>
+      </EntityType>
+      <EntityType Name="B">
+        <Key>
+          <PropertyRef Name="UID"/>
+        </Key>
+        <Property Name="UID" Type="Edm.String" Nullable="false"/>
+        <Property Name="a_ID" Type="Edm.String"/>
+        <Property Name="complex" Type="TestService.B_complex"/>
+      </EntityType>
+      <ComplexType Name="A_complex">
+        <Property Name="value1" Type="Edm.Int32"/>
+        <Property Name="value2" Type="Edm.Int32"/>
+      </ComplexType>
+      <ComplexType Name="B_complex">
+        <Property Name="value1" Type="Edm.Boolean"/>
+        <Property Name="value2" Type="Edm.Boolean"/>
+      </ComplexType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
This fixes requests like `GET /Root?$expand=children($select=complexType/member)`, which returned empty data for all children before.

Also now always includes key properties in the response, even if they are not explicitly selected by the client. This aligns the behaviour with the CAP and ABAP implementations of the OData protocol.