### PR TITLE
fix: 1 to 1 navigation was not respecting draft status

### DIFF
--- a/.changeset/few-papayas-watch.md
+++ b/.changeset/few-papayas-watch.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+fix: 1 to 1 navigation was not respecting draft status

--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -280,10 +280,8 @@ export class DataAccess implements DataAccessInterface {
                 if (
                     currentEntitySet &&
                     navigationData.hasOwnProperty('IsActiveEntity') &&
-                    ((currentEntitySet.navigationPropertyBinding[navPropDetail.name]?.annotations?.Common as any)
-                        ?.DraftNode ||
-                        (currentEntitySet.navigationPropertyBinding[navPropDetail.name]?.annotations?.Common as any)
-                            ?.DraftRoot)
+                    ((currentEntitySet?.annotations?.Common as any)?.DraftNode ||
+                        (currentEntitySet?.annotations?.Common as any)?.DraftRoot)
                 ) {
                     currentKeys['IsActiveEntity'] = navigationData.IsActiveEntity;
                 }

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -532,6 +532,17 @@ describe('Data Access', () => {
         expect(subElement.HasActiveEntity).toEqual(false);
         expect(subElement.Name).toEqual('OtherChild2');
 
+        subElement = await dataAccess.createData(
+            new ODataRequest({ method: 'GET', url: '/FormRoot(ID=1,IsActiveEntity=false)/SpecialOne' }, dataAccess),
+            {
+                Name: 'My Favorite'
+            }
+        );
+        expect(subElement).toBeDefined;
+        expect(subElement.IsActiveEntity).toEqual(false);
+        expect(subElement.HasActiveEntity).toEqual(false);
+        expect(subElement.Name).toEqual('My Favorite');
+
         // Activate the Draft
         actionResult = await dataAccess.performAction(
             new ODataRequest(
@@ -544,7 +555,7 @@ describe('Data Access', () => {
         expect(formData.length).toEqual(1);
         formData = await dataAccess.getData(
             new ODataRequest(
-                { method: 'GET', url: '/FormRoot?$filter=IsActiveEntity eq true&$expand=_Elements' },
+                { method: 'GET', url: '/FormRoot?$filter=IsActiveEntity eq true&$expand=_Elements,SpecialOne' },
                 dataAccess
             )
         );
@@ -553,6 +564,9 @@ describe('Data Access', () => {
         expect(formData[0]._Elements.length).toEqual(2);
         expect(formData[0]._Elements[0].Name).toEqual('OtherChild2');
         expect(formData[0]._Elements[1].Name).toEqual('SecondChild');
+        expect(formData[0].SpecialOne.Name).toEqual('My Favorite');
+        expect(formData[0].SpecialOne.IsActiveEntity).toEqual(true);
+        expect(formData[0].SpecialOne.HasDraftEntity).toEqual(false);
         formData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/FormRoot?$filter=IsActiveEntity eq false' }, dataAccess)
         );
@@ -567,7 +581,7 @@ describe('Data Access', () => {
         expect(actionResult).toBeDefined;
         formData = await dataAccess.getData(
             new ODataRequest(
-                { method: 'GET', url: '/FormRoot?$filter=IsActiveEntity eq false&$expand=_Elements' },
+                { method: 'GET', url: '/FormRoot?$filter=IsActiveEntity eq false&$expand=_Elements,SpecialOne' },
                 dataAccess
             )
         );
@@ -576,6 +590,9 @@ describe('Data Access', () => {
         expect(formData[0]._Elements.length).toEqual(2);
         expect(formData[0]._Elements[0].Name).toEqual('OtherChild2');
         expect(formData[0]._Elements[1].Name).toEqual('SecondChild');
+        expect(formData[0].SpecialOne.Name).toEqual('My Favorite');
+        expect(formData[0].SpecialOne.IsActiveEntity).toEqual(false);
+        expect(formData[0].SpecialOne.HasActiveEntity).toEqual(true);
         // Activate the Draft
         actionResult = await dataAccess.performAction(
             new ODataRequest(

--- a/packages/fe-mockserver-core/test/unit/v4/services/formSample/FormTemplate.cds
+++ b/packages/fe-mockserver-core/test/unit/v4/services/formSample/FormTemplate.cds
@@ -13,6 +13,7 @@ entity FormRoot {
         DateOfBirth  : Date    @Common.Label :                                'Date of Birth';
         EmailAddress : String  @Communication.IsEmailAddress  @Common.Label : 'Email Address';
         _Elements    : Composition of many SubElements;
+        SpecialOne: Composition of one SubElements;
         Currency     : Currency;
         Country      : String  @(Common : {
             Label     : 'Country of Residence',


### PR DESCRIPTION
The evaluation of draft related properties seemed to have had a flaw in it that was only visible for 1..1 navigation.
Now fixed with this changed, should help #221 