### PR TITLE
fix: Export the JS code for the enums for people not using TS

### DIFF
--- a/.changeset/seven-dolphins-relax.md
+++ b/.changeset/seven-dolphins-relax.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/vocabularies-types': patch
+---
+
+Exposes the enum for those not using typescript to compile their app

--- a/packages/vocabularies-types/.gitignore
+++ b/packages/vocabularies-types/.gitignore
@@ -1,3 +1,4 @@
 src/vocabularies
 vocabularies
 *.d.ts
+*.js

--- a/packages/vocabularies-types/package.json
+++ b/packages/vocabularies-types/package.json
@@ -14,7 +14,7 @@
     "typings": "index.d.ts",
     "scripts": {
         "build": "pnpm clean && pnpm generate_types && tsc",
-        "clean": "rimraf vocabularies && rimraf *.d.ts && rimraf src/vocabularies",
+        "clean": "rimraf vocabularies && rimraf *.d.ts && rimraf *.js && rimraf *.js.map && rimraf src/vocabularies",
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",

--- a/packages/vocabularies-types/tsconfig.json
+++ b/packages/vocabularies-types/tsconfig.json
@@ -4,7 +4,8 @@
         "outDir": ".",
         "declarationMap": false,
         "types": ["node"],
-        "emitDeclarationOnly": true
+        "isolatedModules": true,
+        "sourceMap": false
     },
     "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Package size will increase but since it should always be a devDep and not used in targets apps this should be fine.