### PR TITLE
fix(@sap-ux/annotation-converter): resolve @UI.DataFieldForAction.Action if it uses a fully-qualified bound action reference

### DIFF
--- a/.changeset/lucky-olives-jump.md
+++ b/.changeset/lucky-olives-jump.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-converter': patch
+---
+
+DataFieldForAction annotations are now resolved correctly if the action is bound to a different entity type

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -607,12 +607,18 @@ function parseRecord(
                 context.additionalAnnotations.push(subAnnotationList);
             }
             if (isDataFieldWithForAction(annotationContent, annotationTerm)) {
-                // try to resolve to a bound action
+                // try to resolve to a bound action of the annotation target
                 annotationContent.ActionTarget = context.currentTarget.actions?.[annotationContent.Action];
 
-                // try to resolve to an unbound action (annotation must point to an ActionImport)
                 if (!annotationContent.ActionTarget) {
-                    annotationContent.ActionTarget = objectMap[annotationContent.Action]?.action;
+                    const action = objectMap[annotationContent.Action];
+                    if (action?.isBound) {
+                        // bound action of a different entity type
+                        annotationContent.ActionTarget = action;
+                    } else if (action) {
+                        // unbound action --> resolve via the action import
+                        annotationContent.ActionTarget = action.action;
+                    }
                 }
 
                 if (!annotationContent.ActionTarget) {

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -684,11 +684,13 @@ describe('Annotation Converter', () => {
         expect(dataFields1[1].ActionTarget).toBe(getAction('TestService.function(TestService.Entity1)'));
         expect(dataFields1[2].ActionTarget).toBe(getAction('TestService.action'));
         expect(dataFields1[3].ActionTarget).toBe(getAction('TestService.function'));
+        expect(dataFields1[4].ActionTarget).toBe(getAction('TestService.action(TestService.Entity1)'));
 
         const dataFields2 = convertedTypes.entityTypes[1]?.annotations.UI?.LineItem as DataFieldForAction[];
         expect(dataFields2[0].ActionTarget).toBe(getAction('TestService.action(TestService.Entity2)'));
         expect(dataFields2[1].ActionTarget).toBe(getAction('TestService.function(TestService.Entity2)'));
         expect(dataFields2[2].ActionTarget).toBe(getAction('TestService.action'));
         expect(dataFields2[3].ActionTarget).toBe(getAction('TestService.function'));
+        expect(dataFields2[4].ActionTarget).toBe(getAction('TestService.action(TestService.Entity1)'));
     });
 });

--- a/packages/annotation-converter/test/fixtures/v4/actions-and-functions-overload.cds
+++ b/packages/annotation-converter/test/fixtures/v4/actions-and-functions-overload.cds
@@ -17,48 +17,58 @@ service TestService {
     function function() returns Integer;
 }
 
-annotate TestService.Entity1 with @UI.LineItem : [
+annotate TestService.Entity1 with @UI.LineItem: [
     {
-        $Type  : 'UI.DataFieldForAction',
-        Label  : 'Bound Action',
-        Action : 'TestService.action',
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Bound Action',
+        Action: 'TestService.action',
     },
     {
-        $Type  : 'UI.DataFieldForAction',
-        Label  : 'Bound Function',
-        Action : 'TestService.function',
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Bound Function',
+        Action: 'TestService.function',
     },
     {
-        $Type  : 'UI.DataFieldForAction',
-        Label  : 'Unbound Action via ActionImport',
-        Action : 'TestService.EntityContainer/action',
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Unbound Action via ActionImport',
+        Action: 'TestService.EntityContainer/action',
     },
     {
-        $Type  : 'UI.DataFieldForAction',
-        Label  : 'Unbound Function via ActionImport',
-        Action : 'TestService.EntityContainer/function',
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Unbound Function via ActionImport',
+        Action: 'TestService.EntityContainer/function',
+    },
+    {
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Bound action of the same entity type (explicit reference)',
+        Action: 'TestService.action(TestService.Entity1)',
     },
 ];
 
-annotate TestService.Entity2 with @UI.LineItem : [
+annotate TestService.Entity2 with @UI.LineItem: [
     {
-        $Type  : 'UI.DataFieldForAction',
-        Label  : 'Bound Action',
-        Action : 'TestService.action',
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Bound Action',
+        Action: 'TestService.action',
     },
     {
-        $Type  : 'UI.DataFieldForAction',
-        Label  : 'Bound Function',
-        Action : 'TestService.function',
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Bound Function',
+        Action: 'TestService.function',
     },
     {
-        $Type  : 'UI.DataFieldForAction',
-        Label  : 'Unbound Action via ActionImport',
-        Action : 'TestService.EntityContainer/action',
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Unbound Action via ActionImport',
+        Action: 'TestService.EntityContainer/action',
     },
     {
-        $Type  : 'UI.DataFieldForAction',
-        Label  : 'Unbound Function via ActionImport',
-        Action : 'TestService.EntityContainer/function',
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Unbound Function via ActionImport',
+        Action: 'TestService.EntityContainer/function',
+    },
+    {
+        $Type : 'UI.DataFieldForAction',
+        Label : 'Bound action of a different entity type',
+        Action: 'TestService.action(TestService.Entity1)',
     },
 ];

--- a/packages/annotation-converter/test/fixtures/v4/actions-and-functions-overload.xml
+++ b/packages/annotation-converter/test/fixtures/v4/actions-and-functions-overload.xml
@@ -3,6 +3,9 @@
   <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
     <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
   </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+  </edmx:Reference>
   <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
     <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
   </edmx:Reference>
@@ -63,6 +66,10 @@
               <PropertyValue Property="Label" String="Unbound Function via ActionImport"/>
               <PropertyValue Property="Action" String="TestService.EntityContainer/function"/>
             </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Bound action of the same entity type (explicit reference)"/>
+              <PropertyValue Property="Action" String="TestService.action(TestService.Entity1)"/>
+            </Record>
           </Collection>
         </Annotation>
       </Annotations>
@@ -84,6 +91,10 @@
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Unbound Function via ActionImport"/>
               <PropertyValue Property="Action" String="TestService.EntityContainer/function"/>
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Bound action of a different entity type"/>
+              <PropertyValue Property="Action" String="TestService.action(TestService.Entity1)"/>
             </Record>
           </Collection>
         </Annotation>


### PR DESCRIPTION
The annotation converter only resolved bound actions of the annotation target (@UI.DataFieldForAction on entity A --> only consider actions bound to entity A). With this change it also resolves actions bound to other entity types if they are referenced by `<action FQN>(<other entity FQN>)`.