### PR TITLE
feat(@sap-ux/vocabularies-types): Generate a collection of vocabulary references

### DIFF
--- a/.changeset/unlucky-eels-sing.md
+++ b/.changeset/unlucky-eels-sing.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/annotation-converter': patch
+'@sap-ux/vocabularies-types': patch
+---
+
+The vocabulary types now provide a complete set of vocabulary references in constant `VocabularyReferences`

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -42,7 +42,6 @@ import {
     addGetByValue,
     alias,
     Decimal,
-    defaultReferences,
     EnumIsFlag,
     lazy,
     splitAtFirst,
@@ -52,6 +51,7 @@ import {
     TermToTypes,
     unalias
 } from './utils';
+import { VocabularyReferences } from '@sap-ux/vocabularies-types/vocabularies/VocabularyReferences';
 
 /**
  * Symbol to extend an annotation with the reference to its target.
@@ -1556,19 +1556,19 @@ function convertTypeDefinition(converter: Converter, rawTypeDefinition: RawTypeD
  * @returns the converted representation of the metadata.
  */
 export function convert(rawMetadata: RawMetadata): ConvertedMetadata {
-    // fall back on the default references if the caller does not specify any
-    if (rawMetadata.references.length === 0) {
-        rawMetadata.references = defaultReferences;
-    }
-
     // Converter Output
     const convertedOutput: ConvertedMetadata = {
         version: rawMetadata.version,
         namespace: rawMetadata.schema.namespace,
         annotations: rawMetadata.schema.annotations,
-        references: defaultReferences.concat(rawMetadata.references),
+        references: VocabularyReferences.concat(rawMetadata.references),
         diagnostics: []
     } as any;
+
+    // fall back on the default references if the caller does not specify any
+    if (rawMetadata.references.length === 0) {
+        rawMetadata.references = VocabularyReferences;
+    }
 
     // Converter
     const converter = new Converter(rawMetadata, convertedOutput);

--- a/packages/annotation-converter/src/utils.ts
+++ b/packages/annotation-converter/src/utils.ts
@@ -1,20 +1,7 @@
 import type { Index, ComplexType, Reference, TypeDefinition, ArrayWithIndex } from '@sap-ux/vocabularies-types';
+import { VocabularyReferences } from '@sap-ux/vocabularies-types/vocabularies/VocabularyReferences';
 
-export const defaultReferences: ReferencesWithMap = [
-    { alias: 'Capabilities', namespace: 'Org.OData.Capabilities.V1', uri: '' },
-    { alias: 'Aggregation', namespace: 'Org.OData.Aggregation.V1', uri: '' },
-    { alias: 'Validation', namespace: 'Org.OData.Validation.V1', uri: '' },
-    { namespace: 'Org.OData.Core.V1', alias: 'Core', uri: '' },
-    { namespace: 'Org.OData.Measures.V1', alias: 'Measures', uri: '' },
-    { namespace: 'com.sap.vocabularies.Common.v1', alias: 'Common', uri: '' },
-    { namespace: 'com.sap.vocabularies.UI.v1', alias: 'UI', uri: '' },
-    { namespace: 'com.sap.vocabularies.Session.v1', alias: 'Session', uri: '' },
-    { namespace: 'com.sap.vocabularies.Analytics.v1', alias: 'Analytics', uri: '' },
-    { namespace: 'com.sap.vocabularies.CodeList.v1', alias: 'CodeList', uri: '' },
-    { namespace: 'com.sap.vocabularies.PersonalData.v1', alias: 'PersonalData', uri: '' },
-    { namespace: 'com.sap.vocabularies.Communication.v1', alias: 'Communication', uri: '' },
-    { namespace: 'com.sap.vocabularies.HTML5.v1', alias: 'HTML5', uri: '' }
-];
+export const defaultReferences: ReferencesWithMap = VocabularyReferences;
 
 export type ReferencesWithMap = Reference[] & {
     referenceMap?: Record<string, Reference>;

--- a/packages/vocabularies-types/utils/config.json
+++ b/packages/vocabularies-types/utils/config.json
@@ -5,13 +5,13 @@
     "Aggregation": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.json",
     "Validation": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Validation.V1.json",
     "Measures": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.json",
-    "Analytics": "https://raw.githubusercontent.com/SAP/odata-vocabularies/main/vocabularies/Analytics.json",
-    "Common": "https://raw.githubusercontent.com/SAP/odata-vocabularies/main/vocabularies/Common.json",
-    "CodeList": "https://raw.githubusercontent.com/SAP/odata-vocabularies/main/vocabularies/CodeList.json",
-    "Communication": "https://raw.githubusercontent.com/SAP/odata-vocabularies/main/vocabularies/Communication.json",
-    "Hierarchy": "https://raw.githubusercontent.com/SAP/odata-vocabularies/main/vocabularies/Hierarchy.json",
-    "PersonalData": "https://raw.githubusercontent.com/SAP/odata-vocabularies/main/vocabularies/PersonalData.json",
-    "Session": "https://raw.githubusercontent.com/SAP/odata-vocabularies/main/vocabularies/Session.json",
-    "UI": "https://raw.githubusercontent.com/SAP/odata-vocabularies/main/vocabularies/UI.json",
-    "HTML5": "https://raw.githubusercontent.com/SAP/odata-vocabularies/main/vocabularies/HTML5.json"
+    "Analytics": "https://sap.github.io/odata-vocabularies/vocabularies/Analytics.json",
+    "Common": "https://sap.github.io/odata-vocabularies/vocabularies/Common.json",
+    "CodeList": "https://sap.github.io/odata-vocabularies/vocabularies/CodeList.json",
+    "Communication": "https://sap.github.io/odata-vocabularies/vocabularies/Communication.json",
+    "Hierarchy": "https://sap.github.io/odata-vocabularies/vocabularies/Hierarchy.json",
+    "PersonalData": "https://sap.github.io/odata-vocabularies/vocabularies/PersonalData.json",
+    "Session": "https://sap.github.io/odata-vocabularies/vocabularies/Session.json",
+    "UI": "https://sap.github.io/odata-vocabularies/vocabularies/UI.json",
+    "HTML5": "https://sap.github.io/odata-vocabularies/vocabularies/HTML5.json"
 }

--- a/packages/vocabularies-types/utils/generate_types.ts
+++ b/packages/vocabularies-types/utils/generate_types.ts
@@ -608,9 +608,27 @@ async function generateTypes(targetFolder: string) {
     });
     enumIsFlag += '}';
 
+    let vocabularyReferences = `
+import type {Reference} from "../Edm";
+
+/**
+ * The list of vocabularies with default aliases.
+ */
+export const VocabularyReferences : Reference[] = [
+`;
+    vocabularyReferences += Object.keys(references)
+        .map((alias) => {
+            const namespace = references[alias];
+            const uri = vocabularyConfig[alias].replace('.json', '.xml');
+            return `\t{ alias: "${alias}", namespace: "${namespace}", uri: "${uri}" }`;
+        })
+        .join(',\n');
+    vocabularyReferences += '\n]';
+
     await writeFile(path.join(targetFolder, `Edm_Types.ts`), edmTypesValue);
     await writeFile(path.join(targetFolder, `TermToTypes.ts`), edmTermToTypes);
     await writeFile(path.join(targetFolder, `EnumIsFlag.ts`), enumIsFlag);
+    await writeFile(path.join(targetFolder, `VocabularyReferences.ts`), vocabularyReferences);
 }
 
 generateTypes(path.join(__dirname, '../src/vocabularies'))


### PR DESCRIPTION
The vocabulary types now export a list of references to all the vocabularies (in constant `VocabularyReferences`). This ensures that the annotation converter works on a up-to-date list of references.

This also solves the problem of missing `Hierarchy` vocabulary in the `defaultReferences` constant.