### PR TITLE
fix(@sap-ux/fe-mockserver-core): Support actions that do not return a value

### DIFF
--- a/.changeset/kind-clocks-sort.md
+++ b/.changeset/kind-clocks-sort.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+The mockserver now allows to use actions that do not return a value

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -384,7 +384,7 @@ export class FileBasedMockData {
         actionData: any,
         _keys: Record<string, any>,
         _odataRequest: ODataRequest
-    ): Promise<object> {
+    ): Promise<object | undefined> {
         return actionData;
     }
 

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -45,7 +45,7 @@ export type MockDataContributor = {
         actionData: any,
         keys: Record<string, any>,
         odataRequest: ODataRequest
-    ): Promise<object>;
+    ): Promise<object | undefined>;
     onAfterAction?(
         actionDefinition: Action,
         actionData: any,
@@ -254,7 +254,7 @@ export class FunctionBasedMockData extends FileBasedMockData {
         actionData: any,
         keys: Record<string, any>,
         odataRequest: ODataRequest
-    ): Promise<object> {
+    ): Promise<object | undefined> {
         if (this._mockDataFn?.executeAction) {
             return this._mockDataFn.executeAction(actionDefinition, actionData, keys, odataRequest);
         } else {

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -337,6 +337,9 @@ export default class ODataRequest {
                     if (actionResponse === null) {
                         this.setResponseData(await this.dataAccess.createData(this, this.requestContent.body));
                         this.statusCode = 201;
+                    } else if (actionResponse === undefined) {
+                        this.setResponseData(actionResponse);
+                        this.statusCode = 204;
                     } else {
                         this.setResponseData(actionResponse);
                     }

--- a/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`V4 Requestor can create data through a call 1`] = `
 {
   "@odata.context": "../$metadata#RootElement/$entity",
-  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
+  "@odata.metadataEtag": "W/"5f65-P8siAqcLFztkvF0c1BTxYtFrvVo"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 555,
@@ -20,7 +20,7 @@ exports[`V4 Requestor can create data through a call 1`] = `
 exports[`V4 Requestor can create data through a call 2`] = `
 {
   "@odata.context": "../$metadata#RootElement/$entity",
-  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
+  "@odata.metadataEtag": "W/"5f65-P8siAqcLFztkvF0c1BTxYtFrvVo"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 666,
@@ -157,6 +157,9 @@ exports[`V4 Requestor can get the metadata 1`] = `
       <Action Name="boundAction3" IsBound="true" EntitySetPath="self">
         <Parameter Name="self" Type="sap.fe.core.ActionVisibility.RootElement"/>
         <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+      </Action>
+      <Action Name="boundActionReturnsVoid" IsBound="true">
+        <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
       </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
         <Parameter Name="in" Type="sap.fe.core.ActionVisibility.RootElement"/>
@@ -565,7 +568,7 @@ exports[`V4 Requestor can reload the data 1`] = `
 exports[`V4 Requestor can update data through a call 1`] = `
 {
   "@odata.context": "../$metadata#RootElement/$entity",
-  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
+  "@odata.metadataEtag": "W/"5f65-P8siAqcLFztkvF0c1BTxYtFrvVo"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 556,
@@ -582,7 +585,7 @@ exports[`V4 Requestor can update data through a call 1`] = `
 exports[`V4 Requestor can update data through a call 2`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=556)",
-  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
+  "@odata.metadataEtag": "W/"5f65-P8siAqcLFztkvF0c1BTxYtFrvVo"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 556,
@@ -601,7 +604,7 @@ exports[`V4 Requestor can update data through a call 3`] = `"Cannot convert unde
 exports[`V4 Requestor can update data through a call 4`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=556)/Prop1",
-  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
+  "@odata.metadataEtag": "W/"5f65-P8siAqcLFztkvF0c1BTxYtFrvVo"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 556,
@@ -618,7 +621,7 @@ exports[`V4 Requestor can update data through a call 4`] = `
 exports[`V4 Requestor get one data 1`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=2)",
-  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
+  "@odata.metadataEtag": "W/"5f65-P8siAqcLFztkvF0c1BTxYtFrvVo"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 2,
@@ -637,7 +640,7 @@ exports[`V4 Requestor get one data 2`] = `""`;
 exports[`V4 Requestor get one data 3`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=2)",
-  "@odata.metadataEtag": "W/"5eca-S4loLm2mnROdb6MLU94VQPWBjMI"",
+  "@odata.metadataEtag": "W/"5f65-P8siAqcLFztkvF0c1BTxYtFrvVo"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 2,

--- a/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
+++ b/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
@@ -424,4 +424,7 @@ export class ODataV4Requestor extends ODataRequestor {
     public updateData<T>(sEntityPath: string, objectData: any, noJSON: boolean = false): ODataV4ObjectRequest<T> {
         return new ODataV4ObjectRequest<T>(this.odataRootUri, sEntityPath, {}, 'PATCH').setBody(objectData, noJSON);
     }
+    public callAction<T>(actionPath: string, actionParameters: any, noJSON: boolean = false): ODataV4ObjectRequest<T> {
+        return new ODataV4ObjectRequest<T>(this.odataRootUri, actionPath, {}, 'POST').setBody(actionParameters, noJSON);
+    }
 }

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
@@ -6,5 +6,18 @@ module.exports = {
             return require('./tenant-003/RootElement.json');
         }
         return JSON.parse(fs.readFileSync(path.join(__dirname, 'RootElement.json')).toString('utf-8'));
+    },
+
+    executeAction: async function (actionDefinition, actionData, keys, odataRequest) {
+        switch (actionDefinition.name) {
+            case 'boundActionReturnsVoid':
+                return undefined;
+            default:
+                this.throwError('Not implemented', 501, {
+                    error: {
+                        message: `FunctionImport or Action "${actionDefinition.name}" not mocked`
+                    }
+                });
+        }
     }
 };

--- a/packages/fe-mockserver-core/test/unit/__testData/service.cds
+++ b/packages/fe-mockserver-core/test/unit/__testData/service.cds
@@ -204,5 +204,6 @@ service ActionVisibility {
 	 	action boundAction2() returns RootElement;
 	 	@cds.odata.bindingparameter.name : 'self'
 	 	action boundAction3() returns RootElement;
+		action boundActionReturnsVoid();
     };
 }

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -85,6 +85,16 @@ describe('V4 Requestor', function () {
         const dataRes2 = await dataRequestor.getList<any>('RootElement').executeAsBatch();
         expect(dataRes2.length).toBe(4);
     });
+    it('can execute an action without return type', async () => {
+        const dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');
+        const dataRes = await dataRequestor
+            .callAction(
+                '/RootElement(ID=1,IsActiveEntity=true)/sap.fe.core.ActionVisibility.boundActionReturnsVoid',
+                {}
+            )
+            .execute('POST');
+        expect(dataRes).toMatchInlineSnapshot(`""`);
+    });
     it('can get the metadata', async () => {
         const dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');
         const dataRes = await dataRequestor.getMetadata().execute();


### PR DESCRIPTION
Actions do not need to return anything, but the `MockDataContributor` API did not allow to return `undefined` as an action result. If this was still done, the HTTP response contained the OData context stuff, but it should be a plain 204 No Content response instead.