### PR TITLE
feat: improve the function based mockdata

### DIFF
--- a/.changeset/sour-points-rush.md
+++ b/.changeset/sour-points-rush.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+'@sap-ux/ui5-middleware-fe-mockserver': patch
+---
+
+Improve the function based mockdata API

--- a/.changeset/sour-points-rush.md
+++ b/.changeset/sour-points-rush.md
@@ -1,6 +1,6 @@
 ---
-'@sap-ux/fe-mockserver-core': patch
-'@sap-ux/ui5-middleware-fe-mockserver': patch
+'@sap-ux/fe-mockserver-core': minor
+'@sap-ux/ui5-middleware-fe-mockserver': minor
 ---
 
 Improve the function based mockdata API

--- a/packages/fe-mockserver-core/src/data/common.ts
+++ b/packages/fe-mockserver-core/src/data/common.ts
@@ -7,8 +7,8 @@ import type { IFileLoader } from '../index';
 
 export interface EntitySetInterface {
     checkKeyValue(mockData: object, keyValues: object, keyName: string, keyProp?: Property): boolean;
-    checkFilter(mockData: object, filterExpression: any, tenantId: string): boolean;
-    checkSearch(mockData: object, searchQueries: string[]): boolean;
+    checkFilter(mockData: object, filterExpression: any, tenantId: string, odataRequest: ODataRequest): boolean;
+    checkSearch(mockData: object, searchQueries: string[], odataRequest: ODataRequest): boolean;
     executeAction(
         actionDefinition: Action,
         actionData: object | undefined,
@@ -19,12 +19,29 @@ export interface EntitySetInterface {
         keyValues: KeyDefinitions,
         asArray: boolean,
         tenantId: string,
-        dontClone?: boolean,
-        odataRequest?: ODataRequest
+        odataRequest: ODataRequest,
+        dontClone?: boolean
     ): Promise<any>;
-    performPOST(keyValues: KeyDefinitions, postData: any, tenantId: string, _updateParent?: boolean): Promise<any>;
-    performPATCH(keyValues: KeyDefinitions, patchData: object, tenantId: string, _updateParent?: boolean): Promise<any>;
-    performDELETE(keyValues: KeyDefinitions, tenantId: string, _updateParent?: boolean): Promise<void>;
+    performPOST(
+        keyValues: KeyDefinitions,
+        postData: any,
+        tenantId: string,
+        odataRequest: ODataRequest,
+        _updateParent?: boolean
+    ): Promise<any>;
+    performPATCH(
+        keyValues: KeyDefinitions,
+        patchData: object,
+        tenantId: string,
+        odataRequest: ODataRequest,
+        _updateParent?: boolean
+    ): Promise<any>;
+    performDELETE(
+        keyValues: KeyDefinitions,
+        tenantId: string,
+        odataRequest: ODataRequest,
+        _updateParent?: boolean
+    ): Promise<void>;
     getParentEntityInterface(tenantId: string): Promise<FileBasedMockData | undefined>;
     getEntityInterface(entitySetName: string, tenantId: string): Promise<FileBasedMockData | undefined>;
     getMockData(tenantId: string): FileBasedMockData;

--- a/packages/fe-mockserver-core/src/index.ts
+++ b/packages/fe-mockserver-core/src/index.ts
@@ -12,6 +12,7 @@ export interface IMetadataProcessor {
     loadMetadata(filePath: string): Promise<string>;
 }
 export * from './api';
+export { MockDataContributor } from './mockdata/functionBasedMockData';
 
 export default class FEMockserver {
     isReady: Promise<void>;

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -6,6 +6,31 @@ import type ODataRequest from '../request/odataRequest';
 
 export type KeyDefinitions = Record<string, number | boolean | string>;
 
+function performSimpleComparison(operator: string, mockValue: any, targetLiteral: any) {
+    let isValid = true;
+    switch (operator) {
+        case 'gt':
+            isValid = mockValue > targetLiteral;
+            break;
+        case 'ge':
+            isValid = mockValue >= targetLiteral;
+            break;
+        case 'lt':
+            isValid = mockValue < targetLiteral;
+            break;
+        case 'le':
+            isValid = mockValue <= targetLiteral;
+            break;
+        case 'ne':
+            isValid = mockValue !== targetLiteral;
+            break;
+        case 'eq':
+        default:
+            isValid = mockValue === targetLiteral;
+            break;
+    }
+    return isValid;
+}
 export class FileBasedMockData {
     protected _mockData: object[];
     protected _entityType: EntityType;
@@ -47,7 +72,7 @@ export class FileBasedMockData {
     async updateEntry(
         keyValues: KeyDefinitions,
         updatedData: object,
-        patchData: object,
+        _patchData: object,
         _odataRequest: ODataRequest
     ): Promise<void> {
         const dataIndex = this.getDataIndex(keyValues, _odataRequest);
@@ -414,52 +439,12 @@ export class FileBasedMockData {
             case 'Edm.Int32':
             case 'Edm.Int64': {
                 const intTestValue = parseInt(literal, 10);
-                switch (operator) {
-                    case 'gt':
-                        isValid = mockValue > intTestValue;
-                        break;
-                    case 'ge':
-                        isValid = mockValue >= intTestValue;
-                        break;
-                    case 'lt':
-                        isValid = mockValue < intTestValue;
-                        break;
-                    case 'le':
-                        isValid = mockValue <= intTestValue;
-                        break;
-                    case 'ne':
-                        isValid = mockValue !== intTestValue;
-                        break;
-                    case 'eq':
-                    default:
-                        isValid = mockValue === intTestValue;
-                        break;
-                }
+                isValid = performSimpleComparison(operator, mockValue, intTestValue);
                 break;
             }
             case 'Edm.Decimal': {
                 const decimalTestValue = parseFloat(literal);
-                switch (operator) {
-                    case 'gt':
-                        isValid = mockValue > decimalTestValue;
-                        break;
-                    case 'ge':
-                        isValid = mockValue >= decimalTestValue;
-                        break;
-                    case 'lt':
-                        isValid = mockValue < decimalTestValue;
-                        break;
-                    case 'le':
-                        isValid = mockValue <= decimalTestValue;
-                        break;
-                    case 'ne':
-                        isValid = mockValue !== decimalTestValue;
-                        break;
-                    case 'eq':
-                    default:
-                        isValid = mockValue === decimalTestValue;
-                        break;
-                }
+                isValid = performSimpleComparison(operator, mockValue, decimalTestValue);
                 break;
             }
             case 'Edm.Date':
@@ -468,27 +453,7 @@ export class FileBasedMockData {
             case 'Edm.DateTimeOffset':
                 const testValue = new Date(literal).getTime();
                 const mockValueDate = new Date(mockValue).getTime();
-                switch (operator) {
-                    case 'gt':
-                        isValid = mockValueDate > testValue;
-                        break;
-                    case 'ge':
-                        isValid = mockValueDate >= testValue;
-                        break;
-                    case 'lt':
-                        isValid = mockValueDate < testValue;
-                        break;
-                    case 'le':
-                        isValid = mockValueDate <= testValue;
-                        break;
-                    case 'ne':
-                        isValid = mockValueDate !== testValue;
-                        break;
-                    case 'eq':
-                    default:
-                        isValid = mockValueDate === testValue;
-                        break;
-                }
+                isValid = performSimpleComparison(operator, mockValueDate, testValue);
                 break;
             case 'Edm.String':
             case 'Edm.Guid':
@@ -499,27 +464,7 @@ export class FileBasedMockData {
                 } else if (literal && literal.startsWith("'")) {
                     targetLiteral = literal.substring(1, literal.length - 1);
                 }
-                switch (operator) {
-                    case 'gt':
-                        isValid = mockValue > targetLiteral;
-                        break;
-                    case 'ge':
-                        isValid = mockValue >= targetLiteral;
-                        break;
-                    case 'lt':
-                        isValid = mockValue < targetLiteral;
-                        break;
-                    case 'le':
-                        isValid = mockValue <= targetLiteral;
-                        break;
-                    case 'ne':
-                        isValid = mockValue !== targetLiteral;
-                        break;
-                    case 'eq':
-                    default:
-                        isValid = mockValue === targetLiteral;
-                        break;
-                }
+                isValid = performSimpleComparison(operator, mockValue, targetLiteral);
                 break;
         }
         return isValid;

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -46,8 +46,8 @@ export class FileBasedMockData {
 
     async updateEntry(
         keyValues: KeyDefinitions,
-        newData: object,
         updatedData: object,
+        patchData: object,
         _odataRequest: ODataRequest
     ): Promise<void> {
         const dataIndex = this.getDataIndex(keyValues, _odataRequest);

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -155,14 +155,14 @@ export class FunctionBasedMockData extends FileBasedMockData {
 
     async updateEntry(
         keyValues: KeyDefinitions,
-        newData: object,
         updatedData: object,
+        patchData: object,
         odataRequest: ODataRequest
     ): Promise<void> {
         if (this._mockDataFn.updateEntry) {
-            return this._mockDataFn.updateEntry(keyValues, newData, updatedData, odataRequest);
+            return this._mockDataFn.updateEntry(keyValues, updatedData, patchData, odataRequest);
         }
-        return super.updateEntry(keyValues, newData, updatedData, odataRequest);
+        return super.updateEntry(keyValues, updatedData, patchData, odataRequest);
     }
 
     async removeEntry(keyValues: KeyDefinitions, odataRequest: ODataRequest): Promise<void> {

--- a/packages/fe-mockserver-core/src/request/filterParser.ts
+++ b/packages/fe-mockserver-core/src/request/filterParser.ts
@@ -60,12 +60,13 @@ type FilterMethodCall = {
     method: string;
     methodArgs: string[];
 };
-type LambdaExpression = {
+export type LambdaExpression = {
     type: 'lambda';
     operator: string;
     key: string;
     expression: FilterExpression;
     target: string;
+    propertyPath?: string;
 };
 export type FilterExpression = {
     expressions: FilterExpression[];

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -62,6 +62,7 @@ export default class ODataRequest {
     public responseData: any;
     private allParams: URLSearchParams;
     private context: string;
+    private messages: any[] = [];
 
     constructor(private requestContent: ODataRequestContent, private dataAccess: DataAccess) {
         const decodedUrl = requestContent.url;
@@ -371,6 +372,10 @@ export default class ODataRequest {
     }
     public getResponseData() {
         this.addResponseHeader('content-type', 'application/json;odata.metadata=minimal;IEEE754Compatible=true');
+        if (this.messages.length) {
+            this.addResponseHeader('sap-messages', JSON.stringify(this.messages));
+        }
+
         if (this.dataAccess.getMetadata().getVersion() === '4.0') {
             this.addResponseHeader('odata-version', '4.0');
         } else {
@@ -409,6 +414,12 @@ export default class ODataRequest {
             // V2
             return JSON.stringify(this.responseData);
         }
+    }
+    public addMessage(code: number, message: string, severity: number, target: string) {
+        this.addCustomMessage({ code, message, numericSeverity: severity, target });
+    }
+    public addCustomMessage(messageData: any) {
+        this.messages.push(messageData);
     }
     public addResponseHeader(headerName: string, headerValue: string) {
         this.responseHeaders[headerName] = headerValue;

--- a/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
+++ b/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 import { ODataMetadata } from '../../../src/data/metadata';
 import { DataAccess } from '../../../src/data/dataAccess';
 import type { ServiceConfig } from '../../../src';
+import ODataRequest from '../../../src/request/odataRequest';
 
 let metadata!: ODataMetadata;
 const baseUrl = '/sap/fe/mock';
@@ -38,14 +39,21 @@ describe('EntitySet', () => {
             const v4ComplexLambda = parseFilter(
                 "((ArrayData/any(t:t/SubArray/any(a0:a0/Name eq 'Something' and a0/SubSubArray/any(a1:a1/Value ge '20220600') and a0/SubSubArray/any(a1:a1/Value le '20220603'))))) and (BaseData eq 'FirstCheck')"
             );
-            const mockData = myEntitySet.getMockData('default').getAllEntries() as any;
-            let filteredData = myEntitySet.checkFilter(mockData[0], v4ComplexLambda, 'default');
+            const fakeRequest = new ODataRequest(
+                {
+                    method: 'GET',
+                    url: 'MyEntityData'
+                },
+                dataAccess
+            );
+            const mockData = myEntitySet.getMockData('default').getAllEntries(fakeRequest) as any;
+            let filteredData = myEntitySet.checkFilter(mockData[0], v4ComplexLambda, 'default', fakeRequest);
             expect(filteredData).toBe(true);
-            filteredData = myEntitySet.checkFilter(mockData[1], v4ComplexLambda, 'default');
+            filteredData = myEntitySet.checkFilter(mockData[1], v4ComplexLambda, 'default', fakeRequest);
             expect(filteredData).toBe(true);
-            filteredData = myEntitySet.checkFilter(mockData[2], v4ComplexLambda, 'default');
+            filteredData = myEntitySet.checkFilter(mockData[2], v4ComplexLambda, 'default', fakeRequest);
             expect(filteredData).toBe(false);
-            filteredData = myEntitySet.checkFilter(mockData[3], v4ComplexLambda, 'default');
+            filteredData = myEntitySet.checkFilter(mockData[3], v4ComplexLambda, 'default', fakeRequest);
             expect(filteredData).toBe(false);
         });
     });

--- a/packages/fe-mockserver-core/test/unit/data/functionBasedMockData.test.ts
+++ b/packages/fe-mockserver-core/test/unit/data/functionBasedMockData.test.ts
@@ -1,0 +1,186 @@
+import { MockDataEntitySet } from '../../../src/data/entitySets/entitySet';
+import FileSystemLoader from '../../../src/plugins/fileSystemLoader';
+import CDSMetadataProvider from '@sap-ux/fe-mockserver-plugin-cds';
+import { join } from 'path';
+import { ODataMetadata } from '../../../src/data/metadata';
+import { DataAccess } from '../../../src/data/dataAccess';
+import type { ServiceConfig } from '../../../src';
+import ODataRequest from '../../../src/request/odataRequest';
+import type { EntitySet } from '@sap-ux/vocabularies-types';
+import type { EntitySetInterface } from '../../../src/data/common';
+
+let metadata!: ODataMetadata;
+const baseUrl = '/sap/fe/mock';
+describe('Function Based Mock Data', () => {
+    const fileLoader = new FileSystemLoader();
+    const baseDir = join(__dirname, 'mockdata');
+    const metadataProvider = new CDSMetadataProvider(fileLoader);
+    let dataAccess: DataAccess;
+    let myEntitySet: EntitySetInterface;
+    let myOtherEntitySet: EntitySetInterface;
+    beforeAll(async () => {
+        const edmx = await metadataProvider.loadMetadata(join(baseDir, 'service.cds'));
+        metadata = await ODataMetadata.parse(edmx, baseUrl + '/$metadata');
+        dataAccess = new DataAccess({ mockdataPath: baseDir } as ServiceConfig, metadata, fileLoader);
+        myEntitySet = await dataAccess.getMockEntitySet('MyRootEntity');
+        myOtherEntitySet = await dataAccess.getMockEntitySet('MySecondEntity');
+    });
+    it('can GET All Entries', () => {
+        const fakeRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: 'MyRootEntity'
+            },
+            dataAccess
+        );
+        let mockData = myEntitySet.getMockData('default').getAllEntries(fakeRequest) as any;
+        expect(mockData.length).toBe(3);
+        // Fake that in tenant 001 we only return one data
+        fakeRequest.tenantId = 'tenant-001';
+        mockData = myEntitySet.getMockData('tenant-001').getAllEntries(fakeRequest) as any;
+        expect(mockData.length).toBe(1);
+        // Fake that in tenant 002 we throw an error
+        fakeRequest.tenantId = 'tenant-002';
+        expect(() => {
+            mockData = myEntitySet.getMockData('tenant-002').getAllEntries(fakeRequest) as any;
+        }).toThrow('This tenant is not allowed for you');
+    });
+    it('can Update Entries', async () => {
+        const fakeRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: 'MyRootEntity'
+            },
+            dataAccess
+        );
+        let mockData = myEntitySet.getMockData('default');
+        let allData = mockData.getAllEntries(fakeRequest) as any;
+        expect(allData.length).toBe(3);
+        mockData.updateEntry(
+            { ID: 1 },
+            {
+                ID: 1,
+                Name: 'My Updated Name',
+                Value: 'My Value'
+            },
+            {
+                Name: 'My Updated Name'
+            },
+            fakeRequest
+        );
+        allData = mockData.getAllEntries(fakeRequest) as any;
+        expect(allData.length).toBe(3);
+        expect(allData[0].Name).toBe('My Updated Name');
+
+        // Fake that in tenant 003 we change the value
+        fakeRequest.tenantId = 'tenant-003';
+        mockData = myEntitySet.getMockData('tenant-003');
+        allData = mockData.getAllEntries(fakeRequest) as any;
+        expect(allData.length).toBe(3);
+        const updatedData = mockData.updateEntry(
+            { ID: 1 },
+            {
+                ID: 1,
+                Name: 'My Updated Name',
+                Value: 'My Value'
+            },
+            {
+                Name: 'My Updated Name'
+            },
+            fakeRequest
+        );
+        allData = mockData.getAllEntries(fakeRequest) as any;
+        expect(allData.length).toBe(3);
+        expect(allData[0].Name).toBe('My Updated Name');
+        expect(allData[0].Value).toBe('My ValueFor Special Tenant');
+        // Fake that in tenant 004 we add an extra value
+        fakeRequest.tenantId = 'tenant-004';
+        mockData = myEntitySet.getMockData('tenant-004');
+        allData = mockData.getAllEntries(fakeRequest) as any;
+        expect(allData.length).toBe(3);
+        mockData.updateEntry(
+            { ID: 1 },
+            {
+                ID: 1,
+                Name: 'My Updated Name',
+                Value: 'My Value'
+            },
+            {
+                Name: 'My Updated Name'
+            },
+            fakeRequest
+        );
+        allData = mockData.getAllEntries(fakeRequest) as any;
+        expect(allData.length).toBe(4);
+        expect(allData[0].Name).toBe('My Updated Name');
+        expect(allData[0].Value).toBe('My Value');
+        expect(allData[3].ID).toBe(4);
+        expect(allData[3].Name).toBe('Fourth Name Value');
+        expect(allData[3].Value).toBe('Fourth Value');
+
+        // Fake that in tenant 005 we add a sap message to the output
+        fakeRequest.tenantId = 'tenant-005';
+        mockData = myEntitySet.getMockData('tenant-005');
+        allData = mockData.getAllEntries(fakeRequest) as any;
+        expect(allData.length).toBe(3);
+        mockData.updateEntry(
+            { ID: 1 },
+            {
+                ID: 1,
+                Name: 'My Updated Name',
+                Value: 'My Value'
+            },
+            {
+                Name: 'My Updated Name'
+            },
+            fakeRequest
+        );
+        fakeRequest.getResponseData();
+        expect(JSON.parse(fakeRequest.responseHeaders['sap-messages'])).toStrictEqual([
+            { code: 8008, message: 'Warning Message', numericSeverity: 3, target: '/' }
+        ]);
+        // Fake that in tenant 006 we can also update another entity
+        fakeRequest.tenantId = 'tenant-006';
+        mockData = myEntitySet.getMockData('tenant-006');
+        allData = mockData.getAllEntries(fakeRequest) as any;
+        const secondMock = myOtherEntitySet.getMockData('tenant-006') as any;
+        let allSecondData = secondMock.getAllEntries(fakeRequest) as any;
+        expect(allData.length).toBe(3);
+        expect(allSecondData.length).toBe(1);
+        await mockData.updateEntry(
+            { ID: 1 },
+            {
+                ID: 1,
+                Name: 'My Updated Name',
+                Value: 'My Value'
+            },
+            {
+                Name: 'My Updated Name'
+            },
+            fakeRequest
+        );
+        fakeRequest.getResponseData();
+        allSecondData = secondMock.getAllEntries(fakeRequest) as any;
+        expect(allSecondData.length).toBe(2);
+        expect(allSecondData[1]).toStrictEqual({ Name: 'MySecondEntityName' });
+    });
+
+    it('can get entries based on filters', () => {
+        // Fake that in tenant 007 we can influence filtering
+        const fakeRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: 'MyRootEntity'
+            },
+            dataAccess
+        );
+        fakeRequest.tenantId = 'tenant-006';
+        const mockData = myEntitySet.getMockData('tenant-006');
+        const allData = mockData.getAllEntries(fakeRequest);
+        let filterResult = mockData.checkFilterValue('Edm.String', allData[0]?.Name, 'Name', 'eq', fakeRequest);
+        expect(filterResult).toBe(false);
+        fakeRequest.tenantId = 'tenant-007';
+        filterResult = mockData.checkFilterValue('Edm.String', allData[0]?.Name, 'Name', 'eq', fakeRequest);
+        expect(filterResult).toBe(true);
+    });
+});

--- a/packages/fe-mockserver-core/test/unit/data/mockdata/MyRootEntity.js
+++ b/packages/fe-mockserver-core/test/unit/data/mockdata/MyRootEntity.js
@@ -1,0 +1,37 @@
+const ODataRequest = require('../../../../src/request/odataRequest');
+module.exports = {
+    getAllEntries(odataRequest) {
+        const allEntries = this.base.getAllEntries(); // Retrieve them from the base
+        if (odataRequest.tenantId === 'tenant-001') {
+            return [allEntries[0]];
+        } else if (odataRequest.tenantId === 'tenant-002') {
+            this.throwError('This tenant is not allowed for you');
+        }
+        return allEntries;
+    },
+    async updateEntry(keyValues, newData, patchData, odataRequest) {
+        if (odataRequest.tenantId === 'tenant-003') {
+            newData.Value += 'For Special Tenant';
+            return this.base.updateEntry(keyValues, newData);
+        } else if (odataRequest.tenantId === 'tenant-004') {
+            this.base.addEntry({ Name: 'Fourth Name Value', Value: 'Fourth Value' });
+            return this.base.updateEntry(keyValues, newData);
+        } else if (odataRequest.tenantId === 'tenant-005') {
+            odataRequest.addMessage(8008, 'Warning Message', 3, '/');
+            return this.base.updateEntry(keyValues, newData);
+        } else if (odataRequest.tenantId === 'tenant-006') {
+            const mySecondEntityInterface = await this.base.getEntityInterface('MySecondEntity');
+            mySecondEntityInterface.addEntry({ Name: 'MySecondEntityName' });
+            return this.base.updateEntry(keyValues, newData);
+        } else {
+            return this.base.updateEntry(keyValues, newData);
+        }
+    },
+    checkFilterValue(comparisonType, mockValue, literal, operator, _odataRequest) {
+        if (_odataRequest.tenantId === 'tenant-007') {
+            return true;
+        } else {
+            return this.base.checkFilterValue(comparisonType, mockValue, literal, operator);
+        }
+    }
+};

--- a/packages/fe-mockserver-core/test/unit/data/mockdata/MyRootEntity.json
+++ b/packages/fe-mockserver-core/test/unit/data/mockdata/MyRootEntity.json
@@ -1,0 +1,17 @@
+[
+    {
+        "ID": 1,
+        "Name": "My Name",
+        "Value": "My Value"
+    },
+    {
+        "ID": 2,
+        "Name": "Second Name",
+        "Value": "Second Value"
+    },
+    {
+        "ID": 3,
+        "Name": "Third Name",
+        "Value": "Third Value"
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/data/mockdata/MySecondEntity.json
+++ b/packages/fe-mockserver-core/test/unit/data/mockdata/MySecondEntity.json
@@ -1,0 +1,7 @@
+[
+    {
+        "ID": 1,
+        "Name": "My Second Entity Name",
+        "Value": "My Second Entity Value"
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/data/mockdata/service.cds
+++ b/packages/fe-mockserver-core/test/unit/data/mockdata/service.cds
@@ -1,0 +1,16 @@
+aspect AbstractEntity {
+    key ID : Integer;
+    Name   : String;
+    Value  : String;
+}
+
+
+service MultiLevelExpand {
+    entity MyRootEntity : AbstractEntity {
+
+    }
+
+    entity MySecondEntity : AbstractEntity {
+
+    }
+}

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -640,7 +640,7 @@ describe('Data Access', () => {
         // Activate it
         let actionResult = await dataAccess.performAction(
             new ODataRequest(
-                { method: 'GET', url: '/Part3(ID=2,IsActiveEntity=false)/sap.fe.core.Form.draftActivate' },
+                { method: 'GET', url: '/Part3(ID=151,IsActiveEntity=false)/sap.fe.core.Form.draftActivate' },
                 dataAccess
             )
         );
@@ -649,7 +649,7 @@ describe('Data Access', () => {
         expect(part3Data.length).toEqual(151);
 
         const part3Update = await dataAccess.updateData(
-            new ODataRequest({ method: 'GET', url: '/Part3(ID=2,IsActiveEntity=true)' }, dataAccess),
+            new ODataRequest({ method: 'GET', url: '/Part3(ID=151,IsActiveEntity=true)' }, dataAccess),
             {
                 number: 7
             }
@@ -666,7 +666,7 @@ describe('Data Access', () => {
 
         actionResult = await dataAccess.performAction(
             new ODataRequest(
-                { method: 'GET', url: '/Part3(ID=2,IsActiveEntity=true)/sap.fe.core.Form.boundAction1' },
+                { method: 'GET', url: '/Part3(ID=151,IsActiveEntity=true)/sap.fe.core.Form.boundAction1' },
                 dataAccess
             )
         );

--- a/packages/ui5-middleware-fe-mockserver/src/index.ts
+++ b/packages/ui5-middleware-fe-mockserver/src/index.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import FEMockserver from '@sap-ux/fe-mockserver-core';
 import { resolveConfig } from './configResolver';
 import type { IRouter } from 'router';
+export type { MockDataContributor } from '@sap-ux/fe-mockserver-core';
 
 async function FEMiddleware(middlewareConfig: any): Promise<IRouter> {
     // basepath will be the webapp folder so we have to go up a level to retrieve the config
@@ -12,5 +13,6 @@ async function FEMiddleware(middlewareConfig: any): Promise<IRouter> {
     await mockserverInstance.isReady;
     return mockserverInstance.getRouter();
 }
-
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 export = FEMiddleware;


### PR DESCRIPTION
Fixes #127 
- All the function based mockdata will now receive the request object that contains a lot of information, especially the tenantId
- Search and Filter can now be evaluated individually and overwritten
- sap messages can be added to any request manually