### PR TITLE
fix: we now have better support for finding parent of entities

### DIFF
--- a/.changeset/spotty-bees-unite.md
+++ b/.changeset/spotty-bees-unite.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Improved the logic to resolve the parent from a specific node

--- a/packages/fe-mockserver-core/src/data/metadata.ts
+++ b/packages/fe-mockserver-core/src/data/metadata.ts
@@ -133,6 +133,7 @@ export class ODataMetadata {
             // nothing to do - we are there already
             return true;
         }
+        const pathLength = path.length;
 
         for (const [navPropBindingName, target] of Object.entries(entitySet.navigationPropertyBinding)) {
             if (!entitySetFilter(target)) {
@@ -161,7 +162,13 @@ export class ODataMetadata {
             if (target === targetEntitySet) {
                 return true;
             } else {
-                return this.findInDescendant(target, targetEntitySet, path, entitySetFilter);
+                const wasFound = this.findInDescendant(target, targetEntitySet, path, entitySetFilter);
+                if (!wasFound) {
+                    // Let's try another path sp we reset to what we had before
+                    path.splice(pathLength);
+                } else {
+                    return true;
+                }
             }
         }
 
@@ -194,7 +201,7 @@ export class ODataMetadata {
         let foundPath!: NameAndNav[];
         let rootEntitySet!: EntitySet;
         this.metadata.entitySets.forEach((et) => {
-            if (!found) {
+            if (!found && et !== entitySet) {
                 const resolvePath: any[] = [];
                 found = this.findInDescendant(et, entitySet, resolvePath);
                 if (found) {

--- a/packages/fe-mockserver-core/test/unit/data/metadata.spec.ts
+++ b/packages/fe-mockserver-core/test/unit/data/metadata.spec.ts
@@ -30,6 +30,15 @@ describe('resolveDraftRoot()', () => {
             expect(resolved.path).toHaveLength(0);
         });
 
+        test('should resolve parent entity', async () => {
+            const child = metadata.getEntitySet('OtherEntities');
+            expect(child?.name).toEqual('OtherEntities');
+
+            const entitySet = metadata.getParentEntitySetName(child!);
+            expect(entitySet).toBeDefined();
+            expect(entitySet).toBe('DraftRoots');
+        });
+
         test('should resolve the root directly', async () => {
             const resolved = metadata.resolveDraftRoot(root);
             expect(resolved.found).toBeTruthy();


### PR DESCRIPTION
The existing algorithm was making many assumption that life was easy.
This is a bit more robust (but not enough tested probably).

@c-kobo feel free to add more test case if you feel it's required