### PR TITLE
fix: better analytical queries

### DIFF
--- a/.changeset/sour-roses-prove.md
+++ b/.changeset/sour-roses-prove.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Analytical queries operator will not overmatch their boundaries

--- a/packages/fe-mockserver-core/src/request/applyParser.ts
+++ b/packages/fe-mockserver-core/src/request/applyParser.ts
@@ -384,6 +384,7 @@ export class ApplyParser extends FilterParser {
                         this.CONSUME5(WS);
                         this.CONSUME(AS_TOKEN);
                         this.CONSUME6(WS);
+                        // NetAmount%20with%20max%20as%20maxAmount
                         alias = this.CONSUME3(SIMPLEIDENTIFIER).image;
                     });
 

--- a/packages/fe-mockserver-core/src/request/commonTokens.ts
+++ b/packages/fe-mockserver-core/src/request/commonTokens.ts
@@ -58,6 +58,6 @@ export const FROM_TOKEN = createToken({ name: 'From', pattern: /from/ });
 export const AS_TOKEN = createToken({ name: 'As', pattern: /as/ });
 export const AGGREGATE_FUNCTION = createToken({
     name: 'Aggregate Functions',
-    pattern: /sum|min|max|countdistinct|average/
+    pattern: /\b(sum|min|max|countdistinct|average)\b/
 });
 export const ROOT_TOKEN = createToken({ name: 'Root Token', pattern: /\$root\// });

--- a/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
@@ -507,6 +507,37 @@ describe('OData Request', () => {
               },
             ]
         `);
+
+        const anotherALPRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: `/SalesOrderItem?entitySet=SalesOrderItem&useBatchRequests=true&provideGrandTotals=true&provideTotalResultSize=true&noPaging=true&$apply=groupby((SalesOrderItem,SalesOrderItemText),aggregate(NetAmount%20with%20max%20as%20maxAmount))`
+            },
+            fakeDataAccess
+        );
+        expect(anotherALPRequest.applyDefinition).toMatchInlineSnapshot(`
+            [
+              {
+                "groupBy": [
+                  "SalesOrderItem",
+                  "SalesOrderItemText",
+                ],
+                "subTransformations": [
+                  {
+                    "aggregateDef": [
+                      {
+                        "name": "maxAmount",
+                        "operator": "max",
+                        "sourceProperty": "NetAmount",
+                      },
+                    ],
+                    "type": "aggregates",
+                  },
+                ],
+                "type": "groupBy",
+              },
+            ]
+        `);
     });
 
     // $filter


### PR DESCRIPTION
Fix for the second error reported in #541 

Basically the `max` operator was always matched in `maxAmount` which was breaking some patterns there