### PR TITLE
fix: an issue with the filter parser has been fixed

### DIFF
--- a/.changeset/rotten-trees-lie.md
+++ b/.changeset/rotten-trees-lie.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+An issue with the filter parser has been fixed

--- a/packages/fe-mockserver-core/src/request/filterParser.ts
+++ b/packages/fe-mockserver-core/src/request/filterParser.ts
@@ -30,7 +30,7 @@ const LITERAL = createToken({
 });
 //ee1a9172-f3c3-47ce-b0f7-dd28c740210c
 const LOGICAL_OPERATOR = createToken({ name: 'Logical', pattern: /(:?eq|ne|lt|le|gt|ge)/ });
-const ANDOR = createToken({ name: 'AndOr', pattern: /(:?and|or)/ });
+const ANDOR = createToken({ name: 'AndOr', pattern: /\s(:?and|or)\s/ });
 const WS = createToken({ name: 'Whitespace', pattern: /\s+/ });
 const filterTokens = [
     OPEN,
@@ -322,12 +322,10 @@ export class FilterParser extends EmbeddedActionsParser {
                 }
             ]);
             $.OPTION2(() => {
-                $.CONSUME3(WS);
                 operator = $.CONSUME(ANDOR);
-                $.CONSUME4(WS);
                 const subsubExpr = $.SUBRULE2($.boolCommonExpr);
                 let expressions: FilterExpression[];
-                let currentOperator = operator.image.toUpperCase();
+                let currentOperator = operator.image.trim().toUpperCase();
                 if (!subsubExpr.expressions && subExpr.expressions) {
                     expressions = [subExpr].concat([subsubExpr]);
                 } else if (

--- a/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
@@ -82,6 +82,13 @@ describe('Filter Parser', () => {
         expect(andOrPrecedence?.expressions[0].expressions.length).toBe(2);
         expect(andOrPrecedence?.expressions[0].operator).toBe('AND');
 
+        const andOrWithOverlappingName = parseFilter("companyCode eq '1510' and orderCompany eq '0015100001'");
+        expect(andOrWithOverlappingName?.operator).toBe('AND');
+        expect(andOrWithOverlappingName?.expressions.length).toBe(2);
+        expect(andOrWithOverlappingName?.expressions[0].identifier).toBe('companyCode');
+        expect(andOrWithOverlappingName?.expressions[0].literal).toBe("'1510'");
+        expect(andOrWithOverlappingName?.expressions[0].operator).toBe('eq');
+
         const andOrParenthesis = parseFilter('(IsHot eq false and IsHot eq true) or PeopleCount gt 3');
         expect(andOrParenthesis?.operator).toBe('OR');
         expect(andOrParenthesis?.expressions.length).toBe(2);


### PR DESCRIPTION
If one of the property identifier started with `or` or `and` the filter parser was unhappy