### PR TITLE
fix(@sap-ux/annotation-converter): Correctly return an undefined target when resolving an invalid path

### DIFF
--- a/.changeset/two-elephants-watch.md
+++ b/.changeset/two-elephants-watch.md
@@ -2,4 +2,5 @@
 '@sap-ux/annotation-converter': patch
 ---
 
-Invalid paths are now no longer resolved to the last valid segment
+* Invalid paths no longer resolve to their last valid segment, but return `undefined` instead
+* `undefined` is not pushed to the list of visited objects if path resolution fails 

--- a/.changeset/two-elephants-watch.md
+++ b/.changeset/two-elephants-watch.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-converter': patch
+---
+
+Invalid paths are now no longer resolved to the last valid segment

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -326,11 +326,15 @@ function resolveTarget<T>(
                     return current;
 
                 default:
+                    if (segment === '') {
+                        return current;
+                    }
+
                     if (current.target[segment]) {
                         current.target = current.target[segment];
                         current.objectPath = appendObjectPath(current.objectPath, current.target);
+                        return current;
                     }
-                    return current;
             }
 
             return error(

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -123,7 +123,6 @@ function resolveTarget<T>(
         (current: ResolutionTarget<any>, segment: string) => {
             const error = (message: string) => {
                 current.messages.push({ message });
-                current.objectPath = appendObjectPath(current.objectPath, undefined);
                 current.target = undefined;
                 return current;
             };

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -498,6 +498,16 @@ describe('Annotation Converter', () => {
             expect(target.visitedObjects.length).toEqual(1); // EntityType
             expect(target.target).toStrictEqual(entityType);
         });
+
+        it('correctly returns an undefined target for invalid paths', () => {
+            const entityType = convertedTypes.entityTypes[0];
+            expect(entityType).not.toBeNull();
+            expect(entityType).not.toBeUndefined();
+
+            const target = entityType.resolvePath('@com.sap.vocabularies.Common.v1.Label/XXXXXXXXX', true);
+            expect(target.target).toBeUndefined();
+            expect(target.visitedObjects.length).toEqual(3); // EntityType / Annotation / <undefined>
+        });
     });
 
     describe('can support resolution target for singleton as well', () => {

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -504,9 +504,15 @@ describe('Annotation Converter', () => {
             expect(entityType).not.toBeNull();
             expect(entityType).not.toBeUndefined();
 
-            const target = entityType.resolvePath('@com.sap.vocabularies.Common.v1.Label/XXXXXXXXX', true);
-            expect(target.target).toBeUndefined();
-            expect(target.visitedObjects.length).toEqual(3); // EntityType / Annotation / <undefined>
+            // invalid: target is undefined
+            const target1 = entityType.resolvePath('@com.sap.vocabularies.Common.v1.Label/XXXXXXXXX', true);
+            expect(target1.target).toBeUndefined();
+            expect(target1.visitedObjects.length).toEqual(2); // EntityType / Annotation
+
+            // but allow a slash at the end
+            const target2 = entityType.resolvePath('@com.sap.vocabularies.Common.v1.Label/', true);
+            expect(target2.target).toBeDefined();
+            expect(target2.visitedObjects.length).toEqual(2); // EntityType / Annotation
         });
     });
 


### PR DESCRIPTION
Previously resolution stopped at the last valid segment of the path