### PR TITLE
fix: singleton properties can now be queried individually

### DIFF
--- a/.changeset/ninety-pens-jog.md
+++ b/.changeset/ninety-pens-jog.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Singleton property can now be queried individually

--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -255,9 +255,6 @@ export class DataAccess implements DataAccessInterface {
                         odataRequest
                     );
                 }
-            } else {
-                // unknown action
-                throw new Error(`Unsupported Action`);
             }
         }
         return null;

--- a/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
@@ -17,7 +17,7 @@ Object {
 }
 `;
 
-exports[`V4 Requestor can fail to create data through a call 1`] = `"Unsupported Action"`;
+exports[`V4 Requestor can fail to create data through a call 1`] = `"Unknown Entity SetIDONTEXIST"`;
 
 exports[`V4 Requestor can get the annotation file 1`] = `
 "<edmx:Edmx xmlns:edmx=\\"http://docs.oasis-open.org/odata/ns/edmx\\" Version=\\"4.0\\">

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -183,7 +183,8 @@ describe('Data Access', () => {
         let singletonData = await dataAccess.getData(odataRequest);
         expect(singletonData).toStrictEqual({ prop1: true, name: 'Me' });
         odataRequest = new ODataRequest({ method: 'GET', url: '/MySingleton/prop1' }, dataAccess);
-        singletonData = await dataAccess.getData(odataRequest);
+        await odataRequest.handleRequest();
+        singletonData = JSON.parse(odataRequest.getResponseData() || '');
         expect(singletonData.value).toEqual(true);
     });
     test('v4metadata - it can GET data for an entity with complex filter function', async () => {

--- a/packages/fe-mockserver-core/test/unit/v4/unboundAction.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/unboundAction.test.ts
@@ -31,6 +31,7 @@ describe('Unbound Action', () => {
         const requestUrl = '/unboundActionThatIDontknow';
 
         const request = new ODataRequest({ method: 'POST', url: requestUrl }, dataAccess);
-        return expect(dataAccess.performAction(request)).rejects.toThrowError('Unsupported Action');
+        const actionData = await dataAccess.performAction(request);
+        expect(actionData).toBeNull();
     });
 });


### PR DESCRIPTION
The refactoring of the action introduced a regression during the standard flow (since we always check for action execution before entity interaction...)