### PR TITLE
fix: the base type of the mockdata contributor is now correct

### DIFF
--- a/.changeset/violet-carpets-reflect.md
+++ b/.changeset/violet-carpets-reflect.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+The base type of the mockdata contributor is now correct

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -82,9 +82,9 @@ export type MockDataContributor<T extends object> = {
     base?: {
         generateMockData: () => void;
         generateKey: (property: Property, lineIndex?: number, mockData?: any) => any;
-        addEntry: (mockEntry: T, odataRequest: ODataRequest) => void;
-        updateEntry: (keyValues: KeyDefinitions, newData: T, odataRequest: ODataRequest) => void;
-        removeEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;
+        addEntry: (mockEntry: T, odataRequest: ODataRequest) => Promise<void>;
+        updateEntry: (keyValues: KeyDefinitions, newData: T, odataRequest: ODataRequest) => Promise<void>;
+        removeEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => Promise<void>;
         hasEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => boolean;
         fetchEntries: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => object[];
         hasEntries: (odataRequest: ODataRequest) => boolean;


### PR DESCRIPTION
Quick fix on the API regarding async usage

Fix for #512 