### PR TITLE
feat(MockDataContributor): Add support of generic types

### DIFF
--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -202,7 +202,7 @@ export class MockDataEntitySet implements EntitySetInterface {
     }
 
     protected _rootMockData: object[] = [];
-    private _rootMockDataFn: MockDataContributor;
+    private _rootMockDataFn: MockDataContributor<object>;
     protected contextBasedMockData: Record<string, FileBasedMockData> = {};
     public readyPromise: Promise<EntitySetInterface>;
     protected entitySetDefinition: EntitySet | null;
@@ -242,7 +242,7 @@ export class MockDataEntitySet implements EntitySetInterface {
                 dataAccess
             ).then((mockData) => {
                 if (typeof mockData === 'object' && !Array.isArray(mockData)) {
-                    this._rootMockDataFn = mockData as MockDataContributor;
+                    this._rootMockDataFn = mockData as MockDataContributor<object>;
                 } else {
                     this._rootMockData = mockData;
                 }

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -6,13 +6,13 @@ import type ODataRequest from '../request/odataRequest';
 import type { KeyDefinitions } from './fileBasedMockData';
 import { FileBasedMockData } from './fileBasedMockData';
 
-export type MockDataContributor = {
+export type MockDataContributor<T> = {
     getInitialDataSet?: (contextId: string) => object[];
-    addEntry?: (mockEntry: object, odataRequest: ODataRequest) => void;
+    addEntry?: (mockEntry: T extends object ? T : object, odataRequest: ODataRequest) => void;
     updateEntry?: (
         keyValues: KeyDefinitions,
-        newData: object,
-        updatedData: object,
+        newData: T extends object ? T : object,
+        updatedData: T extends object ? T : object,
         odataRequest: ODataRequest
     ) => Promise<void>;
     removeEntry?: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;
@@ -73,8 +73,16 @@ export type MockDataContributor = {
         responseData: any,
         odataRequest: ODataRequest
     ): Promise<any>;
-    onAfterUpdateEntry?(keyValues: KeyDefinitions, updatedData: object, odataRequest: ODataRequest): Promise<void>;
-    onBeforeUpdateEntry?(keyValues: KeyDefinitions, updatedData: object, odataRequest: ODataRequest): Promise<void>;
+    onAfterUpdateEntry?(
+        keyValues: KeyDefinitions,
+        updatedData: T extends object ? T : object,
+        odataRequest: ODataRequest
+    ): Promise<void>;
+    onBeforeUpdateEntry?(
+        keyValues: KeyDefinitions,
+        updatedData: T extends object ? T : object,
+        odataRequest: ODataRequest
+    ): Promise<void>;
     hasCustomAggregate?(customAggregateName: string, odataRequest: ODataRequest): boolean;
     performCustomAggregate?(customAggregateName: string, dataToAggregate: any[], odataRequest: ODataRequest): any;
     throwError?(
@@ -87,8 +95,12 @@ export type MockDataContributor = {
     base?: {
         generateMockData: () => void;
         generateKey: (property: Property, lineIndex?: number, mockData?: any) => any;
-        addEntry: (mockEntry: object, odataRequest: ODataRequest) => void;
-        updateEntry: (keyValues: KeyDefinitions, newData: object, odataRequest: ODataRequest) => void;
+        addEntry: (mockEntry: T extends object ? T : object, odataRequest: ODataRequest) => void;
+        updateEntry: (
+            keyValues: KeyDefinitions,
+            newData: T extends object ? T : object,
+            odataRequest: ODataRequest
+        ) => void;
         removeEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;
         hasEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => boolean;
         fetchEntries: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => object[];
@@ -113,10 +125,10 @@ export type MockDataContributor = {
  *
  */
 export class FunctionBasedMockData extends FileBasedMockData {
-    private _mockDataFn: MockDataContributor;
+    private _mockDataFn: MockDataContributor<object>;
 
     constructor(
-        mockDataFn: MockDataContributor,
+        mockDataFn: MockDataContributor<object>,
         entityType: EntityType,
         mockDataEntitySet: EntitySetInterface,
         contextId: string


### PR DESCRIPTION
Allow entity data (`newData`, `updatedData `and `mockEntry`) that extends object.

**Current Problem:**

Type definition:
`addEntry?: (mockEntry: object, odataRequest: ODataRequest) => void;`
 
Implementation
```
import {MyEntity} from "../../types/MyTypes";
[…]
addEntry(this: MockDataContributor, mockEntry: MyEntity, odataRequest: ODataRequest) {
```
Error: `Type '{}' is missing the following properties from type 'MyEntity': foo, bar`
 
**Solution:**

Adjusted type definition in this PR:
`addEntry?: (mockEntry: T extends object ? T : object, odataRequest: ODataRequest) => void; `
