### PR TITLE
fix: empty navigation path should lead to an undefined target

### DIFF
--- a/.changeset/empty-gifts-stare.md
+++ b/.changeset/empty-gifts-stare.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Empty navigation path will now lead to empty target

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -765,19 +765,22 @@ function parseCollection(
 
         case 'NavigationPropertyPath':
             return collectionDefinition.map((navPropertyPath, navPropIdx) => {
+                const navigationPropertyPath = navPropertyPath.NavigationPropertyPath ?? '';
                 const result = {
                     type: 'NavigationPropertyPath',
-                    value: navPropertyPath.NavigationPropertyPath,
+                    value: navigationPropertyPath,
                     fullyQualifiedName: `${parentFQN}/${navPropIdx}`
                 } as any;
 
-                lazy(
-                    result,
-                    '$target',
-                    () =>
-                        resolveTarget(converter, currentTarget, navPropertyPath.NavigationPropertyPath, currentTerm)
-                            .target
-                );
+                if (navigationPropertyPath === '') {
+                    result.$target = undefined;
+                } else {
+                    lazy(
+                        result,
+                        '$target',
+                        () => resolveTarget(converter, currentTarget, navigationPropertyPath, currentTerm).target
+                    );
+                }
 
                 return result;
             });

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -629,6 +629,12 @@ describe('Annotation Converter', () => {
         expect((sdEntityType.annotations as any).Common['SideEffects#IncotermsChange'].$Type).toEqual(
             CommonAnnotationTypes.SideEffectsType
         );
+        expect((sdEntityType.annotations as any).Common['SideEffects#IncotermsChange'].SourceEntities[0].value).toEqual(
+            ''
+        );
+        expect(
+            (sdEntityType.annotations as any).Common['SideEffects#IncotermsChange'].SourceEntities[0].$target
+        ).toEqual(undefined);
         expect((sdEntityType.annotations as any).Common['SideEffects#IncotermsChange']).not.toBeNull();
         expect((sdEntityType.annotations as any).Common['SideEffects#IncotermsChange'].TargetProperties[0]).toEqual(
             'IncotermsLocation1'

--- a/packages/annotation-converter/test/fixtures/v4/v4Meta.xml
+++ b/packages/annotation-converter/test/fixtures/v4/v4Meta.xml
@@ -4217,6 +4217,11 @@
         </Annotation>
         <Annotation Term="Common.SideEffects" Qualifier="IncotermsChange">
           <Record>
+            <PropertyValue Property="SourceEntities">
+              <Collection>
+                <NavigationPropertyPath/>
+              </Collection>
+            </PropertyValue>
             <PropertyValue Property="SourceProperties">
               <Collection>
                 <PropertyPath>IncotermsVersion</PropertyPath>


### PR DESCRIPTION
Currently if we don't provide a path we would end up with the current entity type which breaks the assumption that a navigationPropertyPath returns a navigation property