### PR TITLE
feat(MockDataContributor): Add support of generic types

### DIFF
--- a/.changeset/perfect-rules-notice.md
+++ b/.changeset/perfect-rules-notice.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+feat(MockDataContributor): Add support of generic types

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -202,7 +202,7 @@ export class MockDataEntitySet implements EntitySetInterface {
     }
 
     protected _rootMockData: object[] = [];
-    private _rootMockDataFn: MockDataContributor;
+    private _rootMockDataFn: MockDataContributor<object>;
     protected contextBasedMockData: Record<string, FileBasedMockData> = {};
     public readyPromise: Promise<EntitySetInterface>;
     protected entitySetDefinition: EntitySet | null;
@@ -242,7 +242,7 @@ export class MockDataEntitySet implements EntitySetInterface {
                 dataAccess
             ).then((mockData) => {
                 if (typeof mockData === 'object' && !Array.isArray(mockData)) {
-                    this._rootMockDataFn = mockData as MockDataContributor;
+                    this._rootMockDataFn = mockData as MockDataContributor<object>;
                 } else {
                     this._rootMockData = mockData;
                 }

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -6,13 +6,13 @@ import type ODataRequest from '../request/odataRequest';
 import type { KeyDefinitions } from './fileBasedMockData';
 import { FileBasedMockData } from './fileBasedMockData';
 
-export type MockDataContributor = {
+export type MockDataContributor<T> = {
     getInitialDataSet?: (contextId: string) => object[];
-    addEntry?: (mockEntry: object, odataRequest: ODataRequest) => void;
+    addEntry?: (mockEntry: T extends object ? T : object, odataRequest: ODataRequest) => void;
     updateEntry?: (
         keyValues: KeyDefinitions,
-        newData: object,
-        updatedData: object,
+        newData: T extends object ? T : object,
+        updatedData: T extends object ? T : object,
         odataRequest: ODataRequest
     ) => Promise<void>;
     removeEntry?: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;
@@ -73,8 +73,16 @@ export type MockDataContributor = {
         responseData: any,
         odataRequest: ODataRequest
     ): Promise<any>;
-    onAfterUpdateEntry?(keyValues: KeyDefinitions, updatedData: object, odataRequest: ODataRequest): Promise<void>;
-    onBeforeUpdateEntry?(keyValues: KeyDefinitions, updatedData: object, odataRequest: ODataRequest): Promise<void>;
+    onAfterUpdateEntry?(
+        keyValues: KeyDefinitions,
+        updatedData: T extends object ? T : object,
+        odataRequest: ODataRequest
+    ): Promise<void>;
+    onBeforeUpdateEntry?(
+        keyValues: KeyDefinitions,
+        updatedData: T extends object ? T : object,
+        odataRequest: ODataRequest
+    ): Promise<void>;
     hasCustomAggregate?(customAggregateName: string, odataRequest: ODataRequest): boolean;
     performCustomAggregate?(customAggregateName: string, dataToAggregate: any[], odataRequest: ODataRequest): any;
     throwError?(
@@ -87,8 +95,12 @@ export type MockDataContributor = {
     base?: {
         generateMockData: () => void;
         generateKey: (property: Property, lineIndex?: number, mockData?: any) => any;
-        addEntry: (mockEntry: object, odataRequest: ODataRequest) => void;
-        updateEntry: (keyValues: KeyDefinitions, newData: object, odataRequest: ODataRequest) => void;
+        addEntry: (mockEntry: T extends object ? T : object, odataRequest: ODataRequest) => void;
+        updateEntry: (
+            keyValues: KeyDefinitions,
+            newData: T extends object ? T : object,
+            odataRequest: ODataRequest
+        ) => void;
         removeEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;
         hasEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => boolean;
         fetchEntries: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => object[];
@@ -113,10 +125,10 @@ export type MockDataContributor = {
  *
  */
 export class FunctionBasedMockData extends FileBasedMockData {
-    private _mockDataFn: MockDataContributor;
+    private _mockDataFn: MockDataContributor<object>;
 
     constructor(
-        mockDataFn: MockDataContributor,
+        mockDataFn: MockDataContributor<object>,
         entityType: EntityType,
         mockDataEntitySet: EntitySetInterface,
         contextId: string

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -6,13 +6,13 @@ import type ODataRequest from '../request/odataRequest';
 import type { KeyDefinitions } from './fileBasedMockData';
 import { FileBasedMockData } from './fileBasedMockData';
 
-export type MockDataContributor<T> = {
+export type MockDataContributor<T extends object> = {
     getInitialDataSet?: (contextId: string) => object[];
-    addEntry?: (mockEntry: T extends object ? T : object, odataRequest: ODataRequest) => void;
+    addEntry?: (mockEntry: T, odataRequest: ODataRequest) => void;
     updateEntry?: (
         keyValues: KeyDefinitions,
-        newData: T extends object ? T : object,
-        updatedData: T extends object ? T : object,
+        newData: T,
+        updatedData: T,
         odataRequest: ODataRequest
     ) => Promise<void>;
     removeEntry?: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;
@@ -75,12 +75,12 @@ export type MockDataContributor<T> = {
     ): Promise<any>;
     onAfterUpdateEntry?(
         keyValues: KeyDefinitions,
-        updatedData: T extends object ? T : object,
+        updatedData: T,
         odataRequest: ODataRequest
     ): Promise<void>;
     onBeforeUpdateEntry?(
         keyValues: KeyDefinitions,
-        updatedData: T extends object ? T : object,
+        updatedData: T,
         odataRequest: ODataRequest
     ): Promise<void>;
     hasCustomAggregate?(customAggregateName: string, odataRequest: ODataRequest): boolean;
@@ -95,10 +95,10 @@ export type MockDataContributor<T> = {
     base?: {
         generateMockData: () => void;
         generateKey: (property: Property, lineIndex?: number, mockData?: any) => any;
-        addEntry: (mockEntry: T extends object ? T : object, odataRequest: ODataRequest) => void;
+        addEntry: (mockEntry: T, odataRequest: ODataRequest) => void;
         updateEntry: (
             keyValues: KeyDefinitions,
-            newData: T extends object ? T : object,
+            newData: T,
             odataRequest: ODataRequest
         ) => void;
         removeEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -6,8 +6,8 @@ import type ODataRequest from '../request/odataRequest';
 import type { KeyDefinitions } from './fileBasedMockData';
 import { FileBasedMockData } from './fileBasedMockData';
 
-export type MockDataContributor<T extends object> = {
-    getInitialDataSet?: (contextId: string) => object[];
+export type MockDataContributor <T extends object> = {
+    getInitialDataSet?: (contextId: string) => T[];
     addEntry?: (mockEntry: T, odataRequest: ODataRequest) => void;
     updateEntry?: (
         keyValues: KeyDefinitions,

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -6,15 +6,10 @@ import type ODataRequest from '../request/odataRequest';
 import type { KeyDefinitions } from './fileBasedMockData';
 import { FileBasedMockData } from './fileBasedMockData';
 
-export type MockDataContributor <T extends object> = {
+export type MockDataContributor<T extends object> = {
     getInitialDataSet?: (contextId: string) => T[];
     addEntry?: (mockEntry: T, odataRequest: ODataRequest) => void;
-    updateEntry?: (
-        keyValues: KeyDefinitions,
-        newData: T,
-        updatedData: T,
-        odataRequest: ODataRequest
-    ) => Promise<void>;
+    updateEntry?: (keyValues: KeyDefinitions, newData: T, updatedData: T, odataRequest: ODataRequest) => Promise<void>;
     removeEntry?: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;
     hasEntry?: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => boolean;
     hasEntries?: (odataRequest: ODataRequest) => boolean;
@@ -73,16 +68,8 @@ export type MockDataContributor <T extends object> = {
         responseData: any,
         odataRequest: ODataRequest
     ): Promise<any>;
-    onAfterUpdateEntry?(
-        keyValues: KeyDefinitions,
-        updatedData: T,
-        odataRequest: ODataRequest
-    ): Promise<void>;
-    onBeforeUpdateEntry?(
-        keyValues: KeyDefinitions,
-        updatedData: T,
-        odataRequest: ODataRequest
-    ): Promise<void>;
+    onAfterUpdateEntry?(keyValues: KeyDefinitions, updatedData: T, odataRequest: ODataRequest): Promise<void>;
+    onBeforeUpdateEntry?(keyValues: KeyDefinitions, updatedData: T, odataRequest: ODataRequest): Promise<void>;
     hasCustomAggregate?(customAggregateName: string, odataRequest: ODataRequest): boolean;
     performCustomAggregate?(customAggregateName: string, dataToAggregate: any[], odataRequest: ODataRequest): any;
     throwError?(
@@ -96,11 +83,7 @@ export type MockDataContributor <T extends object> = {
         generateMockData: () => void;
         generateKey: (property: Property, lineIndex?: number, mockData?: any) => any;
         addEntry: (mockEntry: T, odataRequest: ODataRequest) => void;
-        updateEntry: (
-            keyValues: KeyDefinitions,
-            newData: T,
-            odataRequest: ODataRequest
-        ) => void;
+        updateEntry: (keyValues: KeyDefinitions, newData: T, odataRequest: ODataRequest) => void;
         removeEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;
         hasEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => boolean;
         fetchEntries: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => object[];


### PR DESCRIPTION
See #497 

Allow entity data (newData, updatedData and mockEntry) that extends object.

Current Problem:

Type definition:
addEntry?: (mockEntry: object, odataRequest: ODataRequest) => void;

Implementation

import {MyEntity} from "../../types/MyTypes";
[…]
addEntry(this: MockDataContributor, mockEntry: MyEntity, odataRequest: ODataRequest) {
Error: Type '{}' is missing the following properties from type 'MyEntity': foo, bar

Solution:

Adjusted type definition in this PR:
addEntry?: (mockEntry: T extends object ? T : object, odataRequest: ODataRequest) => void; 