### PR TITLE
fix(fe-mockserver-core): endless recursion on services with multiple draft roots

### DIFF
--- a/.changeset/thick-dots-travel.md
+++ b/.changeset/thick-dots-travel.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Fix the draft root resolution in services with multiple draft roots

--- a/packages/fe-mockserver-core/test/unit/data/metadata.spec.ts
+++ b/packages/fe-mockserver-core/test/unit/data/metadata.spec.ts
@@ -1,0 +1,196 @@
+import CDSMetadataProvider from '@sap-ux/fe-mockserver-plugin-cds';
+import type { EntitySet } from '@sap-ux/vocabularies-types';
+import { join } from 'path';
+import { ODataMetadata } from '../../../src/data/metadata';
+import FileSystemLoader from '../../../src/plugins/fileSystemLoader';
+
+describe('resolveDraftRoot()', () => {
+    const baseDir = join(__dirname, 'metadata', 'resolveDraftRoot');
+    const fileLoader = new FileSystemLoader();
+    const metadataProvider = new CDSMetadataProvider(fileLoader);
+
+    describe('on a service with a single draft entity', () => {
+        let metadata: ODataMetadata;
+        let root: EntitySet;
+
+        beforeAll(async () => {
+            const edmx = await metadataProvider.loadMetadata(join(baseDir, 'SingleDraft.cds'));
+            metadata = await ODataMetadata.parse(edmx, `/TestService/$metadata`);
+            root = metadata.getEntitySet('DraftRoots')!;
+            expect(root.name).toEqual('DraftRoots');
+        });
+
+        test('should not resolve the root from a non-draft entity', async () => {
+            const entitySet = metadata.getEntitySet('OtherEntities');
+            expect(entitySet).toBeDefined();
+
+            const resolved = metadata.resolveDraftRoot(entitySet!);
+            expect(resolved.found).toBeFalsy();
+            expect(resolved.entitySet).toBeUndefined();
+            expect(resolved.path).toHaveLength(0);
+        });
+
+        test('should resolve the root directly', async () => {
+            const resolved = metadata.resolveDraftRoot(root);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(0);
+        });
+
+        test('should resolve the root from 1 level below', async () => {
+            const entitySet = metadata.getEntitySet('DraftNodes_1');
+            expect(entitySet).toBeDefined();
+
+            const resolved = metadata.resolveDraftRoot(entitySet!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(1);
+        });
+
+        test('should resolve the root from 2 levels below', async () => {
+            const entitySet = metadata.getEntitySet('DraftNodes_2');
+            expect(entitySet).toBeDefined();
+
+            const resolved = metadata.resolveDraftRoot(entitySet!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(2);
+        });
+    });
+
+    describe('on a service with multiple draft entities', () => {
+        let metadata: ODataMetadata;
+
+        beforeAll(async () => {
+            const edmx = await metadataProvider.loadMetadata(join(baseDir, 'MultiDraft.cds'));
+            metadata = await ODataMetadata.parse(edmx, `/TestService/$metadata`);
+        });
+
+        test('Draft 1: should resolve the root directly', async () => {
+            const root = metadata.getEntitySet('Draft_1_Roots');
+            expect(root?.name).toEqual('Draft_1_Roots');
+
+            const resolved = metadata.resolveDraftRoot(root!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(0);
+        });
+
+        test('Draft 1: should resolve the root from 1 level below', async () => {
+            const root = metadata.getEntitySet('Draft_1_Roots');
+            expect(root?.name).toEqual('Draft_1_Roots');
+
+            const entitySet = metadata.getEntitySet('Draft_1_Nodes_1');
+            expect(entitySet).toBeDefined();
+
+            const resolved = metadata.resolveDraftRoot(entitySet!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(1);
+        });
+
+        test('Draft 1: should resolve the root from 2 levels below', async () => {
+            const root = metadata.getEntitySet('Draft_1_Roots');
+            expect(root?.name).toEqual('Draft_1_Roots');
+
+            const entitySet = metadata.getEntitySet('Draft_1_Nodes_2');
+            expect(entitySet).toBeDefined();
+
+            const resolved = metadata.resolveDraftRoot(entitySet!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(2);
+        });
+
+        test('Draft 2: should resolve the root directly', async () => {
+            const root = metadata.getEntitySet('Draft_2_Roots');
+            expect(root?.name).toEqual('Draft_2_Roots');
+
+            const resolved = metadata.resolveDraftRoot(root!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(0);
+        });
+
+        test('Draft 2: should resolve the root from 1 level below', async () => {
+            const root = metadata.getEntitySet('Draft_2_Roots');
+            expect(root?.name).toEqual('Draft_2_Roots');
+
+            const entitySet = metadata.getEntitySet('Draft_2_Nodes_1');
+            expect(entitySet).toBeDefined();
+
+            const resolved = metadata.resolveDraftRoot(entitySet!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(1);
+        });
+
+        test('Draft 2: should resolve the root from 2 levels below', async () => {
+            const root = metadata.getEntitySet('Draft_2_Roots');
+            expect(root?.name).toEqual('Draft_2_Roots');
+
+            const entitySet = metadata.getEntitySet('Draft_2_Nodes_2');
+            expect(entitySet).toBeDefined();
+
+            const resolved = metadata.resolveDraftRoot(entitySet!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(2);
+        });
+    });
+
+    describe('on a service with multiple draft entities linked to each other', () => {
+        let metadata: ODataMetadata;
+
+        beforeAll(async () => {
+            const edmx = await metadataProvider.loadMetadata(join(baseDir, 'MultiDraftLinked.cds'));
+            metadata = await ODataMetadata.parse(edmx, `/TestService/$metadata`);
+        });
+
+        test('Draft 1: should resolve the root directly', async () => {
+            const root = metadata.getEntitySet('Draft_1_Roots');
+            expect(root?.name).toEqual('Draft_1_Roots');
+
+            const resolved = metadata.resolveDraftRoot(root!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(0);
+        });
+
+        test('Draft 1: should resolve the root from 1 level below', async () => {
+            const root = metadata.getEntitySet('Draft_1_Roots');
+            expect(root?.name).toEqual('Draft_1_Roots');
+
+            const entitySet = metadata.getEntitySet('Draft_1_Nodes_1');
+            expect(entitySet).toBeDefined();
+
+            const resolved = metadata.resolveDraftRoot(entitySet!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(1);
+        });
+
+        test('Draft 2: should resolve the root directly', async () => {
+            const root = metadata.getEntitySet('Draft_2_Roots');
+            expect(root?.name).toEqual('Draft_2_Roots');
+
+            const resolved = metadata.resolveDraftRoot(root!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(0);
+        });
+
+        test('Draft 2: should resolve the root from 1 level below', async () => {
+            const root = metadata.getEntitySet('Draft_2_Roots');
+            expect(root?.name).toEqual('Draft_2_Roots');
+
+            const entitySet = metadata.getEntitySet('Draft_2_Nodes_1');
+            expect(entitySet).toBeDefined();
+
+            const resolved = metadata.resolveDraftRoot(entitySet!);
+            expect(resolved.found).toBeTruthy();
+            expect(resolved.entitySet).toEqual(root);
+            expect(resolved.path).toHaveLength(1);
+        });
+    });
+});

--- a/packages/fe-mockserver-core/test/unit/data/metadata/resolveDraftRoot/MultiDraft.cds
+++ b/packages/fe-mockserver-core/test/unit/data/metadata/resolveDraftRoot/MultiDraft.cds
@@ -1,0 +1,48 @@
+// A service with two isolated draft roots (both draft objects are completely independent)
+service TestService {
+    /**
+     * Draft 1
+     */
+    @odata.draft.enabled
+    entity Draft_1_Roots {
+        key ID     : Integer;
+            _nodes : Composition of many Draft_1_Nodes_1
+                         on _nodes._parent = $self;
+    }
+
+    entity Draft_1_Nodes_1 {
+        key ID      : Integer;
+            _parent : Association to one Draft_1_Roots;
+            _nodes  : Composition of many Draft_1_Nodes_2
+                          on _nodes._parent = $self
+    }
+
+    entity Draft_1_Nodes_2 {
+        key ID      : Integer;
+            _parent : Association to one Draft_1_Nodes_1;
+    }
+
+
+    /**
+     * Draft 1
+     */
+    @odata.draft.enabled
+    entity Draft_2_Roots {
+        key ID     : Integer;
+            _nodes : Composition of many Draft_2_Nodes_1
+                         on _nodes._parent = $self;
+    }
+
+    entity Draft_2_Nodes_1 {
+        key ID      : Integer;
+            _parent : Association to one Draft_2_Roots;
+            _nodes  : Composition of many Draft_2_Nodes_2
+                          on _nodes._parent = $self
+    }
+
+    entity Draft_2_Nodes_2 {
+        key ID      : Integer;
+            _parent : Association to one Draft_2_Nodes_1;
+    }
+
+}

--- a/packages/fe-mockserver-core/test/unit/data/metadata/resolveDraftRoot/MultiDraftLinked.cds
+++ b/packages/fe-mockserver-core/test/unit/data/metadata/resolveDraftRoot/MultiDraftLinked.cds
@@ -1,0 +1,46 @@
+// A service with two draft roots linked to each other:
+//
+// Draft_1_Roots
+// +-- Draft_1_Nodes_1
+//       |
+//       | (assoc)
+//       | 
+//       V
+// Draft_2_Roots
+// +-- Draft_2_Nodes_1
+//
+service TestService {
+    /**
+     * Draft 1
+     */
+    @odata.draft.enabled
+    entity Draft_1_Roots {
+        key ID     : Integer;
+            _nodes : Composition of many Draft_1_Nodes_1
+                         on _nodes._parent = $self;
+    }
+
+    entity Draft_1_Nodes_1 {
+        key ID      : Integer;
+            _parent : Association to one Draft_1_Roots;
+            _draft2 : Association to one Draft_2_Roots;
+    }
+
+
+    /**
+     * Draft 1
+     */
+    @odata.draft.enabled
+    entity Draft_2_Roots {
+        key ID      : Integer;
+            _nodes  : Composition of many Draft_2_Nodes_1
+                          on _nodes._parent = $self;
+            _draft1 : Association to many Draft_1_Nodes_1
+                          on _draft1._draft2 = $self;
+    }
+
+    entity Draft_2_Nodes_1 {
+        key ID      : Integer;
+            _parent : Association to one Draft_2_Roots;
+    }
+}

--- a/packages/fe-mockserver-core/test/unit/data/metadata/resolveDraftRoot/SingleDraft.cds
+++ b/packages/fe-mockserver-core/test/unit/data/metadata/resolveDraftRoot/SingleDraft.cds
@@ -1,0 +1,26 @@
+// A service with a single draft root
+service TestService {
+    @odata.draft.enabled
+    entity DraftRoots {
+        key ID     : Integer;
+            _nodes : Composition of many DraftNodes_1
+                         on _nodes._parent = $self;
+            _other : Association to one OtherEntities;
+    }
+
+    entity DraftNodes_1 {
+        key ID      : Integer;
+            _parent : Association to one DraftRoots;
+            _nodes  : Composition of many DraftNodes_2
+                          on _nodes._parent = $self
+    }
+
+    entity DraftNodes_2 {
+        key ID      : Integer;
+            _parent : Association to one DraftNodes_1;
+    }
+
+    entity OtherEntities {
+        key ID : Integer;
+    }
+}


### PR DESCRIPTION
The draft root resolution sometimes failed when there were multiple draft roots in one service. For example, if two such draft sub-trees were linked by an navigation property.