### PR TITLE
fix(@sap-ux/annotation-converter): typo and wrong local alias

### DIFF
--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -950,7 +950,7 @@ function mergeAnnotations(converter: Converter): Record<string, Annotation[]> {
 }
 
 class Converter {
-    private annotationyByTarget: Record<FullyQualifiedName, Annotation[]>;
+    private annotationsByTarget: Record<FullyQualifiedName, Annotation[]>;
 
     /**
      * Get preprocessed annotations on the specified target.
@@ -959,11 +959,11 @@ class Converter {
      * @returns An array of annotations
      */
     getAnnotations(target: FullyQualifiedName): Annotation[] {
-        if (this.annotationyByTarget === undefined) {
-            this.annotationyByTarget = mergeAnnotations(this);
+        if (this.annotationsByTarget === undefined) {
+            this.annotationsByTarget = mergeAnnotations(this);
         }
 
-        return this.annotationyByTarget[target] ?? [];
+        return this.annotationsByTarget[target] ?? [];
     }
 
     getConvertedEntityContainer() {

--- a/packages/annotation-converter/test/fixtures/v4/aliased.xml
+++ b/packages/annotation-converter/test/fixtures/v4/aliased.xml
@@ -9,11 +9,8 @@
     <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
         <edmx:Include Alias="MyUI" Namespace="com.sap.vocabularies.UI.v1"/>
     </edmx:Reference>
-    <edmx:Reference Uri="">
-        <edmx:Include Alias="MyServiceAlias" Namespace="sap.fe.test.JestService"/>
-    </edmx:Reference>
     <edmx:DataServices>
-        <Schema Namespace="sap.fe.test.JestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Schema Namespace="sap.fe.test.JestService" xmlns="http://docs.oasis-open.org/odata/ns/edm" Alias="MyServiceAlias" >
             <EntityContainer Name="EntityContainer">
                 <EntitySet Name="Entities" EntityType="sap.fe.test.JestService.Entities"/>
                 <ActionImport Name="doSomethingUnbound" Action="sap.fe.test.JestService.doSomethingUnbound"/>


### PR DESCRIPTION
The service-local alias was actually incorrectly defined in the test data (no impact on test results). Also fixes a small typo in a private member.

No changeset required.