### PR TITLE
feat: add flag for collection-valued action parameters

### DIFF
--- a/.changeset/tiny-points-boil.md
+++ b/.changeset/tiny-points-boil.md
@@ -1,0 +1,6 @@
+---
+"@sap-ux/edmx-parser": patch
+"@sap-ux/vocabularies-types": patch
+---
+
+feat: add flag for collection-valued action parameters

--- a/.changeset/tiny-points-boil.md
+++ b/.changeset/tiny-points-boil.md
@@ -1,6 +1,7 @@
 ---
-"@sap-ux/edmx-parser": patch
-"@sap-ux/vocabularies-types": patch
+'@sap-ux/edmx-parser': patch
+'@sap-ux/vocabularies-types': patch
+'@sap-ux/annotation-converter': patch
 ---
 
 feat: add flag for collection-valued action parameters

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -523,7 +523,8 @@ function parseActions(
                     fullyQualifiedName: `${actionFQN}/${param._attributes.Name}`,
                     name: `${param._attributes.Name}`,
                     type: param._attributes.Type,
-                    isEntitySet: param._attributes.Name === action._attributes.EntitySetPath
+                    isEntitySet: param._attributes.Name === action._attributes.EntitySetPath,
+                    isCollection: param._attributes.Type.match(/^Collection\(.+\)$/) !== null
                 };
             }),
             returnType: action.ReturnType ? action.ReturnType._attributes.Type : ''
@@ -552,7 +553,8 @@ function parseFunctionImport(
                     name: param._attributes.Name,
                     fullyQualifiedName: `${actionFQN}/${param._attributes.Name}`,
                     type: param._attributes.Type,
-                    isEntitySet: false
+                    isEntitySet: false,
+                    isCollection: param._attributes.Type.match(/^Collection\(.+\)$/) !== null
                 };
             }),
             returnType: action._attributes.ReturnType ? action._attributes.ReturnType : ''

--- a/packages/edmx-parser/test/__snapshots__/merge.spec.ts.snap
+++ b/packages/edmx-parser/test/__snapshots__/merge.spec.ts.snap
@@ -13,6 +13,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction1(sap.fe.core.ActionVisibility.RootElement)/self",
+          "isCollection": false,
           "isEntitySet": true,
           "name": "self",
           "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -31,6 +32,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction2(sap.fe.core.ActionVisibility.RootElement)/in",
+          "isCollection": false,
           "isEntitySet": true,
           "name": "in",
           "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -49,6 +51,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction3(sap.fe.core.ActionVisibility.RootElement)/self",
+          "isCollection": false,
           "isEntitySet": true,
           "name": "self",
           "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -67,6 +70,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)/in",
+          "isCollection": false,
           "isEntitySet": true,
           "name": "in",
           "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -74,6 +78,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)/SideEffectsQualifier",
+          "isCollection": false,
           "isEntitySet": false,
           "name": "SideEffectsQualifier",
           "type": "Edm.String",
@@ -92,6 +97,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)/in",
+          "isCollection": false,
           "isEntitySet": true,
           "name": "in",
           "type": "sap.fe.core.ActionVisibility.SubElement",
@@ -99,6 +105,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)/SideEffectsQualifier",
+          "isCollection": false,
           "isEntitySet": false,
           "name": "SideEffectsQualifier",
           "type": "Edm.String",
@@ -117,6 +124,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftActivate(sap.fe.core.ActionVisibility.RootElement)/in",
+          "isCollection": false,
           "isEntitySet": true,
           "name": "in",
           "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -135,6 +143,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)/in",
+          "isCollection": false,
           "isEntitySet": true,
           "name": "in",
           "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -142,6 +151,7 @@ MergedRawMetadata {
         Object {
           "_type": "ActionParameter",
           "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)/PreserveChanges",
+          "isCollection": false,
           "isEntitySet": false,
           "name": "PreserveChanges",
           "type": "Edm.Boolean",
@@ -2240,6 +2250,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction1(sap.fe.core.ActionVisibility.RootElement)/self",
+                "isCollection": false,
                 "isEntitySet": true,
                 "name": "self",
                 "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -2258,6 +2269,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction2(sap.fe.core.ActionVisibility.RootElement)/in",
+                "isCollection": false,
                 "isEntitySet": true,
                 "name": "in",
                 "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -2276,6 +2288,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.boundAction3(sap.fe.core.ActionVisibility.RootElement)/self",
+                "isCollection": false,
                 "isEntitySet": true,
                 "name": "self",
                 "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -2294,6 +2307,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)/in",
+                "isCollection": false,
                 "isEntitySet": true,
                 "name": "in",
                 "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -2301,6 +2315,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.RootElement)/SideEffectsQualifier",
+                "isCollection": false,
                 "isEntitySet": false,
                 "name": "SideEffectsQualifier",
                 "type": "Edm.String",
@@ -2319,6 +2334,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)/in",
+                "isCollection": false,
                 "isEntitySet": true,
                 "name": "in",
                 "type": "sap.fe.core.ActionVisibility.SubElement",
@@ -2326,6 +2342,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftPrepare(sap.fe.core.ActionVisibility.SubElement)/SideEffectsQualifier",
+                "isCollection": false,
                 "isEntitySet": false,
                 "name": "SideEffectsQualifier",
                 "type": "Edm.String",
@@ -2344,6 +2361,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftActivate(sap.fe.core.ActionVisibility.RootElement)/in",
+                "isCollection": false,
                 "isEntitySet": true,
                 "name": "in",
                 "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -2362,6 +2380,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)/in",
+                "isCollection": false,
                 "isEntitySet": true,
                 "name": "in",
                 "type": "sap.fe.core.ActionVisibility.RootElement",
@@ -2369,6 +2388,7 @@ MergedRawMetadata {
               Object {
                 "_type": "ActionParameter",
                 "fullyQualifiedName": "sap.fe.core.ActionVisibility.draftEdit(sap.fe.core.ActionVisibility.RootElement)/PreserveChanges",
+                "isCollection": false,
                 "isEntitySet": false,
                 "name": "PreserveChanges",
                 "type": "Edm.Boolean",

--- a/packages/edmx-parser/test/fixtures/v4/static-action.xml
+++ b/packages/edmx-parser/test/fixtures/v4/static-action.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:DataServices>
+        <Schema Namespace="TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+            <EntityContainer Name="EntityContainer">
+                <EntitySet Name="TestEntities" EntityType="TestService.TestEntities"/>
+            </EntityContainer>
+            <EntityType Name="TestEntities">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+            </EntityType>
+            <Action Name="staticAction" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="Collection(TestService.TestEntities)"/>
+                <Parameter Name="a" Type="Edm.Int32"/>
+                <ReturnType Type="TestService.TestEntities"/>
+            </Action>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/edmx-parser/test/parser.spec.ts
+++ b/packages/edmx-parser/test/parser.spec.ts
@@ -12,36 +12,36 @@ describe('Parser', function () {
         expect(mergeSchema).toMatchSnapshot();
     });
 
-    it('can convertTypes an v3 edmx file', async () => {
+    it('can parse an v3 edmx file', async () => {
         const xmlFile = await loadFixture('northwind.metadata.xml');
         const schema: RawMetadata = parse(xmlFile);
         expect(schema).toMatchSnapshot();
     });
 
-    it('can convertTypes the worklist edmx file', async () => {
+    it('can parse the worklist edmx file', async () => {
         const xmlFile = await loadFixture('v2/worklist.xml');
         const schema: RawMetadata = parse(xmlFile);
         expect(schema).toMatchSnapshot();
     });
 
-    it('can convertTypes a v2 edmx file with function import', async () => {
+    it('can parse a v2 edmx file with function import', async () => {
         const xmlFile = await loadFixture('v2/metadataFunctionImport.xml');
         const schema: RawMetadata = parse(xmlFile);
         expect(schema).toMatchSnapshot();
     });
-    it('can convertTypes a v2 edmx file with analytics', async () => {
+    it('can parse a v2 edmx file with analytics', async () => {
         const xmlFile = await loadFixture('v2/metadata_analytics.xml');
         const schema: RawMetadata = parse(xmlFile);
         expect(schema).toMatchSnapshot();
     });
 
-    it('can convertTypes a weird edmx file', async () => {
+    it('can parse a weird edmx file', async () => {
         const xmlFile = await loadFixture('weirdCollection.metadata.xml');
         const schema: RawMetadata = parse(xmlFile);
         expect(schema).toMatchSnapshot();
     });
 
-    it('can convertTypes a trippin metadata', async () => {
+    it('can parse a trippin metadata', async () => {
         const xmlFile = await loadFixture('v4/trippin/metadata.xml');
         const schema: RawMetadata = parse(xmlFile);
         const annoFile = await loadFixture('v4/trippin/annotation.xml');
@@ -49,14 +49,20 @@ describe('Parser', function () {
         const mergeSchema = merge(schema, annoSchema);
         expect(mergeSchema).toMatchSnapshot();
     });
-    it('can convertTypes a metadata with a typedef', async () => {
+    it('can parse a metadata with a typedef', async () => {
         const xmlFile = await loadFixture('v4/withTypeDef.xml');
         const schema: RawMetadata = parse(xmlFile);
         expect(schema).toMatchSnapshot();
     });
 
-    it('can convertTypes an edmx file', async () => {
+    it('can parse an edmx file', async () => {
         const xmlFile = await loadFixture('salesOrder.metadata.xml');
+        const schema: RawMetadata = parse(xmlFile);
+        expect(schema).toMatchSnapshot();
+    });
+
+    it('can parse edmx with a static action', async () => {
+        const xmlFile = await loadFixture('v4/static-action.xml');
         const schema: RawMetadata = parse(xmlFile);
         expect(schema).toMatchSnapshot();
     });

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -405,6 +405,7 @@ export type EntityContainer = {
 export type ActionParameter = {
     _type: 'ActionParameter';
     isEntitySet: boolean;
+    isCollection: boolean;
     name: string;
     fullyQualifiedName: string;
     type: string;


### PR DESCRIPTION
Add a new property `isCollection` to the `ActionParameter` type that indicates whether the parameter is collection-valued. This makes it easier to decide whether an action is "static".