### PR TITLE
Lenient create

### DIFF
--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -491,18 +491,8 @@ export class MockDataEntitySet implements EntitySetInterface {
                 }
             });
         }
-        // Remove non key items only if all keys are provided
-        let realKeys = outKeys;
-        if (this.entityTypeDefinition.keys.every((keyProp) => outKeys[keyProp.name] !== undefined)) {
-            realKeys = {};
-            Object.keys(outKeys).forEach((keyName) => {
-                if (this.entityTypeDefinition.keys.find((keyProp) => keyProp.name === keyName)) {
-                    realKeys[keyName] = outKeys[keyName];
-                }
-            });
-        }
 
-        return realKeys;
+        return outKeys;
     }
 
     public performGET(

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -491,7 +491,6 @@ export class MockDataEntitySet implements EntitySetInterface {
                 }
             });
         }
-
         return outKeys;
     }
 

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -330,6 +330,11 @@ export class FileBasedMockData {
                 );
             }
         });
+        this._entityType.navigationProperties.forEach((navigationProperty) => {
+            if (navigationProperty.containsTarget) {
+                outObj[navigationProperty.name] = [];
+            }
+        });
 
         return outObj;
     }

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -662,6 +662,7 @@ describe('Data Access', () => {
         subElement = await dataAccess.createData(
             new ODataRequest({ method: 'GET', url: '/FormRoot(ID=1,IsActiveEntity=false)/_Elements' }, dataAccess),
             {
+                ID: 777,
                 Name: 'SecondChild',
                 sibling_ID: 1
             }
@@ -670,6 +671,12 @@ describe('Data Access', () => {
         expect(subElement.IsActiveEntity).toEqual(false);
         expect(subElement.HasActiveEntity).toEqual(false);
         expect(subElement.Name).toEqual('SecondChild');
+
+        subElement = await dataAccess.getData(
+            new ODataRequest({ method: 'GET', url: '/FormRoot(ID=1,IsActiveEntity=false)/_Elements' }, dataAccess)
+        );
+        expect(subElement).toBeDefined;
+        expect(subElement.length).toEqual(2);
 
         subElement = await dataAccess.updateData(
             new ODataRequest({ method: 'PATCH', url: '/SubElements(ID=1,IsActiveEntity=false)' }, dataAccess),
@@ -791,7 +798,7 @@ describe('Data Access', () => {
         );
         // Delete one child
         actionResult = await dataAccess.deleteData(
-            new ODataRequest({ method: 'DELETE', url: '/SubElements(ID=2,IsActiveEntity=false)' }, dataAccess)
+            new ODataRequest({ method: 'DELETE', url: '/SubElements(ID=777,IsActiveEntity=false)' }, dataAccess)
         );
         formData = await dataAccess.getData(
             new ODataRequest(


### PR DESCRIPTION
Solves #448 

Currently in case of composition, we sometimes resolved the back navigation key but were removing them.

This lead to newly created items not being attached to their parent.
This code is not needed (at least our tests agree with this).

I'm also ensuring we provide an empty collection for contained navigation property (unrelated but three liner)