### PR TITLE
fix: improve hierarchy queries related to sorting

### DIFF
--- a/.changeset/dry-guests-matter.md
+++ b/.changeset/dry-guests-matter.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-middleware-fe-mockserver': patch
+---
+
+Fix some hierarchy queries

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -734,14 +734,11 @@ export class FileBasedMockData {
                 const parent = adjustedData.find((parent) => parent[nodeProperty] === node[sourceReference]);
                 return !parent || !parent.$inResultSet;
             });
-            allRootNodes.sort((a, b) => {
+            allRootNodes.sort((a) => {
                 if (a.$rootDistance === undefined) {
                     return -1;
-                } else if (b.$rootDistance === undefined) {
-                    return 1;
-                } else {
-                    return a.$rootDistance - b.$rootDistance;
                 }
+                return 1;
             });
 
             const depth: number = parseInt(_parameters.Levels, 10);

--- a/packages/fe-mockserver-core/src/request/commonTokens.ts
+++ b/packages/fe-mockserver-core/src/request/commonTokens.ts
@@ -33,9 +33,9 @@ export const LITERAL = createToken({
 });
 //ee1a9172-f3c3-47ce-b0f7-dd28c740210c
 export const LOGICAL_OPERATOR = createToken({ name: 'Logical', pattern: /(:?eq|ne|lt|le|gt|ge)/ });
-export const ANDOR = createToken({ name: 'AndOr', pattern: /\s(:?and|or)\s/ });
-export const ASCDESC = createToken({ name: 'AscDesc', pattern: /\s(:?asc|desc)\s/ });
-export const WS = createToken({ name: 'Whitespace', pattern: /\s+/ });
+export const ANDOR = createToken({ name: 'AndOr', pattern: /(\s|%20)(:?and|or)(\s|%20)/ });
+export const ASCDESC = createToken({ name: 'AscDesc', pattern: /(:?asc|desc)/ });
+export const WS = createToken({ name: 'Whitespace', pattern: /(\s|%20)+/ });
 // const STRINGLITERAL = createToken({
 //     name: 'SimpleIdentifier',
 //     pattern: /(:?[^\\"\s]+|\\(:?[bfnrtv"\\/]|u[0-9a-fA-F]{4}))+/

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -1255,64 +1255,64 @@ describe('Hierarchy Access', () => {
         );
 
         expect(odataRequest.applyDefinition).toMatchInlineSnapshot(`
-          [
-            {
-              "parameters": {
-                "hierarchyRoot": "$root/SalesOrganizations",
-                "inputSetTransformations": [
-                  {
-                    "searchExpr": [
-                      "West",
-                    ],
-                    "type": "search",
-                  },
-                ],
-                "keepStart": true,
-                "maximumDistance": -1,
-                "propertyPath": "ID",
-                "qualifier": "SalesOrgHierarchy",
-              },
-              "type": "ancestors",
-            },
-            {
-              "name": "com.sap.vocabularies.Hierarchy.v1.TopLevels",
-              "parameters": {
-                "HierarchyNodes": "$root/SalesOrganizations",
-                "HierarchyQualifier": "'SalesOrgHierarchy'",
-                "Levels": "99",
-                "NodeProperty": "'ID'",
-              },
-              "type": "customFunction",
-            },
-          ]
-      `);
+                      [
+                        {
+                          "parameters": {
+                            "hierarchyRoot": "$root/SalesOrganizations",
+                            "inputSetTransformations": [
+                              {
+                                "searchExpr": [
+                                  "West",
+                                ],
+                                "type": "search",
+                              },
+                            ],
+                            "keepStart": true,
+                            "maximumDistance": -1,
+                            "propertyPath": "ID",
+                            "qualifier": "SalesOrgHierarchy",
+                          },
+                          "type": "ancestors",
+                        },
+                        {
+                          "name": "com.sap.vocabularies.Hierarchy.v1.TopLevels",
+                          "parameters": {
+                            "HierarchyNodes": "$root/SalesOrganizations",
+                            "HierarchyQualifier": "'SalesOrgHierarchy'",
+                            "Levels": "99",
+                            "NodeProperty": "'ID'",
+                          },
+                          "type": "customFunction",
+                        },
+                      ]
+              `);
 
         const data = await dataAccess.getData(odataRequest);
         expect(data).toMatchInlineSnapshot(`
-        [
-          {
-            "DistanceFromRoot": 0,
-            "DrillState": "expanded",
-            "ID": "Sales",
-            "LimitedDescendantCount": 2,
-            "Name": "Corporate Sales",
-          },
-          {
-            "DistanceFromRoot": 1,
-            "DrillState": "expanded",
-            "ID": "US",
-            "LimitedDescendantCount": 1,
-            "Name": "US",
-          },
-          {
-            "DistanceFromRoot": 2,
-            "DrillState": "leaf",
-            "ID": "US West",
-            "LimitedDescendantCount": 0,
-            "Name": "US West",
-          },
-        ]
-      `);
+                    [
+                      {
+                        "DistanceFromRoot": 0,
+                        "DrillState": "expanded",
+                        "ID": "Sales",
+                        "LimitedDescendantCount": 2,
+                        "Name": "Corporate Sales",
+                      },
+                      {
+                        "DistanceFromRoot": 1,
+                        "DrillState": "expanded",
+                        "ID": "US",
+                        "LimitedDescendantCount": 1,
+                        "Name": "US",
+                      },
+                      {
+                        "DistanceFromRoot": 2,
+                        "DrillState": "leaf",
+                        "ID": "US West",
+                        "LimitedDescendantCount": 0,
+                        "Name": "US West",
+                      },
+                    ]
+              `);
     });
 
     test('5- Hierarchy in Object Page - Product hierarchy expanded to two levels (including root)', async () => {
@@ -1326,27 +1326,6 @@ describe('Hierarchy Access', () => {
         const data = await dataAccess.getData(odataRequest);
         expect(data).toMatchInlineSnapshot(`
             [
-              {
-                "DistanceFromRoot": 0,
-                "DrillState": "expanded",
-                "ID": "1",
-                "LimitedDescendantCount": 2,
-                "Name": "Waters",
-              },
-              {
-                "DistanceFromRoot": 1,
-                "DrillState": "leaf",
-                "ID": "10",
-                "LimitedDescendantCount": 0,
-                "Name": "Still water",
-              },
-              {
-                "DistanceFromRoot": 1,
-                "DrillState": "leaf",
-                "ID": "11",
-                "LimitedDescendantCount": 0,
-                "Name": "Sparkling water",
-              },
               {
                 "DistanceFromRoot": 0,
                 "DrillState": "expanded",
@@ -1374,6 +1353,27 @@ describe('Hierarchy Access', () => {
                 "ID": "22",
                 "LimitedDescendantCount": 0,
                 "Name": "Sparkling wines",
+              },
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "ID": "1",
+                "LimitedDescendantCount": 2,
+                "Name": "Waters",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "leaf",
+                "ID": "10",
+                "LimitedDescendantCount": 0,
+                "Name": "Still water",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "leaf",
+                "ID": "11",
+                "LimitedDescendantCount": 0,
+                "Name": "Sparkling water",
               },
             ]
         `);
@@ -1435,5 +1435,149 @@ describe('Hierarchy Access', () => {
                         },
                       ]
               `);
+    });
+
+    it('7 - Hierarchy in LR, sort in desc order', async () => {
+        const odataRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: "/SalesOrganizations?$apply=orderby(ID%20desc)/com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/SalesOrganizations,HierarchyQualifier='SalesOrgHierarchy',NodeProperty='ID',Levels=2)&$select=DistanceFromRoot,DrillState,ID,LimitedDescendantCount,Name&$count=true&$skip=0&$top=76"
+            },
+            dataAccess
+        );
+        expect(odataRequest.applyDefinition).toMatchInlineSnapshot(`
+            [
+              {
+                "orderBy": [
+                  {
+                    "direction": "desc",
+                    "name": "ID",
+                  },
+                ],
+                "type": "orderBy",
+              },
+              {
+                "name": "com.sap.vocabularies.Hierarchy.v1.TopLevels",
+                "parameters": {
+                  "HierarchyNodes": "$root/SalesOrganizations",
+                  "HierarchyQualifier": "'SalesOrgHierarchy'",
+                  "Levels": "2",
+                  "NodeProperty": "'ID'",
+                },
+                "type": "customFunction",
+              },
+            ]
+        `);
+        const data = await dataAccess.getData(odataRequest);
+        expect(data).toMatchInlineSnapshot(`
+            [
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "ID": "Sales",
+                "LimitedDescendantCount": 2,
+                "Name": "Corporate Sales",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "collapsed",
+                "ID": "US",
+                "LimitedDescendantCount": 0,
+                "Name": "US",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "collapsed",
+                "ID": "EMEA",
+                "LimitedDescendantCount": 0,
+                "Name": "EMEA",
+              },
+            ]
+        `);
+    });
+
+    it('8 - Expand all should work ', async () => {
+        const odataRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: `/SalesOrganizations?$apply=com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/SalesOrganizations,HierarchyQualifier='SalesOrgHierarchy',NodeProperty='ID',Levels=999)&$select=DistanceFromRoot,DrillState,ID,LimitedDescendantCount,Name&$count=true&$skip=0&$top=47`
+            },
+            dataAccess
+        );
+        expect(odataRequest.applyDefinition).toMatchInlineSnapshot(`
+            [
+              {
+                "name": "com.sap.vocabularies.Hierarchy.v1.TopLevels",
+                "parameters": {
+                  "HierarchyNodes": "$root/SalesOrganizations",
+                  "HierarchyQualifier": "'SalesOrgHierarchy'",
+                  "Levels": "999",
+                  "NodeProperty": "'ID'",
+                },
+                "type": "customFunction",
+              },
+            ]
+        `);
+        const data = await dataAccess.getData(odataRequest);
+        expect(data).toMatchInlineSnapshot(`
+            [
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "ID": "Sales",
+                "LimitedDescendantCount": 7,
+                "Name": "Corporate Sales",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "expanded",
+                "ID": "EMEA",
+                "LimitedDescendantCount": 1,
+                "Name": "EMEA",
+              },
+              {
+                "DistanceFromRoot": 2,
+                "DrillState": "leaf",
+                "ID": "EMEA Central",
+                "LimitedDescendantCount": 0,
+                "Name": "EMEA Central",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "expanded",
+                "ID": "US",
+                "LimitedDescendantCount": 4,
+                "Name": "US",
+              },
+              {
+                "DistanceFromRoot": 2,
+                "DrillState": "leaf",
+                "ID": "US West",
+                "LimitedDescendantCount": 0,
+                "Name": "US West",
+              },
+              {
+                "DistanceFromRoot": 2,
+                "DrillState": "expanded",
+                "ID": "US East",
+                "LimitedDescendantCount": 2,
+                "Name": "US East",
+              },
+              {
+                "DistanceFromRoot": 3,
+                "DrillState": "expanded",
+                "ID": "NY",
+                "LimitedDescendantCount": 1,
+                "Name": "New York State",
+              },
+              {
+                "DistanceFromRoot": 4,
+                "DrillState": "leaf",
+                "ID": "NYC",
+                "LimitedDescendantCount": 0,
+                "Name": "New York City",
+              },
+            ]
+        `);
     });
 });


### PR DESCRIPTION
Fix for #520 #519 

This change technically covers three things

- support for parsing `desc` in the queries
- actually try to support the orderby in the queries (so far ignored)
- making sure that the leaf status is properly set in all case