### PR TITLE
chore: Update Github actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
             # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v1
+              uses: github/codeql-action/autobuild@v2
 
             # ℹ️ Command-line programs to run using the OS shell.
             # 📚 https://git.io/JvXDl
@@ -66,4 +66,4 @@ jobs:
             #   make release
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v1
+              uses: github/codeql-action/analyze@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -88,7 +88,7 @@ jobs:
             - name: Apply changesets
               id: changesetVersion
               run: |
-                  echo ::set-output name=changes::$(pnpm ci:version 2>&1 | grep -q 'No unreleased changesets found' && echo 'false' || echo 'true')
+                  echo "changes=$(pnpm ci:version 2>&1 | grep -q 'No unreleased changesets found' && echo 'false' || echo 'true')" >> $GITHUB_OUTPUT
                   git status
             - name: Commit and push changes
               if: steps.changesetVersion.outputs.changes == 'true'


### PR DESCRIPTION
- [x] update github/codeql-action/* to v2
- [x] replace use of `set-output` (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)