### PR TITLE
feat: Allow usage of sap-client as tenantId

### DIFF
--- a/.changeset/healthy-crews-behave.md
+++ b/.changeset/healthy-crews-behave.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+'@sap-ux/ui5-middleware-fe-mockserver': patch
+---
+
+Allow usage of sap-client in order to determine tenant id

--- a/packages/fe-mockserver-core/src/router/serviceRouter.ts
+++ b/packages/fe-mockserver-core/src/router/serviceRouter.ts
@@ -9,6 +9,7 @@ import { raw } from 'body-parser';
 import { batchRouter } from './batchRouter';
 import ODataRequest from '../request/odataRequest';
 import type { DataAccess } from '../data/dataAccess';
+import { URL } from 'url';
 
 export type IncomingMessageWithTenant = IncomingMessage & {
     tenantId?: string;
@@ -62,7 +63,11 @@ export async function serviceRouter(service: ServiceConfigEx, dataAccess: DataAc
         const parser = raw({ type: '*/*' });
         const tenantId = req.originalUrl?.startsWith('/tenant-') ? req.originalUrl?.split('/')[1] : 'tenant-default';
         req.tenantId = tenantId;
-
+        const sapClient = req.originalUrl?.includes('sap-client');
+        if (sapClient) {
+            const parsedUrl = new URL(`http://dummy${req.originalUrl}`);
+            req.tenantId = `tenant-${parsedUrl.searchParams.get('sap-client')}`;
+        }
         parser(req, res, function () {
             if (
                 (req as any).body === null ||

--- a/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
@@ -36,23 +36,6 @@ exports[`V4 Requestor can create data through a call 2`] = `
 
 exports[`V4 Requestor can fail to create data through a call 1`] = `"Unknown Entity SetIDONTEXIST"`;
 
-exports[`V4 Requestor can get some data after changing the watch mode 1`] = `
-{
-  "@odata.context": "$metadata#RootElement(ID=2)",
-  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
-  "HasActiveEntity": false,
-  "HasDraftEntity": false,
-  "ID": 2,
-  "IsActiveEntity": true,
-  "Prop1": "First Prop for Obj2",
-  "Prop2": "Second Prop for Obj3",
-  "Sibling_ID": 1,
-  "isBoundAction1Hidden": true,
-  "isBoundAction2Hidden": true,
-  "isBoundAction3Hidden": false,
-}
-`;
-
 exports[`V4 Requestor can get the annotation file 1`] = `
 "<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
     <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">

--- a/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
@@ -36,6 +36,23 @@ exports[`V4 Requestor can create data through a call 2`] = `
 
 exports[`V4 Requestor can fail to create data through a call 1`] = `"Unknown Entity SetIDONTEXIST"`;
 
+exports[`V4 Requestor can get some data after changing the watch mode 1`] = `
+{
+  "@odata.context": "$metadata#RootElement(ID=2)",
+  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
+  "HasActiveEntity": false,
+  "HasDraftEntity": false,
+  "ID": 2,
+  "IsActiveEntity": true,
+  "Prop1": "First Prop for Obj2",
+  "Prop2": "Second Prop for Obj3",
+  "Sibling_ID": 1,
+  "isBoundAction1Hidden": true,
+  "isBoundAction2Hidden": true,
+  "isBoundAction3Hidden": false,
+}
+`;
+
 exports[`V4 Requestor can get the annotation file 1`] = `
 "<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
     <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
@@ -619,7 +636,7 @@ exports[`V4 Requestor get one data 1`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=2)",
   "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
-  "HasActiveEntity": true,
+  "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 2,
   "IsActiveEntity": true,
@@ -633,3 +650,20 @@ exports[`V4 Requestor get one data 1`] = `
 `;
 
 exports[`V4 Requestor get one data 2`] = `""`;
+
+exports[`V4 Requestor get one data 3`] = `
+{
+  "@odata.context": "$metadata#RootElement(ID=2)",
+  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
+  "HasActiveEntity": false,
+  "HasDraftEntity": false,
+  "ID": 2,
+  "IsActiveEntity": true,
+  "Prop1": "King of Tenant 003",
+  "Prop2": "Second Prop for Obj3",
+  "Sibling_ID": 1,
+  "isBoundAction1Hidden": true,
+  "isBoundAction2Hidden": true,
+  "isBoundAction3Hidden": false,
+}
+`;

--- a/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
+++ b/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
@@ -52,7 +52,7 @@ export abstract class ODataRequest<T> {
     /**
      *
      */
-    public async executeAsBatch(asChangeset: boolean = false): Promise<T> {
+    public async executeAsBatch(asChangeset: boolean = false, clientInfo: string = ''): Promise<T> {
         const boundary = 'batch_id-1624000588304-308';
         let changesetBoundary = '';
         if (asChangeset) {
@@ -68,7 +68,7 @@ export abstract class ODataRequest<T> {
             }),
             body: this.buildBatchContent(boundary, changesetBoundary)
         };
-        const response = await fetch(`${this.odataRootUri}/$batch`, fetchContent as any);
+        const response = await fetch(`${this.odataRootUri}/$batch${clientInfo}`, fetchContent as any);
         const contentType = response.headers.get('content-type');
         const responseBoundary = contentType?.split('boundary=')[1];
         const responseData = await response.text();

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
@@ -1,0 +1,8 @@
+module.exports = {
+    getInitialDataSet(tenantId) {
+        if (tenantId === 'tenant-003') {
+            return require('./tenant-003/RootElement.json');
+        }
+        return require('./RootElement.json');
+    }
+};

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
@@ -1,8 +1,10 @@
+const fs = require('fs');
+const path = require('path');
 module.exports = {
     getInitialDataSet(tenantId) {
         if (tenantId === 'tenant-003') {
             return require('./tenant-003/RootElement.json');
         }
-        return require('./RootElement.json');
+        return JSON.parse(fs.readFileSync(path.join(__dirname, 'RootElement.json')).toString('utf-8'));
     }
 };

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
@@ -1,7 +1,7 @@
 [
     {
         "ID": 1,
-        "Prop1": "SomethingElse",
+        "Prop1": "First Prop",
         "Prop2": "Second Prop",
         "isBoundAction1Hidden": false,
         "isBoundAction2Hidden": false,

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
@@ -1,7 +1,7 @@
 [
     {
         "ID": 1,
-        "Prop1": "First Prop",
+        "Prop1": "SomethingElse",
         "Prop2": "Second Prop",
         "isBoundAction1Hidden": false,
         "isBoundAction2Hidden": false,

--- a/packages/fe-mockserver-core/test/unit/__testData/tenant-003/RootElement.json
+++ b/packages/fe-mockserver-core/test/unit/__testData/tenant-003/RootElement.json
@@ -1,0 +1,11 @@
+[
+    {
+        "ID": 2,
+        "Prop1": "King of Tenant 003",
+        "Prop2": "Second Prop for Obj3",
+        "isBoundAction1Hidden": true,
+        "isBoundAction2Hidden": true,
+        "isBoundAction3Hidden": false,
+        "Sibling_ID": 1
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -131,6 +131,15 @@ describe('V4 Requestor', function () {
         dataRequestor = new ODataV4Requestor('http://localhost:33331/tenant-002/sap/fe/core/mock/action');
         dataRes = await dataRequestor.getObject<any>('RootElement', { ID: 233 }).executeAsBatch();
         expect(dataRes).toMatchSnapshot();
+
+        dataRequestor = new ODataV4Requestor('http://localhost:33331/tenant-003/sap/fe/core/mock/action');
+        dataRes = await dataRequestor.getObject<any>('RootElement', { ID: 2 }).executeAsBatch();
+        expect(dataRes).toMatchSnapshot();
+        dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');
+        const dataResClient = await dataRequestor
+            .getObject<any>('RootElement', { ID: 2 })
+            .executeAsBatch(false, '?sap-client=003');
+        expect(dataResClient).toEqual(dataRes);
     });
 
     it('can create data through a call', async () => {


### PR DESCRIPTION
This makes for a nicer and simpler usage than with the tenant-xxx in the url as this is handled natively by ui5 and passed down to the proper channels.