### PR TITLE
fix: resolve the back navigation using partner first and then by entitytype

### DIFF
--- a/.changeset/tidy-crabs-work.md
+++ b/.changeset/tidy-crabs-work.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+fix: resolve the back navigation using partner first and then by entitytype

--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -285,9 +285,15 @@ export class DataAccess implements DataAccessInterface {
         } else {
             // Try to find a back link (a nav property going back to the original entityType)
             const originalData = cloneDeep(data);
-            const backNav: any = (navPropDetail.targetType as EntityType).navigationProperties.find(
-                (targetNavProp) => (targetNavProp as any).targetTypeName === currentEntityType.fullyQualifiedName
-            );
+            const backNav: NavigationProperty | undefined = (
+                navPropDetail.targetType as EntityType
+            ).navigationProperties.find((targetNavProp) => {
+                if (navPropDetail.partner) {
+                    return targetNavProp.name === navPropDetail.partner;
+                } else {
+                    return targetNavProp.targetTypeName === currentEntityType.fullyQualifiedName;
+                }
+            });
             if (backNav && backNav.referentialConstraint && backNav.referentialConstraint.length > 0) {
                 backNav.referentialConstraint.forEach((refConstr: ReferentialConstraint) => {
                     if (originalData[refConstr.targetProperty] !== undefined) {


### PR DESCRIPTION
Currently this was done only by entity type which could lead to some unwanted behavior