### PR TITLE
fix(@sap-ux/annotation-converter): Remove the setter for lazy properties

### DIFF
--- a/packages/annotation-converter/src/utils.ts
+++ b/packages/annotation-converter/src/utils.ts
@@ -468,10 +468,6 @@ export function lazy<Type, Key extends keyof Type>(object: Type, property: Key, 
                 _value = init();
             }
             return _value;
-        },
-
-        set(value: Type[Key]) {
-            _value = value;
         }
     });
 }

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -21,7 +21,6 @@ import type {
     DataFieldForAction,
     DataFieldForActionTypes,
     DataFieldForAnnotation,
-    DataFieldWithAction,
     FieldGroupType,
     LineItem
 } from '@sap-ux/vocabularies-types/vocabularies/UI';
@@ -30,8 +29,8 @@ import {
     UIAnnotationTerms,
     UIAnnotationTypes
 } from '@sap-ux/vocabularies-types/vocabularies/UI';
-import { CommunicationAnnotationTypes } from '@sap-ux/vocabularies-types/vocabularies/Communication';
 import type { ContactType } from '@sap-ux/vocabularies-types/vocabularies/Communication';
+import { CommunicationAnnotationTypes } from '@sap-ux/vocabularies-types/vocabularies/Communication';
 import { CommonAnnotationTypes } from '@sap-ux/vocabularies-types/vocabularies/Common';
 
 describe('Annotation Converter', () => {
@@ -749,8 +748,12 @@ describe('Annotation Converter', () => {
 
         if (convertedTypes.entityTypes[39].annotations?.UI?.LineItem) {
             const LineItem = convertedTypes.entityTypes[39].annotations.UI.LineItem;
-            (LineItem[0] as DataFieldForActionTypes).InvocationGrouping = OperationGroupingType.Isolated;
-            (LineItem[0] as DataFieldForActionTypes).Action = 'SAP.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_ProductCopy';
+            LineItem[0] = {
+                ...(LineItem[0] as DataFieldForActionTypes),
+                InvocationGrouping: OperationGroupingType.Isolated,
+                Action: 'SAP.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_ProductCopy'
+            };
+
             const transformedLineItem = revertTermToGenericType(defaultReferences, LineItem) as any;
             expect(transformedLineItem.collection[0].propertyValues[1].name).toEqual('Action');
             expect(transformedLineItem.collection[0].propertyValues[1].value.type).toEqual('String');
@@ -773,7 +776,8 @@ describe('Annotation Converter', () => {
                 path: 'OverallSDStatus',
                 type: 'Path'
             } as EnumValue<CriticalityType>;
-            const LineItem = convertedTypes.entityTypes[39].annotations.UI.LineItem;
+            const convertedLineItem = convertedTypes.entityTypes[39].annotations.UI.LineItem;
+            const LineItem = Object.assign([...convertedLineItem], convertedLineItem);
             LineItem.annotations = { UI: { Criticality: criticality } };
             const transformedLineItem = revertTermToGenericType(defaultReferences, LineItem) as any;
             expect(transformedLineItem.term).toEqual(UIAnnotationTerms.LineItem);

--- a/packages/annotation-converter/test/utils.spec.ts
+++ b/packages/annotation-converter/test/utils.spec.ts
@@ -107,19 +107,20 @@ describe('utils', () => {
             }).toThrowError();
         });
 
-        it('allows to assign a value', () => {
+        it('is readonly', () => {
             const testObject: any = {};
             const initialize = jest.fn().mockReturnValue('abc');
 
             lazy(testObject, 'myProperty', initialize);
-            testObject.myProperty = 'xyz';
+            expect(testObject.myProperty).toEqual('abc');
+            expect(initialize).toBeCalledTimes(1);
 
-            expect(testObject.myProperty).toEqual('xyz');
-            expect(initialize).toBeCalledTimes(0);
+            expect(() => {
+                testObject.myProperty = 'xyz';
+            }).toThrowError();
 
-            testObject.myProperty = 'efg';
-            expect(testObject.myProperty).toEqual('efg');
-            expect(initialize).toBeCalledTimes(0);
+            expect(testObject.myProperty).toEqual('abc');
+            expect(initialize).toBeCalledTimes(1);
         });
     });
 

--- a/packages/annotation-converter/test/writeback.spec.ts
+++ b/packages/annotation-converter/test/writeback.spec.ts
@@ -220,11 +220,11 @@ describe('Writeback capabilities', () => {
         expect(JSON.stringify(transformedFilterDefaultValue)).toStrictEqual(JSON.stringify(target));
         expect(transformedFilterDefaultValue).toMatchSnapshot();
 
-        (convertedTypes.entityTypes['15'].annotations.UI as any)['DataPoint#Progress2'].TargetValue = 99.5;
-        const transformedFilterDefaultValue2 = revertTermToGenericType(
-            defaultReferences,
-            (convertedTypes.entityTypes['15'].annotations.UI as any)['DataPoint#Progress2']
-        ) as any;
+        const dataPoint = {
+            ...convertedTypes.entityTypes['15'].annotations.UI?.['DataPoint#Progress2'],
+            TargetValue: 99.5
+        };
+        const transformedFilterDefaultValue2 = revertTermToGenericType(defaultReferences, dataPoint) as any;
         expect(transformedFilterDefaultValue2).toMatchSnapshot();
     });
     it('can deal with Null', async () => {


### PR DESCRIPTION
This makes lazy properties read-only but leaves the rest of the converted structure mutable. It is a (small) first step towards an immutable structure.