### PR TITLE
feat: add support for complex lambda functions

### DIFF
--- a/.changeset/neat-cats-rush.md
+++ b/.changeset/neat-cats-rush.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+'@sap-ux/ui5-middleware-fe-mockserver': patch
+---
+
+Add support for nested lambda functions

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -322,12 +322,30 @@ export class MockDataEntitySet implements EntitySetInterface {
             if (!Array.isArray(mockDataToCheckValue)) {
                 mockDataToCheckValue = [mockDataToCheckValue];
             }
+            if (identifier.expression.expressions) {
+                identifier.expression.expressions.forEach((entry: any) => {
+                    if (typeof entry.identifier === 'string') {
+                        entry.propertyPath = entry.identifier.replace(
+                            identifier.key,
+                            identifier.propertyPath || identifier.target
+                        );
+                    } else {
+                        entry.identifier.propertyPath = entry.identifier.target.replace(
+                            identifier.key,
+                            identifier.propertyPath || identifier.target
+                        );
+                    }
+                });
+            }
 
             mockDataToCheckValue.find((subMockData: any) => {
                 let mockDataToCheck = subMockData;
                 if (identifier.key && identifier.key.length > 0) {
                     mockDataToCheck = { [identifier.key]: subMockData };
                 }
+                // if (identifier.target && identifier.target.length > 0) {
+                //     mockDataToCheck = createSubData(identifier.target, subMockData);
+                // }
                 const isEntryValid = this.checkFilter(mockDataToCheck, identifier.expression, tenantId);
                 if (!isEntryValid) {
                     hasAllValid = false;
@@ -360,14 +378,9 @@ export class MockDataEntitySet implements EntitySetInterface {
             literal = true;
         }
         let property;
-        if (identifier.indexOf('/')) {
+        if (filterExpression.propertyPath) {
             // We're possibly in a lambda operation so let's try to see if the first part is a real property
-            const identifierSplit = identifier.split('/');
-            if (this.getProperty(identifierSplit[0])) {
-                property = this.getProperty(identifier);
-            } else {
-                property = this.getProperty(identifierSplit[1]);
-            }
+            property = this.getProperty(filterExpression.propertyPath);
         } else {
             property = this.getProperty(identifier);
         }

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -343,9 +343,6 @@ export class MockDataEntitySet implements EntitySetInterface {
                 if (identifier.key && identifier.key.length > 0) {
                     mockDataToCheck = { [identifier.key]: subMockData };
                 }
-                // if (identifier.target && identifier.target.length > 0) {
-                //     mockDataToCheck = createSubData(identifier.target, subMockData);
-                // }
                 const isEntryValid = this.checkFilter(mockDataToCheck, identifier.expression, tenantId);
                 if (!isEntryValid) {
                     hasAllValid = false;

--- a/packages/fe-mockserver-core/test/unit/data/data/MyEntityData.json
+++ b/packages/fe-mockserver-core/test/unit/data/data/MyEntityData.json
@@ -1,0 +1,156 @@
+[
+    {
+        "BaseData": "FirstCheck",
+        "ArrayData": [
+            {
+                "SubArray": [
+                    {
+                        "Name": "Something",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220601"
+                            },
+                            {
+                                "Value": "20220608"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "BaseData": "FirstCheck",
+        "ArrayData": [
+            {
+                "SubArray": [
+                    {
+                        "Name": "Something",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220601"
+                            },
+                            {
+                                "Value": "20220608"
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "SomethingElse",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220601"
+                            },
+                            {
+                                "Value": "20220602"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "SubArray": [
+                    {
+                        "Name": "Something",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220602"
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "SomethingElse",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220601"
+                            },
+                            {
+                                "Value": "20220602"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "SubArray": [
+                    {
+                        "Name": "SomethingDifferent",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220602"
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "SomethingElse",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220601"
+                            },
+                            {
+                                "Value": "20220602"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "SubArray": [
+                    {
+                        "Name": "Something",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220608"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "BaseData": "FirstCheck",
+        "ArrayData": [
+            {
+                "SubArray": [
+                    {
+                        "Name": "SomethingDifferent",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220602"
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "SomethingElse",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220601"
+                            },
+                            {
+                                "Value": "20220602"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "BaseData": "FirstCheck",
+        "ArrayData": [
+            {
+                "SubArray": [
+                    {
+                        "Name": "Something",
+                        "SubSubArray": [
+                            {
+                                "Value": "20220608"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/data/data/service.cds
+++ b/packages/fe-mockserver-core/test/unit/data/data/service.cds
@@ -1,0 +1,24 @@
+aspect AbstractEntity {
+    key ID : String;
+    Name   : String;
+    Value  : String;
+    BaseData : String;
+}
+
+
+service MultiLevelExpand {
+    entity MyEntityData : AbstractEntity {
+        ArrayData : Association to many B
+                      on ArrayData._back = $self;
+    }
+
+    entity B : AbstractEntity {
+        _back   : Association to one MyEntityData;
+        SubSubArray : Association to many C
+                      on SubSubArray._back = $self;
+    }
+
+    entity C : AbstractEntity {
+        _back : Association to one B;
+    }
+}

--- a/packages/fe-mockserver-core/test/unit/data/data/service.cds
+++ b/packages/fe-mockserver-core/test/unit/data/data/service.cds
@@ -14,11 +14,16 @@ service MultiLevelExpand {
 
     entity B : AbstractEntity {
         _back   : Association to one MyEntityData;
-        SubSubArray : Association to many C
-                      on SubSubArray._back = $self;
+        SubArray : Association to many C
+                      on SubArray._back = $self;
     }
 
     entity C : AbstractEntity {
         _back : Association to one B;
+         SubSubArray : Association to many D
+                              on SubSubArray._back = $self;
     }
+    entity D : AbstractEntity {
+            _back : Association to one C;
+        }
 }

--- a/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
+++ b/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
@@ -1,0 +1,54 @@
+import { MockDataEntitySet } from '../../../src/data/entitySets/entitySet';
+import * as path from 'path';
+import { parseFilter } from '../../../src/request/filterParser';
+import FileSystemLoader from '../../../src/plugins/fileSystemLoader';
+import CDSMetadataProvider from '@sap-ux/fe-mockserver-plugin-cds';
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import { ODataMetadata } from '../../../src/data/metadata';
+import { DataAccess } from '../../../src/data/dataAccess';
+import { ServiceConfig } from '../../../src';
+
+let metadata!: ODataMetadata;
+const baseUrl = '/sap/fe/mock';
+describe('EntitySet', () => {
+    const fileLoader = new FileSystemLoader();
+    const baseDir = join(__dirname, 'data');
+    const metadataProvider = new CDSMetadataProvider(fileLoader);
+    let dataAccess: DataAccess;
+    beforeAll(async () => {
+        const edmx = await metadataProvider.loadMetadata(join(baseDir, 'service.cds'));
+        metadata = await ODataMetadata.parse(edmx, baseUrl + '/$metadata');
+        dataAccess = new DataAccess({ mockdataPath: baseDir } as ServiceConfig, metadata, fileLoader);
+    });
+    describe('filtering', () => {
+        it('works on deep lambda expression', async () => {
+            const myEntitySet = new MockDataEntitySet(
+                baseDir,
+                {
+                    name: 'MyEntityData',
+                    entityType: {
+                        entityProperties: []
+                    },
+                    _type: 'EntitySet'
+                } as any,
+                dataAccess,
+                false,
+                true
+            );
+            await myEntitySet.readyPromise;
+            const v4ComplexLambda = parseFilter(
+                "((ArrayData/any(t:t/SubArray/any(a0:a0/Name eq 'Something' and a0/SubSubArray/any(a1:a1/Value ge '20220600') and a0/SubSubArray/any(a1:a1/Value le '20220603'))))) and (BaseData eq 'FirstCheck')"
+            );
+            const mockData = myEntitySet.getMockData('default').getAllEntries() as any;
+            let filteredData = myEntitySet.checkFilter(mockData[0], v4ComplexLambda, 'default');
+            expect(filteredData).toBe(true);
+            filteredData = myEntitySet.checkFilter(mockData[1], v4ComplexLambda, 'default');
+            expect(filteredData).toBe(true);
+            filteredData = myEntitySet.checkFilter(mockData[2], v4ComplexLambda, 'default');
+            expect(filteredData).toBe(false);
+            filteredData = myEntitySet.checkFilter(mockData[3], v4ComplexLambda, 'default');
+            expect(filteredData).toBe(false);
+        });
+    });
+});

--- a/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
+++ b/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
@@ -1,13 +1,11 @@
 import { MockDataEntitySet } from '../../../src/data/entitySets/entitySet';
-import * as path from 'path';
 import { parseFilter } from '../../../src/request/filterParser';
 import FileSystemLoader from '../../../src/plugins/fileSystemLoader';
 import CDSMetadataProvider from '@sap-ux/fe-mockserver-plugin-cds';
 import { join } from 'path';
-import { readFileSync } from 'fs';
 import { ODataMetadata } from '../../../src/data/metadata';
 import { DataAccess } from '../../../src/data/dataAccess';
-import { ServiceConfig } from '../../../src';
+import type { ServiceConfig } from '../../../src';
 
 let metadata!: ODataMetadata;
 const baseUrl = '/sap/fe/mock';

--- a/packages/fe-mockserver-core/test/unit/request/__snapshots__/filterParser.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/request/__snapshots__/filterParser.test.ts.snap
@@ -255,3 +255,86 @@ Object {
   "operator": "AND",
 }
 `;
+
+exports[`Filter Parser v4 complex filter 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "expressions": Array [
+        Object {
+          "identifier": Object {
+            "expression": Object {
+              "expressions": Array [
+                Object {
+                  "identifier": Object {
+                    "expression": Object {
+                      "expressions": Array [
+                        Object {
+                          "identifier": "a0/SitnInstceAttribName",
+                          "literal": "'CAMASSRUNDATE'",
+                          "operator": "eq",
+                        },
+                        Object {
+                          "identifier": Object {
+                            "expression": Object {
+                              "expressions": Array [
+                                Object {
+                                  "identifier": "a1/SitnInstceAttribValue",
+                                  "literal": "'20220601'",
+                                  "operator": "ge",
+                                },
+                              ],
+                            },
+                            "key": "a1",
+                            "operator": "ANY",
+                            "target": "a0/_AttributeValue",
+                            "type": "lambda",
+                          },
+                        },
+                        Object {
+                          "identifier": Object {
+                            "expression": Object {
+                              "expressions": Array [
+                                Object {
+                                  "identifier": "a1/SitnInstceAttribValue",
+                                  "literal": "'20220601'",
+                                  "operator": "le",
+                                },
+                              ],
+                            },
+                            "key": "a1",
+                            "operator": "ANY",
+                            "target": "a0/_AttributeValue",
+                            "type": "lambda",
+                          },
+                        },
+                      ],
+                      "operator": "AND",
+                    },
+                    "key": "a0",
+                    "operator": "ANY",
+                    "target": "t/_Attribute",
+                    "type": "lambda",
+                  },
+                },
+              ],
+            },
+            "key": "t",
+            "operator": "ANY",
+            "target": "_Trigger",
+            "type": "lambda",
+          },
+        },
+      ],
+      "isGroup": true,
+      "operator": undefined,
+    },
+    Object {
+      "identifier": "SitnBaseTemplateID",
+      "literal": "'FICA_MASSACT_MSG_MONITOR'",
+      "operator": "eq",
+    },
+  ],
+  "operator": "AND",
+}
+`;

--- a/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
@@ -227,9 +227,10 @@ describe('Filter Parser', () => {
             expect(lamba?.expressions[0].identifier?.type).toBe('lambda');
             expect(lamba?.expressions[0].identifier?.operator).toBe('ANY');
             expect(lamba?.expressions[0].identifier?.key).toBe('ent');
-            expect(lamba?.expressions[0].identifier?.expression.identifier).toBe('ent');
-            expect(lamba?.expressions[0].identifier?.expression.operator).toBe('eq');
-            expect(lamba?.expressions[0].identifier?.expression.literal).toBe("'GBR'");
+            expect(lamba?.expressions[0].identifier?.expression.expressions.length).toBe(1);
+            expect(lamba?.expressions[0].identifier?.expression.expressions[0].operator).toBe('eq');
+            expect(lamba?.expressions[0].identifier?.expression.expressions[0].literal).toBe("'GBR'");
+            expect(lamba?.expressions[0].identifier?.expression.expressions[0].identifier).toBe('ent');
             expect(lamba?.expressions[0].identifier?.target).toBe('CountryCodes');
         }
 
@@ -270,5 +271,12 @@ describe('Filter Parser', () => {
                 "and SimulationSessionUUID eq guid'd535d9a2-fdea-4e1e-84e6-2c135fcbcd08'"
         );
         expect(v2ComplexFilter).toMatchSnapshot();
+    });
+
+    test('v4 complex filter', () => {
+        const v4ComplexLambda = parseFilter(
+            "((_Trigger/any(t:t/_Attribute/any(a0:a0/SitnInstceAttribName eq 'CAMASSRUNDATE' and a0/_AttributeValue/any(a1:a1/SitnInstceAttribValue ge '20220601') and a0/_AttributeValue/any(a1:a1/SitnInstceAttribValue le '20220601'))))) and (SitnBaseTemplateID eq 'FICA_MASSACT_MSG_MONITOR')"
+        );
+        expect(v4ComplexLambda).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
Add support for complex, nested lambda function such as `((ArrayData/any(t:t/SubArray/any(a0:a0/Name eq 'Something' and a0/SubSubArray/any(a1:a1/Value ge '20220600') and a0/SubSubArray/any(a1:a1/Value le '20220603'))))) and (BaseData eq 'FirstCheck')`

Fixed first the parser implementation to parse that flavor properly.
Then fixed the filter interpretator to properly deal with this.