### PR TITLE
fix: draft Activate will now properly respect passed query parameters

### DIFF
--- a/.changeset/calm-dolls-lay.md
+++ b/.changeset/calm-dolls-lay.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Draft Activate now properly respect passed query parameters

--- a/packages/fe-mockserver-core/src/data/entitySets/draftEntitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/draftEntitySet.ts
@@ -287,9 +287,12 @@ export class DraftMockEntitySet extends MockDataEntitySet {
 
             case `${this.entitySetDefinition.annotations.Common?.DraftRoot?.ActivationAction}(${this.entitySetDefinition.entityTypeName})`:
             case `${this.entitySetDefinition.annotations.Common?.DraftRoot?.ActivationAction}()`: {
-                const activeDraft = this.draftActivate(keys, odataRequest.tenantId, odataRequest);
-
-                responseObject = activeDraft;
+                await this.draftActivate(keys, odataRequest.tenantId, odataRequest);
+                odataRequest.queryPath.pop();
+                odataRequest.queryPath[odataRequest.queryPath.length - 1].keys = Object.assign({}, keys, {
+                    IsActiveEntity: true
+                });
+                responseObject = await this.dataAccess.getData(odataRequest);
                 break;
             }
             default:

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -547,10 +547,30 @@ describe('Data Access', () => {
         // Activate the Draft
         actionResult = await dataAccess.performAction(
             new ODataRequest(
-                { method: 'GET', url: '/FormRoot(ID=1,IsActiveEntity=false)/sap.fe.core.Form.draftActivate' },
+                {
+                    method: 'POST',
+                    url: '/FormRoot(ID=1,IsActiveEntity=false)/sap.fe.core.Form.draftActivate?$select=LastName&$expand=SpecialOne'
+                },
                 dataAccess
             )
         );
+        expect(actionResult).toMatchInlineSnapshot(`
+            Object {
+              "ID": 1,
+              "IsActiveEntity": true,
+              "LastName": "",
+              "SpecialOne": Object {
+                "DraftAdministrativeData": null,
+                "HasActiveEntity": false,
+                "HasDraftEntity": false,
+                "ID": 0,
+                "IsActiveEntity": true,
+                "Name": "My Favorite",
+                "owner_ID": 0,
+                "sibling_ID": 0,
+              },
+            }
+        `);
 
         formData = await dataAccess.getData(new ODataRequest({ method: 'GET', url: '/FormRoot' }, dataAccess));
         expect(formData.length).toEqual(1);


### PR DESCRIPTION
Fix #238 

So far we didn't take the query parameter into account during draftActivate (like we did for draftEdit)