### PR TITLE
fix(@sap-ux/fe-mockserver-core): implicitly expand navigation properties used in a filter expression

### DIFF
--- a/.changeset/pink-cougars-end.md
+++ b/.changeset/pink-cougars-end.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+implicitly expand navigation properties needed for filter conditions

--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -449,12 +449,17 @@ export class DataAccess implements DataAccessInterface {
             for (const navProp of expandedNavProps) {
                 processedNavProps.push(navProp);
 
-                const subElement = element[navProp.name];
-                const subExpand = expandDefinition.expand[navProp.name];
-                if (Array.isArray(subElement)) {
-                    this.apply$Select(subExpand, subElement, navProp.targetType);
+                if (expandDefinition.expand[navProp.name].removeFromResult) {
+                    // delete the navigation property, it was expanded for internal reasons only
+                    delete element[navProp.name];
                 } else {
-                    this.apply$Select(subExpand, [subElement], navProp.targetType);
+                    const subElement = element[navProp.name];
+                    const subExpand = expandDefinition.expand[navProp.name];
+                    if (Array.isArray(subElement)) {
+                        this.apply$Select(subExpand, subElement, navProp.targetType);
+                    } else {
+                        this.apply$Select(subExpand, [subElement], navProp.targetType);
+                    }
                 }
             }
 

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -386,9 +386,6 @@ export class MockDataEntitySet implements EntitySetInterface {
         tenantId: string,
         odataRequest: ODataRequest
     ) {
-        const lambdaOperator = expression.operator;
-        let hasAnyValid = false;
-        let hasAllValid = true;
         let mockDataToCheckValue = identifierTransformation(getData(mockData, expression.target));
         if (!Array.isArray(mockDataToCheckValue)) {
             mockDataToCheckValue = [mockDataToCheckValue];
@@ -404,22 +401,19 @@ export class MockDataEntitySet implements EntitySetInterface {
             });
         }
 
-        mockDataToCheckValue.find((subMockData: any) => {
+        const check = (subMockData: any) => {
             let mockDataToCheck = subMockData;
             if (expression.key && expression.key.length > 0) {
                 mockDataToCheck = { [expression.key]: subMockData };
             }
-            const isEntryValid = this.checkFilter(mockDataToCheck, expression.expression, tenantId, odataRequest);
-            if (!isEntryValid) {
-                hasAllValid = false;
-            } else {
-                hasAnyValid = true;
-            }
-        });
-        if (lambdaOperator === 'ANY') {
-            return hasAnyValid;
-        } else {
-            return hasAllValid;
+            return this.checkFilter(mockDataToCheck, expression.expression, tenantId, odataRequest);
+        };
+
+        switch (expression.operator) {
+            case 'ALL':
+                return mockDataToCheckValue.every(check);
+            case 'ANY':
+                return mockDataToCheckValue.some(check);
         }
     }
 

--- a/packages/fe-mockserver-core/src/request/filterParser.ts
+++ b/packages/fe-mockserver-core/src/request/filterParser.ts
@@ -62,7 +62,7 @@ export type FilterMethodCall = {
 };
 export type LambdaExpression = {
     type: 'lambda';
-    operator: string;
+    operator: 'ALL' | 'ANY';
     key: string;
     expression: FilterExpression;
     target: string;

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -483,17 +483,26 @@ export default class ODataRequest {
     }
 
     private addExpandForFilters() {
-        function expandPath(path: string, expands: Record<string, ExpandDefinition>, lambdaVariable?: string) {
+        function expandPath(
+            path: string,
+            expands: Record<string, ExpandDefinition>,
+            lambdaVariable?: string,
+            skipLast?: boolean
+        ) {
             const segments = path.split('/');
             if (segments[0] === lambdaVariable) {
                 segments.shift();
+            }
+
+            if (skipLast) {
+                segments.pop();
             }
 
             let target = expands;
             for (const segment of segments) {
                 target[segment] = target[segment] ?? {
                     expand: {},
-                    properties: {},
+                    properties: { '*': true },
                     removeFromResult: true
                 };
                 target = target[segment].expand;
@@ -507,7 +516,7 @@ export default class ODataRequest {
             lambdaVariable?: string
         ) {
             if (typeof expression.identifier === 'string') {
-                expandPath(expression.identifier, expandDefinitions, lambdaVariable);
+                expandPath(expression.identifier, expandDefinitions, lambdaVariable, true);
             } else if (expression.identifier?.type === 'lambda') {
                 const target = expandPath(expression.identifier.target, expandDefinitions, lambdaVariable);
 

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -12,6 +12,7 @@ import { URL } from 'url';
 export type ExpandDefinition = {
     expand: Record<string, ExpandDefinition>;
     properties: Record<string, boolean>;
+    removeFromResult?: boolean;
 };
 
 type ODataRequestContent = {

--- a/packages/fe-mockserver-core/test/unit/request/__snapshots__/odataRequest.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/request/__snapshots__/odataRequest.test.ts.snap
@@ -1,0 +1,533 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OData Request It can parse $filter $filter=collection/any(d:d gt 0) 1`] = `
+{
+  "expandProperties": {
+    "collection": {
+      "expand": {},
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d",
+                "literal": "0",
+                "operator": "gt",
+              },
+            ],
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection",
+          "type": "lambda",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=collection/any(d:d/collection/all(e:e gt 0)) 1`] = `
+{
+  "expandProperties": {
+    "collection": {
+      "expand": {
+        "collection": {
+          "expand": {},
+          "properties": {
+            "*": true,
+          },
+          "removeFromResult": true,
+        },
+      },
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": {
+                  "expression": {
+                    "expressions": [
+                      {
+                        "identifier": "e",
+                        "literal": "0",
+                        "operator": "gt",
+                      },
+                    ],
+                  },
+                  "key": "e",
+                  "operator": "ALL",
+                  "target": "d/collection",
+                  "type": "lambda",
+                },
+              },
+            ],
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection",
+          "type": "lambda",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=collection/any(d:d/single1/single2/value gt 0) 1`] = `
+{
+  "expandProperties": {
+    "collection": {
+      "expand": {
+        "single1": {
+          "expand": {
+            "single2": {
+              "expand": {},
+              "properties": {
+                "*": true,
+              },
+              "removeFromResult": true,
+            },
+          },
+          "properties": {
+            "*": true,
+          },
+          "removeFromResult": true,
+        },
+      },
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d/single1/single2/value",
+                "literal": "0",
+                "operator": "gt",
+              },
+            ],
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection",
+          "type": "lambda",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=collection/any(d:d/value gt 0 and d/collection/all(e:e/value eq 1) 1`] = `
+{
+  "expandProperties": {
+    "collection": {
+      "expand": {
+        "collection": {
+          "expand": {},
+          "properties": {
+            "*": true,
+          },
+          "removeFromResult": true,
+        },
+      },
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d/value",
+                "literal": "0",
+                "operator": "gt",
+              },
+              {
+                "identifier": {
+                  "expression": {
+                    "expressions": [
+                      {
+                        "identifier": "e/value",
+                        "literal": "1",
+                        "operator": "eq",
+                      },
+                    ],
+                  },
+                  "key": "e",
+                  "operator": "ALL",
+                  "target": "d/collection",
+                  "type": "lambda",
+                },
+              },
+            ],
+            "operator": "AND",
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection",
+          "type": "lambda",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=collection/any(d:d/value gt 0 and d/single/value eq 1) 1`] = `
+{
+  "expandProperties": {
+    "collection": {
+      "expand": {
+        "single": {
+          "expand": {},
+          "properties": {
+            "*": true,
+          },
+          "removeFromResult": true,
+        },
+      },
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d/value",
+                "literal": "0",
+                "operator": "gt",
+              },
+              {
+                "identifier": "d/single/value",
+                "literal": "1",
+                "operator": "eq",
+              },
+            ],
+            "operator": "AND",
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection",
+          "type": "lambda",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=collection/any(d:d/value gt 0) 1`] = `
+{
+  "expandProperties": {
+    "collection": {
+      "expand": {},
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d/value",
+                "literal": "0",
+                "operator": "gt",
+              },
+            ],
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection",
+          "type": "lambda",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=collection/any(d:d/value1 gt 0)&$expand=collection($select=value2) 1`] = `
+{
+  "expandProperties": {
+    "collection": {
+      "expand": {},
+      "properties": {
+        "value2": true,
+      },
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d/value1",
+                "literal": "0",
+                "operator": "gt",
+              },
+            ],
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection",
+          "type": "lambda",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=collection1/any(d:d/value gt 0) and collection2/any(d:d/value eq 1) 1`] = `
+{
+  "expandProperties": {
+    "collection1": {
+      "expand": {},
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+    "collection2": {
+      "expand": {},
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d/value",
+                "literal": "0",
+                "operator": "gt",
+              },
+            ],
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection1",
+          "type": "lambda",
+        },
+      },
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d/value",
+                "literal": "1",
+                "operator": "eq",
+              },
+            ],
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection2",
+          "type": "lambda",
+        },
+      },
+    ],
+    "operator": "AND",
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=collection1/any(d:d/value1 gt 0)&$expand=collection2 1`] = `
+{
+  "expandProperties": {
+    "collection1": {
+      "expand": {},
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+    "collection2": {
+      "expand": {},
+      "properties": {
+        "*": true,
+      },
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d/value1",
+                "literal": "0",
+                "operator": "gt",
+              },
+            ],
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "collection1",
+          "type": "lambda",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=single/value eq 0 1`] = `
+{
+  "expandProperties": {
+    "single": {
+      "expand": {},
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": "single/value",
+        "literal": "0",
+        "operator": "eq",
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=single/value eq 0&$expand=single($select=other) 1`] = `
+{
+  "expandProperties": {
+    "single": {
+      "expand": {},
+      "properties": {
+        "other": true,
+      },
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": "single/value",
+        "literal": "0",
+        "operator": "eq",
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=single1/single2/collection/any(d:d/value gt 0) 1`] = `
+{
+  "expandProperties": {
+    "single1": {
+      "expand": {
+        "single2": {
+          "expand": {
+            "collection": {
+              "expand": {},
+              "properties": {
+                "*": true,
+              },
+              "removeFromResult": true,
+            },
+          },
+          "properties": {
+            "*": true,
+          },
+          "removeFromResult": true,
+        },
+      },
+      "properties": {
+        "*": true,
+      },
+      "removeFromResult": true,
+    },
+  },
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": {
+          "expression": {
+            "expressions": [
+              {
+                "identifier": "d/value",
+                "literal": "0",
+                "operator": "gt",
+              },
+            ],
+          },
+          "key": "d",
+          "operator": "ANY",
+          "target": "single1/single2/collection",
+          "type": "lambda",
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`OData Request It can parse $filter $filter=value eq 0 1`] = `
+{
+  "expandProperties": {},
+  "filterDefinition": {
+    "expressions": [
+      {
+        "identifier": "value",
+        "literal": "0",
+        "operator": "eq",
+      },
+    ],
+  },
+}
+`;

--- a/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
@@ -399,4 +399,35 @@ describe('OData Request', () => {
             }
         `);
     });
+
+    // $filter
+    describe('It can parse $filter', () => {
+        const $filterTestCases: { query: string }[] = [
+            // simple filters
+            { query: '$filter=value eq 0' },
+            { query: '$filter=single/value eq 0' },
+            { query: '$filter=single/value eq 0&$expand=single($select=other)' },
+
+            // lambda
+            { query: '$filter=collection/any(d:d gt 0)' },
+            { query: '$filter=collection/any(d:d/value gt 0)' },
+            { query: '$filter=collection/any(d:d/value gt 0 and d/single/value eq 1)' },
+            { query: '$filter=collection/any(d:d/collection/all(e:e gt 0))' },
+            { query: '$filter=collection1/any(d:d/value gt 0) and collection2/any(d:d/value eq 1)' },
+            { query: '$filter=single1/single2/collection/any(d:d/value gt 0)' },
+            { query: '$filter=collection/any(d:d/single1/single2/value gt 0)' },
+            { query: '$filter=collection/any(d:d/value gt 0 and d/collection/all(e:e/value eq 1)' },
+            { query: '$filter=collection/any(d:d/value1 gt 0)&$expand=collection($select=value2)' },
+            { query: '$filter=collection1/any(d:d/value1 gt 0)&$expand=collection2' }
+        ];
+
+        test.each($filterTestCases)('$query', ({ query }) => {
+            const request = new ODataRequest({ method: 'GET', url: `/Entities?${query}` }, fakeDataAccess);
+
+            expect({
+                expandProperties: request.expandProperties, // $filter can affect the expandProperties
+                filterDefinition: request.filterDefinition
+            }).toMatchSnapshot();
+        });
+    });
 });

--- a/packages/fe-mockserver-core/test/unit/v4/__snapshots__/dataAccess.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/v4/__snapshots__/dataAccess.test.ts.snap
@@ -529,6 +529,313 @@ exports[`Data Access $select handling with structured complex types can read /A?
 ]
 `;
 
+exports[`Data Access additional $filter tests GET /Entities?$filter=collectionProperty1/all(d:d gt 0) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=collectionProperty1/any(d:d gt 0) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=collectionProperty2/all(d:d/value gt 0) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=collectionProperty2/all(d:d/value gt 0) and navigationProperty1/all(f:f/value eq 1) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=collectionProperty2/any(d:d/value gt 0) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/all(d:d/collectionProperty1/all(e:e gt 0)) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/all(d:d/collectionProperty1/any(e:e gt 0)) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/all(d:d/collectionProperty2/all(e:e/value gt 0)) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/all(d:d/collectionProperty2/any(e:e/value gt 0)) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/all(d:d/navigationProperty1/all(e:e/value gt 0)) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/all(d:d/navigationProperty1/any(e:e/value gt 0)) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/all(d:d/value gt 0) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/collectionProperty1/all(e:e gt 1)) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/collectionProperty1/any(e:e gt 0)) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+  {
+    "ID": "B",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/collectionProperty2/all(e:e/value gt 1)) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/collectionProperty2/any(e:e/value gt 0)) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+  {
+    "ID": "B",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/navigationProperty1/all(e:e/value gt 1)) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/navigationProperty1/any(e:e/value gt 0)) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+  {
+    "ID": "B",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/parent/navigationProperty2/value gt 0) 1`] = `
+[
+  {
+    "ID": "B",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/value gt 0 and d/navigationProperty2/value eq 1) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/value gt 0) 1`] = `
+[
+  {
+    "ID": "A",
+  },
+  {
+    "ID": "B",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty1/any(d:d/value gt 0)&$expand=navigationProperty1($select=ID),navigationProperty2 1`] = `
+[
+  {
+    "ID": "A",
+    "navigationProperty1": [
+      {
+        "ID": "AA",
+      },
+      {
+        "ID": "AB",
+      },
+    ],
+    "navigationProperty2": {
+      "ID": "AA",
+      "collectionProperty1": [
+        0,
+        1,
+      ],
+      "collectionProperty2": [
+        {
+          "value": 0,
+        },
+        {
+          "value": 1,
+        },
+      ],
+      "navigationProperty2_ID": "AA-A",
+      "parent_ID": "A",
+      "value": 0,
+    },
+  },
+  {
+    "ID": "B",
+    "navigationProperty1": [
+      {
+        "ID": "BA",
+      },
+    ],
+    "navigationProperty2": {
+      "ID": "AB",
+      "collectionProperty1": [
+        1,
+        1,
+      ],
+      "collectionProperty2": [
+        {
+          "value": 1,
+        },
+        {
+          "value": 1,
+        },
+      ],
+      "navigationProperty2_ID": "AB-A",
+      "parent_ID": "A",
+      "value": 1,
+    },
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty2/parent/navigationProperty1/all(d:d/value gt 0) 1`] = `
+[
+  {
+    "ID": "C",
+  },
+]
+`;
+
+exports[`Data Access additional $filter tests GET /Entities?$filter=navigationProperty2/value eq 0 1`] = `
+[
+  {
+    "ID": "A",
+  },
+]
+`;
+
 exports[`Data Access v4metadata - GET with $filter involving a navigation property that is null for some elements 1`] = `
 [
   {

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -368,6 +368,14 @@ describe('Data Access', () => {
             {
                 url: '/Entities?$filter=collectionProperty2/all(d:d/value gt 0) and navigationProperty1/all(f:f/value eq 1)',
                 expected: ['B', 'C']
+            },
+            {
+                url: '/Entities?$filter=navigationProperty2/parent/navigationProperty1/all(d:d/value gt 0)',
+                expected: ['C']
+            },
+            {
+                url: '/Entities?$filter=navigationProperty1/any(d:d/parent/navigationProperty2/value gt 0)',
+                expected: ['B']
             }
         ];
 

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -286,6 +286,8 @@ describe('Data Access', () => {
         );
         expect(countryData.length).toEqual(1);
         expect(countryData[0].Name).toEqual('Latvia');
+
+        ///CountryCodes/any(ent:ent eq 'GBR')
     });
     test('v4metadata - GET with $filter involving a navigation property that is null for some elements', async () => {
         const formRootData = await dataAccess.getData(
@@ -293,7 +295,28 @@ describe('Data Access', () => {
         );
         expect(formRootData).toMatchSnapshot();
     });
-
+    test('v4metadata - it can GET data for an entity with lambda operator', async () => {
+        let countryData;
+        countryData = await dataAccess.getData(
+            new ODataRequest(
+                { method: 'GET', url: "/Countries?$filter=SpokenLanguages/any(ent:ent eq 'English')" },
+                dataAccess
+            )
+        );
+        expect(countryData.length).toEqual(4);
+        expect(countryData[0].Name).toEqual('Germany');
+        expect(countryData[1].Name).toEqual('India');
+        expect(countryData[2].Name).toEqual('Ireland');
+        expect(countryData[3].Name).toEqual('U S A');
+        countryData = await dataAccess.getData(
+            new ODataRequest(
+                { method: 'GET', url: "/Countries?$filter=SpokenLanguages/all(ent:ent eq 'English')" },
+                dataAccess
+            )
+        );
+        expect(countryData.length).toEqual(1);
+        expect(countryData[0].Name).toEqual('U S A');
+    });
     describe('additional $filter tests', () => {
         let dataAccess!: DataAccess;
 

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -338,6 +338,10 @@ describe('Data Access', () => {
 
             { url: '/Entities?$filter=navigationProperty1/any(d:d/value gt 0)', expected: ['A', 'B'] },
             { url: '/Entities?$filter=navigationProperty1/all(d:d/value gt 0)', expected: ['B', 'C'] },
+            {
+                url: '/Entities?$filter=navigationProperty1/any(d:d/value gt 0 and d/navigationProperty2/value eq 1)',
+                expected: ['A']
+            },
 
             {
                 url: '/Entities?$filter=navigationProperty1/any(d:d/collectionProperty1/any(e:e gt 0))',

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -327,7 +327,7 @@ describe('Data Access', () => {
             dataAccess = new DataAccess({ mockdataPath: baseDir } as ServiceConfig, metadata, fileLoader);
         });
 
-        const cases: { url: string; expected: string[] }[] = [
+        const cases = [
             { url: '/Entities?$filter=navigationProperty2/value eq 0', expected: ['A'] },
 
             { url: '/Entities?$filter=collectionProperty1/any(d:d gt 0)', expected: ['A', 'B', 'C'] },
@@ -403,17 +403,19 @@ describe('Data Access', () => {
             {
                 url: '/Entities?$filter=navigationProperty1/any(d:d/parent/navigationProperty2/value gt 0)',
                 expected: ['B']
+            },
+            {
+                url: '/Entities?$filter=navigationProperty1/any(d:d/value gt 0)&$expand=navigationProperty1($select=ID),navigationProperty2',
+                expected: ['A', 'B']
             }
         ];
 
         test.each(cases)('GET $url', async ({ url, expected }) => {
-            const result = await dataAccess.getData(new ODataRequest({ method: 'GET', url }, dataAccess));
+            const result = await dataAccess.getData(
+                new ODataRequest({ method: 'GET', url: url + '&$select=ID' }, dataAccess)
+            );
             expect(result).toMatchObject(expected.map((e) => ({ ID: e })));
-
-            for (const entry of result) {
-                expect(entry).not.toHaveProperty('navigationProperty1');
-                expect(entry).not.toHaveProperty('navigationProperty2');
-            }
+            expect(result).toMatchSnapshot();
         });
     });
 

--- a/packages/fe-mockserver-core/test/unit/v4/services/$filter-tests/AssociatedEntities1.json
+++ b/packages/fe-mockserver-core/test/unit/v4/services/$filter-tests/AssociatedEntities1.json
@@ -1,0 +1,25 @@
+[
+    {
+        "ID": "AA",
+        "parent_ID": "A",
+        "value": 0,
+        "collectionProperty1": [0, 1],
+        "collectionProperty2": [{ "value": 0 }, { "value": 1 }],
+        "navigationProperty2_ID": "AA-A"
+    },
+    {
+        "ID": "AB",
+        "parent_ID": "A",
+        "value": 1,
+        "collectionProperty1": [1, 1],
+        "collectionProperty2": [{ "value": 1 }, { "value": 1 }],
+        "navigationProperty2_ID": "AB-A"
+    },
+    {
+        "ID": "BA",
+        "parent_ID": "B",
+        "value": 1,
+        "collectionProperty1": [2, 3],
+        "collectionProperty2": [{ "value": 2 }, { "value": 3 }]
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/v4/services/$filter-tests/AssociatedEntities2.json
+++ b/packages/fe-mockserver-core/test/unit/v4/services/$filter-tests/AssociatedEntities2.json
@@ -1,0 +1,22 @@
+[
+    {
+        "ID": "AA-A",
+        "parent_ID": "AA",
+        "value": 0
+    },
+    {
+        "ID": "AA-B",
+        "parent_ID": "AA",
+        "value": 1
+    },
+    {
+        "ID": "AB-A",
+        "parent_ID": "AB",
+        "value": 1
+    },
+    {
+        "ID": "BB-A",
+        "parent_ID": "BA",
+        "value": 2
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/v4/services/$filter-tests/Entities.json
+++ b/packages/fe-mockserver-core/test/unit/v4/services/$filter-tests/Entities.json
@@ -1,0 +1,23 @@
+[
+    {
+        "ID": "A",
+        "value": 0,
+        "collectionProperty1": [0, 1],
+        "collectionProperty2": [{ "value": 0 }, { "value": 1 }],
+        "navigationProperty2_ID": "AA"
+    },
+    {
+        "ID": "B",
+        "value": 1,
+        "collectionProperty1": [1, 1],
+        "collectionProperty2": [{ "value": 1 }, { "value": 1 }],
+        "navigationProperty2_ID": "AB"
+    },
+    {
+        "ID": "C",
+        "value": 2,
+        "collectionProperty1": [2, 2],
+        "collectionProperty2": [{ "value": 2 }, { "value": 2 }],
+        "navigationProperty2_ID": "BA"
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/v4/services/$filter-tests/service.cds
+++ b/packages/fe-mockserver-core/test/unit/v4/services/$filter-tests/service.cds
@@ -1,0 +1,49 @@
+service FilterTest {
+    entity Entities {
+        key ID                  :      String;
+            // primitive property
+            value               :      Integer;
+            // collection of a primitive type
+            collectionProperty1 : many Integer;
+
+            // collection of a complex type
+            collectionProperty2 : many {
+                value : Integer;
+            };
+
+            // 1:n navigation property
+            navigationProperty1 :      Composition of many AssociatedEntities1
+                                           on navigationProperty1.parent = $self;
+
+            // 1:1 navigation property
+            navigationProperty2 :      Composition of one AssociatedEntities1;
+    }
+
+    entity AssociatedEntities1 {
+        key ID                  :      String;
+            parent              :      Association to one Entities;
+            // primitive property
+            value               :      Integer;
+            // collection of a primitive type
+            collectionProperty1 : many Integer;
+
+            // collection of a complex type
+            collectionProperty2 : many {
+                value : Integer;
+            };
+
+            // 1:n navigation property
+            navigationProperty1  :      Composition of many AssociatedEntities2
+                                           on navigationProperty1.parent = $self;
+
+            // 1:1 navigation property
+            navigationProperty2 :      Composition of one AssociatedEntities2;
+    }
+
+    entity AssociatedEntities2 {
+        key ID     : String;
+            parent : Association to one AssociatedEntities1;
+            // primitive property
+            value  : Integer;
+    }
+}


### PR DESCRIPTION
This PR fixes a limitation on `$filter` expressions. In order to properly apply the filter condition, all data must be available at the time the filter is evaluated. This was only the case when the client requested that data by a corresponding `$expand` parameter.

That is,

`/Entities?$filter=navigationProperty2/value eq 0` and
`/Entities?$filter=navigationProperty2/value eq 0&$expand=navigationProperty2`
probably resulted in a different number of entries.

The mockserver now makes sure that the required data is available to the filters.