### PR TITLE
fix(converter): removed strict checking for a boolean value

### DIFF
--- a/.changeset/heavy-vans-appear.md
+++ b/.changeset/heavy-vans-appear.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/annotation-converter": patch
+---
+
+fix(converter): removed strict checking for a boolean value

--- a/packages/annotation-converter/src/writeback.ts
+++ b/packages/annotation-converter/src/writeback.ts
@@ -61,7 +61,7 @@ function revertObjectToRawType(references: Reference[], value: any) {
     } else if (value.isBoolean?.()) {
         result = {
             type: 'Bool',
-            Bool: value.valueOf() === 'true'
+            Bool: value.valueOf()
         };
     } else if (value.type === 'Path') {
         result = {

--- a/packages/annotation-converter/test/writeback.spec.ts
+++ b/packages/annotation-converter/test/writeback.spec.ts
@@ -11,17 +11,16 @@ const FilterDefaultValue = Object.assign('String', {
     }
 });
 
-const getFilterDefaultValueAnnotation = (edmType: string) => {
-    const value = '12.1';
+const getFilterDefaultValueAnnotation = (edmType: string, testValue: string) => {
     return {
         [`is${edmType}`]() {
             return true;
         },
         valueOf() {
-            return value;
+            return testValue;
         },
         toString() {
-            return value.toString();
+            return testValue.toString();
         }
     };
 };
@@ -67,8 +66,9 @@ describe('Writeback capabilities', () => {
         expect(convertedTypes.entitySets[0].annotations).not.toBeNull();
 
         const supportedEdmTypes = ['String', 'Float', 'Int', 'Date', 'Boolean', 'Decimal'];
+        const testValue = '{{placeholder}}';
         for (const edmType of supportedEdmTypes) {
-            const FilterDefaultValueAnnotation = getFilterDefaultValueAnnotation(edmType);
+            const FilterDefaultValueAnnotation = getFilterDefaultValueAnnotation(edmType, testValue);
             const expectedValueType = edmType === 'Boolean' ? 'Bool' : edmType;
             const transformedFilterDefaultValue = revertTermToGenericType(
                 defaultReferences,
@@ -76,6 +76,7 @@ describe('Writeback capabilities', () => {
             ) as any;
             expect(transformedFilterDefaultValue).not.toBeUndefined();
             expect(transformedFilterDefaultValue.value?.type).toContain(expectedValueType);
+            expect(transformedFilterDefaultValue.value?.[expectedValueType]).toBe(testValue);
         }
     });
 


### PR DESCRIPTION
With this PR, strict checking the value of Boolean type value is removed.

Reason: 
Resolving the type of the value is not possible at the time of applying it as value wouldn't be known at the time.(wrt. Guided Development)
Having a placeholder in place would help replacing it in the later point in time.

With this change it is now possible to apply annotation like so.

```xml
<PropertyValue Property="SearchSupported" Bool="{{searchSupported}}" />
```