### PR TITLE
fix: Fixed an issue with the filter containing a # character

### DIFF
--- a/.changeset/moody-badgers-jump.md
+++ b/.changeset/moody-badgers-jump.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Fixed an issue with the parsing when the filter contained a # character

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -67,16 +67,14 @@ export default class ODataRequest {
     private messages: any[] = [];
 
     constructor(private requestContent: ODataRequestContent, private dataAccess: DataAccess) {
-        const decodedUrl = decodeURIComponent(requestContent.url);
-        const parsedUrl = new URL(`http://dummy${decodedUrl}`);
-        const undecodedParsedUrl = new URL(`http://dummy${requestContent.url}`);
+        const parsedUrl = new URL(`http://dummy${requestContent.url}`);
         this.tenantId = requestContent.tenantId || 'tenant-default';
         this.context = requestContent.url.split('?')[0].substring(1);
         if (this.tenantId) {
             this.addResponseHeader('sap-tenantid', this.tenantId);
         }
         this.isMinimalRepresentation = requestContent.headers?.['prefer'] === 'return=minimal';
-        this.queryPath = this.parsePath(undecodedParsedUrl.pathname.substring(1));
+        this.queryPath = this.parsePath(parsedUrl.pathname.substring(1));
         this.parseParameters(parsedUrl.searchParams);
     }
 

--- a/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
@@ -70,6 +70,32 @@ describe('OData Request', () => {
               ],
             }
         `);
+        const myOtherRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: `/Countries?$filter=SalesOrderType_Text%20eq%20'Standard%20Order%20(OR)%23'&search=Value1`
+            },
+            fakeDataAccess
+        );
+        expect(myOtherRequest.queryPath).toMatchInlineSnapshot(`
+            [
+              {
+                "keys": {},
+                "path": "Countries",
+              },
+            ]
+        `);
+        expect(myOtherRequest.filterDefinition).toMatchInlineSnapshot(`
+            {
+              "expressions": [
+                {
+                  "identifier": "SalesOrderType_Text",
+                  "literal": "'Standard Order (OR)#'",
+                  "operator": "eq",
+                },
+              ],
+            }
+        `);
     });
 
     test('It can parse $orderby', () => {


### PR DESCRIPTION
When the filter contained a hashbang character the parsing was cut short and created issue in the filter parser.
This is now fixed