### PR TITLE
fix: Unbound action are now corretly forwarded to custom handlers

### DIFF
--- a/.changeset/fifty-walls-deny.md
+++ b/.changeset/fifty-walls-deny.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+'@sap-ux/ui5-middleware-fe-mockserver': patch
+---
+
+Unbound Action are now correctly forwarded to custom handlers

--- a/packages/fe-mockserver-core/test/unit/v4/__snapshots__/unboundAction.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/v4/__snapshots__/unboundAction.test.ts.snap
@@ -10,14 +10,3 @@ Array [
 `;
 
 exports[`Unbound Action can be called 2`] = `"This is my action response"`;
-
-exports[`Unbound Action does not catch all 1`] = `
-Array [
-  Object {
-    "keys": Object {},
-    "path": "unboundActionThatIDontknow",
-  },
-]
-`;
-
-exports[`Unbound Action does not catch all 2`] = `null`;

--- a/packages/fe-mockserver-core/test/unit/v4/__snapshots__/unboundAction.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/v4/__snapshots__/unboundAction.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Unbound Action can be called 1`] = `
+Array [
+  Object {
+    "keys": Object {},
+    "path": "unboundAction",
+  },
+]
+`;
+
+exports[`Unbound Action can be called 2`] = `"This is my action response"`;
+
+exports[`Unbound Action does not catch all 1`] = `
+Array [
+  Object {
+    "keys": Object {},
+    "path": "unboundActionThatIDontknow",
+  },
+]
+`;
+
+exports[`Unbound Action does not catch all 2`] = `null`;

--- a/packages/fe-mockserver-core/test/unit/v4/services/unboundAction/EntityContainer.js
+++ b/packages/fe-mockserver-core/test/unit/v4/services/unboundAction/EntityContainer.js
@@ -1,0 +1,16 @@
+module.exports = {
+    executeAction: function (actionDefinition, actionData, keys, odataRequest) {
+        switch (actionDefinition.name) {
+            case 'unboundAction': {
+                return 'This is my action response';
+            }
+            default: {
+                this.throwError('Unsupported Action', 501, {
+                    error: {
+                        message: `FunctionImport or Action "${actionDefinition.name}" not mocked`
+                    }
+                });
+            }
+        }
+    }
+};

--- a/packages/fe-mockserver-core/test/unit/v4/services/unboundAction/service.cds
+++ b/packages/fe-mockserver-core/test/unit/v4/services/unboundAction/service.cds
@@ -1,0 +1,112 @@
+using {
+  cuid,
+  managed
+} from '@sap/cds/common';
+
+service Service {
+  @odata.draft.enabled
+  entity RootEntity {
+    key ID                  : Integer       @title : 'Identifier';
+        TitleProperty       : String        @title : 'Title';
+        DescriptionProperty : String        @title : 'Description';
+        NameProperty        : String        @title : 'Some Text';
+        NumberProperty      : Decimal(4, 2) @title : 'Number';
+        Currency            : String        @title : 'Currency';
+        BooleanProperty     : Boolean       @title : 'Boolean';
+        Progress            : Decimal(4, 1) @title : 'Progress';
+        _Child              : Composition of many ChildEntity
+                                on _Child.Parent = $self;
+  } actions {
+    @(
+      Common.SideEffects              : {TargetProperties : ['_it/BooleanProperty']},
+      cds.odata.bindingparameter.name : '_it'
+    )
+    action boundAction();
+  }
+
+  action unboundAction();
+
+  annotate RootEntity with
+  @(UI : {
+    HeaderInfo                           : {
+      TypeName       : 'Root Entity',
+      TypeNamePlural : 'Root Entities',
+      TypeImageUrl   : 'sap-icon://alert',
+      Title          : {
+        $Type : 'UI.DataField',
+        Value : TitleProperty
+      }
+    },
+    HeaderFacets                         : [{
+      $Type  : 'UI.ReferenceFacet',
+      ID     : 'HeaderFacetIdentifier1',
+      Target : '@UI.FieldGroup#HeaderGeneralInformation'
+    }],
+    Facets                               : [{
+      $Type  : 'UI.ReferenceFacet',
+      ID     : 'FacetIdentifier1',
+      Target : '_Child/@UI.LineItem'
+    }],
+    FieldGroup #HeaderGeneralInformation : {Data : [
+      {
+        $Type : 'UI.DataField',
+        Value : NameProperty
+      },
+      {
+        $Type : 'UI.DataField',
+        Value : DescriptionProperty
+      },
+      {
+        $Type : 'UI.DataField',
+        Value : BooleanProperty
+      }
+    ]}
+  });
+
+  entity ChildEntity {
+    key ID                       : Integer       @title : 'Child Identifier';
+        ChildTitleProperty       : String        @title : 'Child Title';
+        ChildDescriptionProperty : String        @title : 'Child Description';
+        ChildNameProperty        : String        @title : 'Some Child Text';
+        ChildNumberProperty      : Decimal(4, 2) @title : 'Child Number';
+        Parent                   : Association to RootEntity;
+  } actions {
+    @(
+      Common.SideEffects              : {TargetProperties : ['_it/ChildTitleProperty']},
+      cds.odata.bindingparameter.name : '_it'
+    )
+    action boundActionSetTitle(Title : String);
+  }
+
+  annotate ChildEntity with @(UI : {
+    HeaderInfo : {
+      TypeName       : 'Child Entity',
+      TypeNamePlural : 'Child Entities',
+      TypeImageUrl   : 'sap-icon://alert',
+      Title          : {
+        $Type : 'UI.DataField',
+        Value : ChildTitleProperty
+      }
+    },
+    Facets     : [{
+      $Type  : 'UI.ReferenceFacet',
+      ID     : 'FacetIdentifier1',
+      Target : '@UI.FieldGroup'
+    }],
+    LineItem   : [
+      {Value : ID},
+      {Value : ChildTitleProperty},
+      {Value : ChildDescriptionProperty}
+    ],
+    FieldGroup : {Data : [
+      {
+        $Type : 'UI.DataField',
+        Value : ChildNameProperty
+      },
+      {
+        $Type : 'UI.DataField',
+        Value : ChildNumberProperty
+      }
+    ]}
+  });
+}

--- a/packages/fe-mockserver-core/test/unit/v4/unboundAction.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/unboundAction.test.ts
@@ -1,0 +1,37 @@
+import { join } from 'path';
+import FileSystemLoader from '../../../src/plugins/fileSystemLoader';
+import CDSMetadataProvider from '@sap-ux/fe-mockserver-plugin-cds';
+import { ODataMetadata } from '../../../src/data/metadata';
+import { DataAccess } from '../../../src/data/dataAccess';
+import type { ServiceConfig } from '../../../src';
+import ODataRequest from '../../../src/request/odataRequest';
+
+describe('Unbound Action', () => {
+    let metadata, dataAccess: DataAccess;
+    const baseUrl = '/test';
+    const fileLoader = new FileSystemLoader();
+    const metadataProvider = new CDSMetadataProvider(fileLoader);
+    beforeAll(async () => {
+        const baseDir = join(__dirname, 'services', 'unboundAction');
+        const edmx = await metadataProvider.loadMetadata(join(baseDir, 'service.cds'));
+
+        metadata = await ODataMetadata.parse(edmx, baseUrl + '/$metadata');
+        dataAccess = new DataAccess({ mockdataPath: baseDir } as ServiceConfig, metadata, fileLoader);
+    });
+    test('can be called', async () => {
+        const requestUrl = '/unboundAction';
+
+        const request = new ODataRequest({ method: 'POST', url: requestUrl }, dataAccess);
+        expect(request.queryPath).toMatchSnapshot();
+        const actionData = await dataAccess.performAction(request);
+        expect(actionData).toMatchSnapshot();
+    });
+
+    test('does not catch all', async () => {
+        const requestUrl = '/unboundActionThatIDontknow';
+
+        const request = new ODataRequest({ method: 'POST', url: requestUrl }, dataAccess);
+        const actionData = await dataAccess.performAction(request);
+        expect(actionData).toBeNull();
+    });
+});


### PR DESCRIPTION
There was a bit of mix up with the sticky use case where we do leverage this for standard behavior in an unclean way i guess.