### PR TITLE
fix: we now send the correct http header for $count queries

### DIFF
--- a/.changeset/itchy-dryers-compare.md
+++ b/.changeset/itchy-dryers-compare.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+We now send the correct http header for the $count queries

--- a/.changeset/itchy-dryers-compare.md
+++ b/.changeset/itchy-dryers-compare.md
@@ -2,4 +2,4 @@
 '@sap-ux/fe-mockserver-core': patch
 ---
 
-We now send the correct http header for the $count queries
+We now send the correct http header for the $count queries in batch

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -444,12 +444,12 @@ export default class ODataRequest {
         } else {
             this.addResponseHeader('dataserviceversion', '2.0');
             this.addResponseHeader('cache-control', 'no-store, no-cache');
-            this.addResponseHeader('content-type', 'application/json');
         }
         if (typeof this.responseData === 'string') {
             return this.responseData;
         }
         if (typeof this.responseData === 'number' && this.isCountQuery) {
+            this.addResponseHeader('content-type', 'text/plain');
             return this.responseData.toString();
         }
         if (this.dataAccess.getMetadata().getVersion() === '4.0') {
@@ -492,6 +492,7 @@ export default class ODataRequest {
             if (this.statusCode === 204) {
                 return;
             }
+            this.addResponseHeader('content-type', 'application/json');
             // V2
             const resultObject: any = { d: {} };
             if (Array.isArray(this.responseData)) {

--- a/packages/fe-mockserver-core/test/unit/v2/__snapshots__/dataAccess.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/v2/__snapshots__/dataAccess.test.ts.snap
@@ -5,7 +5,6 @@ exports[`Data Access v2metadata - it can DELETE data for an entity 1`] = `undefi
 exports[`Data Access v2metadata - it can DELETE data for an entity 2`] = `
 {
   "cache-control": "no-store, no-cache",
-  "content-type": "application/json",
   "dataserviceversion": "2.0",
   "sap-tenantid": "tenant-default",
 }


### PR DESCRIPTION
This was reported from an internal incident and is also target by #535 