### PR TITLE
fix(@sap-ux/annotation-converter): Resolve annotations on properties of complex types

### DIFF
--- a/.changeset/fast-bananas-shave.md
+++ b/.changeset/fast-bananas-shave.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-converter': patch
+---
+
+Annotations on properties of a ComplexType are now resolved

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -113,8 +113,10 @@ function resolveTarget<T>(
         // annotation: start at the annotation target
         startElement = startElement[ANNOTATION_TARGET];
     } else if (startElement._type === 'Property') {
-        // property: start at the entity type the property belongs to
-        startElement = converter.getConvertedEntityType(substringBeforeFirst(startElement.fullyQualifiedName, '/'));
+        // property: start at the entity type or complex type the property belongs to
+        const parentElementFQN = substringBeforeFirst(startElement.fullyQualifiedName, '/');
+        startElement =
+            converter.getConvertedEntityType(parentElementFQN) ?? converter.getConvertedComplexType(parentElementFQN);
     }
 
     const result = pathSegments.reduce(

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -972,4 +972,15 @@ describe('Annotation Converter', () => {
             entityType.annotations.UI?.Identification?.[0]?.annotations?.Analytics?.RolledUpPropertyCount?.valueOf()
         ).toEqual(11);
     });
+
+    it('Can handle annotations of complex types', async () => {
+        const parsedMetadata = parse(await loadFixture('v4/complexTypeAnnos.xml'));
+        const convertedTypes = convert(parsedMetadata);
+
+        const complexType = convertedTypes.complexTypes[0];
+        const property = complexType.properties.by_name('name');
+        expect(property).toBeDefined();
+        const annos = property?.annotations.Common?.Text;
+        expect(annos).toBeDefined();
+    });
 });

--- a/packages/annotation-converter/test/fixtures/v4/complexTypeAnnos.xml
+++ b/packages/annotation-converter/test/fixtures/v4/complexTypeAnnos.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer"/>
+      <ComplexType Name="testComplexType">
+        <Property Name="name" Type="Edm.String"/>
+        <Property Name="textDescription" Type="Edm.String"/>
+      </ComplexType>
+      <Annotations Target="TestService.testComplexType/name">
+        <Annotation Term="Common.Text" Path="textDescription"/>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
The converter assumed that all properties belong to an EntityType. It now considers ComplexTypes, too.