### PR TITLE
Content type error

### DIFF
--- a/.changeset/curvy-seahorses-film.md
+++ b/.changeset/curvy-seahorses-film.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Content-Type is now properly set on errors

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -363,6 +363,10 @@ export default class ODataRequest {
                     if (errorInformation.isSAPMessage) {
                         this.addResponseHeader('sap-messages', JSON.stringify(errorInformation.messageData));
                     } else {
+                        this.addResponseHeader(
+                            'content-type',
+                            'application/json;odata.metadata=minimal;IEEE754Compatible=true'
+                        );
                         this.setResponseData(JSON.stringify(errorInformation.messageData));
                     }
                 } else {

--- a/packages/fe-mockserver-core/test/unit/data/__snapshots__/functionBasedMockData.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/data/__snapshots__/functionBasedMockData.test.ts.snap
@@ -1,3 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Function Based Mock Data can Delete Entries 1`] = `undefined`;
+
+exports[`Function Based Mock Data can GET All Entries 1`] = `"This tenant is not allowed for you"`;
+
+exports[`Function Based Mock Data can GET All Entries 2`] = `
+Object {
+  "content-type": "text/plain",
+  "odata-version": "4.0",
+  "sap-tenantid": "tenant-default",
+}
+`;
+
+exports[`Function Based Mock Data can GET All Entries 3`] = `"{\\"error\\":{\\"code\\":400,\\"message\\":\\"Field 'Field1' is required.\\",\\"target\\":\\"in/field1\\"}}"`;
+
+exports[`Function Based Mock Data can GET All Entries 4`] = `
+Object {
+  "content-type": "application/json;odata.metadata=minimal;IEEE754Compatible=true",
+  "odata-version": "4.0",
+  "sap-tenantid": "tenant-default",
+}
+`;

--- a/packages/fe-mockserver-core/test/unit/data/functionBasedMockData.test.ts
+++ b/packages/fe-mockserver-core/test/unit/data/functionBasedMockData.test.ts
@@ -55,7 +55,7 @@ describe('Function Based Mock Data', () => {
             },
             dataAccess
         );
-        fakeRequest2.tenantId = 'tenant-003';
+        fakeRequest2.tenantId = 'tenant-002b';
         await fakeRequest2.handleRequest();
         responseData = fakeRequest2.getResponseData();
         expect(responseData).toMatchSnapshot();

--- a/packages/fe-mockserver-core/test/unit/data/mockdata/MyRootEntity.js
+++ b/packages/fe-mockserver-core/test/unit/data/mockdata/MyRootEntity.js
@@ -6,7 +6,7 @@ module.exports = {
             return [allEntries[0]];
         } else if (odataRequest.tenantId === 'tenant-002') {
             this.throwError('This tenant is not allowed for you');
-        } else if (odataRequest.tenantId === 'tenant-003') {
+        } else if (odataRequest.tenantId === 'tenant-002b') {
             this.throwError('Error', 400, {
                 error: {
                     code: 400,

--- a/packages/fe-mockserver-core/test/unit/data/mockdata/MyRootEntity.js
+++ b/packages/fe-mockserver-core/test/unit/data/mockdata/MyRootEntity.js
@@ -6,6 +6,14 @@ module.exports = {
             return [allEntries[0]];
         } else if (odataRequest.tenantId === 'tenant-002') {
             this.throwError('This tenant is not allowed for you');
+        } else if (odataRequest.tenantId === 'tenant-003') {
+            this.throwError('Error', 400, {
+                error: {
+                    code: 400,
+                    message: "Field 'Field1' is required.",
+                    target: 'in/field1'
+                }
+            });
         }
         return allEntries;
     },


### PR DESCRIPTION
Fixes #236 

When throwing an error from the mockdata API we were not sending the content-type, which resulted in the error being ignored in the frontend code.