### PR TITLE
feat(mockserver): Add feature CSRF token

### DIFF
--- a/.changeset/khaki-poems-confess.md
+++ b/.changeset/khaki-poems-confess.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+feat(mockserver): Add feature CSRF token

--- a/packages/fe-mockserver-core/package.json
+++ b/packages/fe-mockserver-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sap-ux/fe-mockserver-core",
-    "version": "1.1.39",
+    "version": "1.1.40",
     "description": "SAP Fiori OData - Fiori elements mock server core",
     "repository": {
         "type": "git",

--- a/packages/fe-mockserver-core/package.json
+++ b/packages/fe-mockserver-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sap-ux/fe-mockserver-core",
-    "version": "1.1.40",
+    "version": "1.1.39",
     "description": "SAP Fiori OData - Fiori elements mock server core",
     "repository": {
         "type": "git",

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -58,6 +58,26 @@ describe('V4 Requestor', function () {
         server.close(done);
     });
 
+    it('can get the XSRF token using HEAD', async () => {
+        const dataRes = await fetch('http://localhost:33331/sap/fe/core/mock/action', {
+            method: 'HEAD',
+            headers: new Headers({
+                'X-CSRF-Token': 'Fetch'
+            })
+        });
+        expect(dataRes.headers.get('X-CSRF-Token')).toBe('0504-71383');
+    });
+
+    it('can get the XSRF token using GET', async () => {
+        const dataRes = await fetch('http://localhost:33331/sap/fe/core/mock/action', {
+            method: 'GET',
+            headers: new Headers({
+                'X-CSRF-Token': 'Fetch'
+            })
+        });
+        expect(dataRes.headers.get('X-CSRF-Token')).toBe('0504-71383');
+    });
+
     it('can get some data', async () => {
         const dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');
         const dataRes = await dataRequestor.getList<any>('RootElement').execute();


### PR DESCRIPTION
The CSRF token will be issued for a GET or HEAD
request to the service document.

The token will not be validated by the mock server.

Reason: Some client libraries expect the token to
be issued when requested