### PR TITLE
feat: Improve type definition

### DIFF
--- a/.changeset/modern-islands-join.md
+++ b/.changeset/modern-islands-join.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/vocabularies-types': minor
+'@sap-ux/annotation-converter': patch
+---
+
+Improve type definition to be more consistent with the output

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -1063,7 +1063,20 @@ function splitTerm(references: ReferencesWithMap, termValue: string) {
  * @returns the function that will allow to resolve element globally.
  */
 function createGlobalResolve(convertedOutput: ConvertedMetadata, objectMap: Record<string, any>) {
-    return function resolvePath<T extends ServiceObjectAndAnnotation>(sPath: string): ResolutionTarget<T> {
+    return function resolvePath<T extends ServiceObjectAndAnnotation>(
+        sPath: string,
+        dontBeSmart: boolean = false
+    ): ResolutionTarget<T> {
+        if (dontBeSmart) {
+            const targetResolution: any = _resolveTarget(objectMap, convertedOutput, '/' + sPath, false, true);
+            if (targetResolution.target) {
+                targetResolution.visitedObjects.push(targetResolution.target);
+            }
+            return {
+                target: targetResolution.target,
+                objectPath: targetResolution.visitedObjects
+            };
+        }
         const aPathSplit = sPath.split('/');
         if (aPathSplit.shift() !== '') {
             throw new Error('Cannot deal with relative path');

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -1065,9 +1065,9 @@ function splitTerm(references: ReferencesWithMap, termValue: string) {
 function createGlobalResolve(convertedOutput: ConvertedMetadata, objectMap: Record<string, any>) {
     return function resolvePath<T extends ServiceObjectAndAnnotation>(
         sPath: string,
-        dontBeSmart: boolean = false
+        resolveDirectly: boolean = false
     ): ResolutionTarget<T> {
-        if (dontBeSmart) {
+        if (resolveDirectly) {
             const targetResolution: any = _resolveTarget(objectMap, convertedOutput, '/' + sPath, false, true);
             if (targetResolution.target) {
                 targetResolution.visitedObjects.push(targetResolution.target);

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -172,6 +172,16 @@ describe('Annotation Converter', () => {
         expect(sdManage.target).not.toBeNull();
         expect(sdManage.target?._type).toEqual('EntitySet');
         expect(sdManage.objectPath.length).toEqual(2); // EntityContainer
+
+        // It can resolve EntitySet
+        const sdManage2: ResolutionTarget<EntitySet> = convertedTypes.resolvePath(
+            convertedTypes.entitySets[40].fullyQualifiedName,
+            true
+        );
+        expect(sdManage2.target).not.toBeNull();
+        expect(sdManage2.target?._type).toEqual('EntitySet');
+        expect(sdManage2.objectPath.length).toEqual(2); // EntityContainer
+
         // It can resolve EntityType
         const sdManageType: ResolutionTarget<EntityType> = convertedTypes.resolvePath('/SalesOrderManage/');
         expect(sdManageType.target).not.toBeNull();

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -458,7 +458,7 @@ export type ConvertedMetadata = {
     entityTypes: EntityType[];
     references: Reference[];
     diagnostics: { message: string }[];
-    resolvePath: <T>(path: string, dontBeSmart?: boolean) => ResolutionTarget<T>;
+    resolvePath: <T>(path: string, resolveDirectly?: boolean) => ResolutionTarget<T>;
 };
 
 // All the Raw types are meant for usage when providing data to the converter

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -458,7 +458,7 @@ export type ConvertedMetadata = {
     entityTypes: EntityType[];
     references: Reference[];
     diagnostics: { message: string }[];
-    resolvePath: <T>(path: string) => ResolutionTarget<T>;
+    resolvePath: <T>(path: string, dontBeSmart?: boolean) => ResolutionTarget<T>;
 };
 
 // All the Raw types are meant for usage when providing data to the converter

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -42,7 +42,7 @@ export type NavigationPropertyPath = {
 export type AnnotationPath<P> = {
     type: 'AnnotationPath';
     value: string;
-    $target: AnnotationTerm<P>;
+    $target: AnnotationTerm<P> & { term: string };
 };
 
 type PrimitiveTypeCast<P, G> =
@@ -55,7 +55,6 @@ export type AnnotationTerm<P> = PrimitiveTypeCast<
     P,
     {
         fullyQualifiedName: string;
-        term: string;
         qualifier: string;
         annotations?: TermAnnotations & AnnotationAnnotations;
     }
@@ -313,6 +312,7 @@ export type Property = {
 
 export type RecordComplexType = {
     annotations?: RecordAnnotations;
+    fullyQualifiedName: string;
 };
 
 export type ComplexType = {

--- a/packages/vocabularies-types/utils/generate_types.ts
+++ b/packages/vocabularies-types/utils/generate_types.ts
@@ -315,9 +315,9 @@ async function generateTypes(targetFolder: string) {
                             renamedTermType.startsWith('Edm.String') ||
                             (isSchemaElement(termName, targetTerm) && isSimpleType(targetTerm))
                         ) {
-                            vocabularyDef += `export type ${vocabularyTerm} = AnnotationTerm<PropertyAnnotationValue<${renamedTermType}>>`;
+                            vocabularyDef += `export type ${vocabularyTerm} = { term : ${vocabularyAlias}AnnotationTerms.${vocabularyTerm}} & AnnotationTerm<PropertyAnnotationValue<${renamedTermType}>>`;
                         } else {
-                            vocabularyDef += `export type ${vocabularyTerm} = AnnotationTerm<${renamedTermType}>`;
+                            vocabularyDef += `export type ${vocabularyTerm} = { term : ${vocabularyAlias}AnnotationTerms.${vocabularyTerm} } & AnnotationTerm<${renamedTermType}>`;
                         }
 
                         // if (vocabularyTermInfo.$Nullable) {
@@ -382,7 +382,7 @@ async function generateTypes(targetFolder: string) {
                                     if (vocabularyTermInfo[vocabularyTermKey].$Collection) {
                                         keyType += `[]`;
                                     }
-                                    keyType = `AnnotationTerm<${keyType}>`;
+                                    keyType = `${keyType}`;
                                 } else {
                                     if (keyType === 'Edm.AnnotationPath') {
                                         if (vocabularyTermInfo[vocabularyTermKey]['@Validation.AllowedTerms']) {
@@ -516,20 +516,18 @@ async function generateTypes(targetFolder: string) {
                 baseType = basebaseType;
             }
             if (!(localVocDefinition[baseType] as ComplexType).$Abstract) {
-                vocabularyDef += `export type ${baseType}Types = AnnotationTerm<${originalBaseType}`;
+                vocabularyDef += `export type ${baseType}Types = ${originalBaseType}`;
                 if (typeInheritances[originalBaseType].length > 0) {
                     vocabularyDef += ` | ${typeInheritances[originalBaseType]
                         .map((type: string) => type + 'Types')
                         .join(' | ')}`;
                 }
-                vocabularyDef += '>;\n';
+                vocabularyDef += ';\n';
             } else if (typeInheritances[originalBaseType].length > 0) {
-                vocabularyDef += `export type ${originalBaseType}Types = AnnotationTerm<${typeInheritances[
-                    originalBaseType
-                ]
+                vocabularyDef += `export type ${originalBaseType}Types = ${typeInheritances[originalBaseType]
                     .map((type: string) => type + 'Types')
                     .join(' | ')}`;
-                vocabularyDef += '>;\n';
+                vocabularyDef += ';\n';
             }
         });
         vocabularyEdmDef = `import * as ${vocabularyNamespaceTrans} from "./${vocabularyAlias}";\n\n`;

--- a/packages/vocabularies-types/utils/generate_types.ts
+++ b/packages/vocabularies-types/utils/generate_types.ts
@@ -366,7 +366,8 @@ async function generateTypes(targetFolder: string) {
                                 if (
                                     keyType.startsWith('Edm.') &&
                                     keyType !== 'Edm.AnnotationPath' &&
-                                    keyType !== 'Edm.PropertyPath'
+                                    keyType !== 'Edm.PropertyPath' &&
+                                    keyType !== 'Edm.NavigationPropertyPath'
                                 ) {
                                     if (vocabularyTermInfo[vocabularyTermKey].$Collection) {
                                         keyType += `[]`;


### PR DESCRIPTION
Currently the type often including a reference to a term property that may not exist.
Furthermore the terms when defined were just string instead of being the actual values making the switch case determination more complex than it could have been.