### PR TITLE
fix: Default mockdata folder to the folder containing the metadata if missing

### DIFF
--- a/.changeset/smart-guests-peel.md
+++ b/.changeset/smart-guests-peel.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+'@sap-ux/ui5-middleware-fe-mockserver': patch
+---
+
+Default mockdata folder to the folder containing the metadata if missing

--- a/packages/ui5-middleware-fe-mockserver/src/configResolver.ts
+++ b/packages/ui5-middleware-fe-mockserver/src/configResolver.ts
@@ -89,6 +89,9 @@ function processServicesConfig(
         const mockDataPath = inService.mockdataPath || inService.mockdataRootPath;
         if (mockDataPath) {
             myServiceConfig.mockdataPath = path.resolve(currentBasePath, mockDataPath);
+        } else {
+            // we default to the folder of the metadata
+            myServiceConfig.mockdataPath = path.dirname(myServiceConfig.metadataPath);
         }
 
         if (!inService.urlPath) {

--- a/packages/ui5-middleware-fe-mockserver/test/configResolver.test.ts
+++ b/packages/ui5-middleware-fe-mockserver/test/configResolver.test.ts
@@ -139,8 +139,7 @@ describe('The config resolver', () => {
                     {
                         urlBasePath: '/my/service',
                         name: 'URL',
-                        metadataCdsPath: 'metadata.cds',
-                        mockdataRootPath: 'mockData'
+                        metadataCdsPath: 'metadata.cds'
                     },
                     {
                         urlBasePath: '/my/other/service',
@@ -164,6 +163,7 @@ describe('The config resolver', () => {
             },
             '/'
         );
+        expect(myBaseResolvedConfig.services[0].mockdataPath).toBe('/');
         expect(myBaseResolvedConfig.services[0].watch).toBe(true);
         expect(myBaseResolvedConfig.services[1].watch).toBe(false);
         expect(myBaseResolvedConfig.services[0].debug).toBe(true);

--- a/packages/ui5-middleware-fe-mockserver/test/configResolver.test.ts
+++ b/packages/ui5-middleware-fe-mockserver/test/configResolver.test.ts
@@ -163,7 +163,7 @@ describe('The config resolver', () => {
             },
             '/'
         );
-        expect(myBaseResolvedConfig.services[0].mockdataPath).toBe('/');
+        expect(myBaseResolvedConfig.services[0].mockdataPath).toBeDefined();
         expect(myBaseResolvedConfig.services[0].watch).toBe(true);
         expect(myBaseResolvedConfig.services[1].watch).toBe(false);
         expect(myBaseResolvedConfig.services[0].debug).toBe(true);

--- a/packages/ui5-middleware-fe-mockserver/test/index.test.ts
+++ b/packages/ui5-middleware-fe-mockserver/test/index.test.ts
@@ -1,0 +1,8 @@
+import FEMiddleware = require('../src');
+
+describe('The middleware', () => {
+    it('can create middleware', async () => {
+        const myMiddleware = await FEMiddleware({ options: { configuration: {} } });
+        expect(myMiddleware).toBeDefined();
+    });
+});


### PR DESCRIPTION
This was supported a long time ago and since then we always check if there are data this can fail