### PR TITLE
fix: resolving works even on edge cases

### DIFF
--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -106,7 +106,7 @@ function resolveTarget<T>(
     if (startElement === undefined) {
         // no starting point given: start at the entity container
         if (
-            pathSegments[0].startsWith(converter.rawSchema.namespace) &&
+            pathSegments[0].startsWith(`${converter.rawSchema.namespace}.`) &&
             pathSegments[0] !== converter.getConvertedEntityContainer()?.fullyQualifiedName
         ) {
             // We have a fully qualified name in the path that is not the entity container.

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -177,10 +177,13 @@ describe('Annotation Converter', () => {
 
     describe('can support resolvePath syntax', () => {
         let convertedTypes: ConvertedMetadata;
+        let convertedTypesModified: ConvertedMetadata;
 
         beforeAll(async () => {
             const parsedEDMX = parse(await loadFixture('v4/v4Meta.xml'));
+            const parsedEDMXModified = parse(await loadFixture('v4/v4MetaModified.xml'));
             convertedTypes = convert(parsedEDMX);
+            convertedTypesModified = convert(parsedEDMXModified);
         });
 
         it('can resolve EntitySet', () => {
@@ -300,6 +303,14 @@ describe('Annotation Converter', () => {
             expect(sdManageLineItem.target).not.toBeUndefined();
             expect(sdManageLineItem.target?.term).toEqual(UIAnnotationTerms.LineItem);
             expect(sdManageLineItem.objectPath.length).toEqual(4); // EntityContainer / EntitySet / EntityType
+
+            const sdManageLineItem2: ResolutionTarget<LineItem> = convertedTypesModified.resolvePath(
+                '/SalesOrderManage/@UI.LineItem'
+            );
+            expect(sdManageLineItem2.target).not.toBeNull();
+            expect(sdManageLineItem2.target).not.toBeUndefined();
+            expect(sdManageLineItem2.target?.term).toEqual(UIAnnotationTerms.LineItem);
+            expect(sdManageLineItem2.objectPath.length).toEqual(4); // EntityContainer / EntitySe
         });
 
         it('can resolve EntityType Annotations by index', () => {

--- a/packages/annotation-converter/test/fixtures/v4/v4MetaModified.xml
+++ b/packages/annotation-converter/test/fixtures/v4/v4MetaModified.xml
@@ -28,48 +28,48 @@
     <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
   </edmx:Reference>
   <edmx:DataServices>
-    <Schema Namespace="com.c_salesordermanage_sd" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+    <Schema Namespace="SalesOrderManage" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EntityContainer Name="EntityContainer">
-        <EntitySet Name="BillingBlockReason" EntityType="com.c_salesordermanage_sd.BillingBlockReason"/>
-        <EntitySet Name="BusinessPartner" EntityType="com.c_salesordermanage_sd.BusinessPartner"/>
-        <EntitySet Name="C_MaterialBySlsOrgDistrChnl" EntityType="com.c_salesordermanage_sd.C_MaterialBySlsOrgDistrChnl"/>
-        <EntitySet Name="C_NotLockedSalesOrderTypeVH" EntityType="com.c_salesordermanage_sd.C_NotLockedSalesOrderTypeVH"/>
-        <EntitySet Name="C_ProductUnitsOfMeasureVH" EntityType="com.c_salesordermanage_sd.C_ProductUnitsOfMeasureVH"/>
-        <EntitySet Name="CreditLimitDetails" EntityType="com.c_salesordermanage_sd.CreditLimitDetails"/>
-        <EntitySet Name="Customer" EntityType="com.c_salesordermanage_sd.Customer"/>
-        <EntitySet Name="CustomerPaymentTerms" EntityType="com.c_salesordermanage_sd.CustomerPaymentTerms">
+        <EntitySet Name="BillingBlockReason" EntityType="SalesOrderManage.BillingBlockReason"/>
+        <EntitySet Name="BusinessPartner" EntityType="SalesOrderManage.BusinessPartner"/>
+        <EntitySet Name="C_MaterialBySlsOrgDistrChnl" EntityType="SalesOrderManage.C_MaterialBySlsOrgDistrChnl"/>
+        <EntitySet Name="C_NotLockedSalesOrderTypeVH" EntityType="SalesOrderManage.C_NotLockedSalesOrderTypeVH"/>
+        <EntitySet Name="C_ProductUnitsOfMeasureVH" EntityType="SalesOrderManage.C_ProductUnitsOfMeasureVH"/>
+        <EntitySet Name="CreditLimitDetails" EntityType="SalesOrderManage.CreditLimitDetails"/>
+        <EntitySet Name="Customer" EntityType="SalesOrderManage.Customer"/>
+        <EntitySet Name="CustomerPaymentTerms" EntityType="SalesOrderManage.CustomerPaymentTerms">
           <NavigationPropertyBinding Path="_CustomerPaymentTermsEx" Target="CustomerPaymentTermsExtended"/>
         </EntitySet>
-        <EntitySet Name="CustomerPaymentTermsExtended" EntityType="com.c_salesordermanage_sd.CustomerPaymentTermsExtended">
+        <EntitySet Name="CustomerPaymentTermsExtended" EntityType="SalesOrderManage.CustomerPaymentTermsExtended">
           <NavigationPropertyBinding Path="_OriginalCustomerPaymentTerms" Target="CustomerPaymentTerms"/>
         </EntitySet>
-        <EntitySet Name="CustomerPurchaseOrderType" EntityType="com.c_salesordermanage_sd.CustomerPurchaseOrderType"/>
-        <EntitySet Name="DeliveryBlockReason" EntityType="com.c_salesordermanage_sd.DeliveryBlockReason"/>
-        <EntitySet Name="DeliveryBlockReasonType" EntityType="com.c_salesordermanage_sd.DeliveryBlockReasonType"/>
-        <EntitySet Name="DeliveryPriority" EntityType="com.c_salesordermanage_sd.DeliveryPriority"/>
-        <EntitySet Name="DistributionChannel" EntityType="com.c_salesordermanage_sd.DistributionChannel"/>
-        <EntitySet Name="HeaderPartner" EntityType="com.c_salesordermanage_sd.HeaderPartner">
+        <EntitySet Name="CustomerPurchaseOrderType" EntityType="SalesOrderManage.CustomerPurchaseOrderType"/>
+        <EntitySet Name="DeliveryBlockReason" EntityType="SalesOrderManage.DeliveryBlockReason"/>
+        <EntitySet Name="DeliveryBlockReasonType" EntityType="SalesOrderManage.DeliveryBlockReasonType"/>
+        <EntitySet Name="DeliveryPriority" EntityType="SalesOrderManage.DeliveryPriority"/>
+        <EntitySet Name="DistributionChannel" EntityType="SalesOrderManage.DistributionChannel"/>
+        <EntitySet Name="HeaderPartner" EntityType="SalesOrderManage.HeaderPartner">
           <NavigationPropertyBinding Path="owner" Target="SalesOrderManage"/>
           <NavigationPropertyBinding Path="SiblingEntity" Target="HeaderPartner"/>
         </EntitySet>
-        <EntitySet Name="HeaderShipToParty" EntityType="com.c_salesordermanage_sd.HeaderShipToParty">
+        <EntitySet Name="HeaderShipToParty" EntityType="SalesOrderManage.HeaderShipToParty">
           <NavigationPropertyBinding Path="_ShipToPartyVH" Target="Customer"/>
           <NavigationPropertyBinding Path="SiblingEntity" Target="HeaderShipToParty"/>
         </EntitySet>
-        <EntitySet Name="I_DistributionChannel" EntityType="com.c_salesordermanage_sd.I_DistributionChannel"/>
-        <EntitySet Name="I_OrganizationDivision" EntityType="com.c_salesordermanage_sd.I_OrganizationDivision">
+        <EntitySet Name="I_DistributionChannel" EntityType="SalesOrderManage.I_DistributionChannel"/>
+        <EntitySet Name="I_OrganizationDivision" EntityType="SalesOrderManage.I_OrganizationDivision">
           <NavigationPropertyBinding Path="_I_SalesOrganization" Target="I_SalesOrganization"/>
         </EntitySet>
-        <EntitySet Name="I_SalesOrganization" EntityType="com.c_salesordermanage_sd.I_SalesOrganization"/>
-        <EntitySet Name="IncotermsClassification" EntityType="com.c_salesordermanage_sd.IncotermsClassification"/>
-        <EntitySet Name="IncotermsVersion" EntityType="com.c_salesordermanage_sd.IncotermsVersion"/>
-        <EntitySet Name="Material" EntityType="com.c_salesordermanage_sd.Material">
+        <EntitySet Name="I_SalesOrganization" EntityType="SalesOrderManage.I_SalesOrganization"/>
+        <EntitySet Name="IncotermsClassification" EntityType="SalesOrderManage.IncotermsClassification"/>
+        <EntitySet Name="IncotermsVersion" EntityType="SalesOrderManage.IncotermsVersion"/>
+        <EntitySet Name="Material" EntityType="SalesOrderManage.Material">
           <NavigationPropertyBinding Path="_MaterialGroup" Target="MaterialGroup"/>
           <NavigationPropertyBinding Path="_MaterialRatings" Target="MaterialRatings"/>
         </EntitySet>
-        <EntitySet Name="MaterialCategory" EntityType="com.c_salesordermanage_sd.MaterialCategory"/>
-        <EntitySet Name="MaterialCountry" EntityType="com.c_salesordermanage_sd.MaterialCountry"/>
-        <EntitySet Name="MaterialDetails" EntityType="com.c_salesordermanage_sd.MaterialDetails">
+        <EntitySet Name="MaterialCategory" EntityType="SalesOrderManage.MaterialCategory"/>
+        <EntitySet Name="MaterialCountry" EntityType="SalesOrderManage.MaterialCountry"/>
+        <EntitySet Name="MaterialDetails" EntityType="SalesOrderManage.MaterialDetails">
           <NavigationPropertyBinding Path="material" Target="Material"/>
           <NavigationPropertyBinding Path="owner" Target="SalesOrderItem"/>
           <NavigationPropertyBinding Path="_ModelYear" Target="MaterialYears"/>
@@ -80,32 +80,32 @@
           <NavigationPropertyBinding Path="_MaterialRatings" Target="MaterialRatings"/>
           <NavigationPropertyBinding Path="SiblingEntity" Target="MaterialDetails"/>
         </EntitySet>
-        <EntitySet Name="MaterialGroup" EntityType="com.c_salesordermanage_sd.MaterialGroup"/>
-        <EntitySet Name="MaterialRatings" EntityType="com.c_salesordermanage_sd.MaterialRatings">
+        <EntitySet Name="MaterialGroup" EntityType="SalesOrderManage.MaterialGroup"/>
+        <EntitySet Name="MaterialRatings" EntityType="SalesOrderManage.MaterialRatings">
           <NavigationPropertyBinding Path="_Rating" Target="Rating"/>
           <NavigationPropertyBinding Path="materialdetail" Target="MaterialDetails"/>
           <NavigationPropertyBinding Path="material" Target="Material"/>
           <NavigationPropertyBinding Path="_MaterialRatingsDetails" Target="MaterialRatingsDetails"/>
           <NavigationPropertyBinding Path="SiblingEntity" Target="MaterialRatings"/>
         </EntitySet>
-        <EntitySet Name="MaterialRatingsDetails" EntityType="com.c_salesordermanage_sd.MaterialRatingsDetails">
+        <EntitySet Name="MaterialRatingsDetails" EntityType="SalesOrderManage.MaterialRatingsDetails">
           <NavigationPropertyBinding Path="materialrating" Target="MaterialRatings"/>
           <NavigationPropertyBinding Path="material" Target="Material"/>
           <NavigationPropertyBinding Path="SiblingEntity" Target="MaterialRatingsDetails"/>
         </EntitySet>
-        <EntitySet Name="MaterialYears" EntityType="com.c_salesordermanage_sd.MaterialYears">
+        <EntitySet Name="MaterialYears" EntityType="SalesOrderManage.MaterialYears">
           <NavigationPropertyBinding Path="WarrantyYearDetail_Association" Target="WarrantyYearDetails"/>
         </EntitySet>
-        <EntitySet Name="OrganizationDivision" EntityType="com.c_salesordermanage_sd.OrganizationDivision"/>
-        <EntitySet Name="OverallBillingBlockStatus" EntityType="com.c_salesordermanage_sd.OverallBillingBlockStatus"/>
-        <EntitySet Name="OverallDeliveryBlockStatus" EntityType="com.c_salesordermanage_sd.OverallDeliveryBlockStatus"/>
-        <EntitySet Name="OverallSDProcessStatus" EntityType="com.c_salesordermanage_sd.OverallSDProcessStatus"/>
-        <EntitySet Name="Rating" EntityType="com.c_salesordermanage_sd.Rating"/>
-        <EntitySet Name="SDDocumentReason" EntityType="com.c_salesordermanage_sd.SDDocumentReason"/>
-        <EntitySet Name="SalesDistrict" EntityType="com.c_salesordermanage_sd.SalesDistrict"/>
-        <EntitySet Name="SalesGroup" EntityType="com.c_salesordermanage_sd.SalesGroup"/>
-        <EntitySet Name="SalesOffice" EntityType="com.c_salesordermanage_sd.SalesOffice"/>
-        <EntitySet Name="SalesOrderItem" EntityType="com.c_salesordermanage_sd.SalesOrderItem">
+        <EntitySet Name="OrganizationDivision" EntityType="SalesOrderManage.OrganizationDivision"/>
+        <EntitySet Name="OverallBillingBlockStatus" EntityType="SalesOrderManage.OverallBillingBlockStatus"/>
+        <EntitySet Name="OverallDeliveryBlockStatus" EntityType="SalesOrderManage.OverallDeliveryBlockStatus"/>
+        <EntitySet Name="OverallSDProcessStatus" EntityType="SalesOrderManage.OverallSDProcessStatus"/>
+        <EntitySet Name="Rating" EntityType="SalesOrderManage.Rating"/>
+        <EntitySet Name="SDDocumentReason" EntityType="SalesOrderManage.SDDocumentReason"/>
+        <EntitySet Name="SalesDistrict" EntityType="SalesOrderManage.SalesDistrict"/>
+        <EntitySet Name="SalesGroup" EntityType="SalesOrderManage.SalesGroup"/>
+        <EntitySet Name="SalesOffice" EntityType="SalesOrderManage.SalesOffice"/>
+        <EntitySet Name="SalesOrderItem" EntityType="SalesOrderManage.SalesOrderItem">
           <NavigationPropertyBinding Path="_CustomerPaymentTerms" Target="CustomerPaymentTerms"/>
           <NavigationPropertyBinding Path="_DeliveryPriority" Target="DeliveryPriority"/>
           <NavigationPropertyBinding Path="_IncotermsClassification" Target="IncotermsClassification"/>
@@ -125,8 +125,8 @@
           <NavigationPropertyBinding Path="_ScheduleLine" Target="SalesOrderScheduleLineType"/>
           <NavigationPropertyBinding Path="SiblingEntity" Target="SalesOrderItem"/>
         </EntitySet>
-        <EntitySet Name="SalesOrderItemCategory" EntityType="com.c_salesordermanage_sd.SalesOrderItemCategory"/>
-        <EntitySet Name="SalesOrderManage" EntityType="com.c_salesordermanage_sd.SalesOrderManage">
+        <EntitySet Name="SalesOrderItemCategory" EntityType="SalesOrderManage.SalesOrderItemCategory"/>
+        <EntitySet Name="SalesOrderManage" EntityType="SalesOrderManage.SalesOrderManage">
           <NavigationPropertyBinding Path="_CustomerPaymentTerms" Target="CustomerPaymentTerms"/>
           <NavigationPropertyBinding Path="_CustomerPurchaseOrderType" Target="CustomerPurchaseOrderType"/>
           <NavigationPropertyBinding Path="_DeliveryBlockReason" Target="DeliveryBlockReason"/>
@@ -154,22 +154,22 @@
           <NavigationPropertyBinding Path="_ReferencedSalesOrder" Target="SalesOrderManage"/>
           <NavigationPropertyBinding Path="SiblingEntity" Target="SalesOrderManage"/>
         </EntitySet>
-        <EntitySet Name="SalesOrderScheduleLineType" EntityType="com.c_salesordermanage_sd.SalesOrderScheduleLineType">
+        <EntitySet Name="SalesOrderScheduleLineType" EntityType="SalesOrderManage.SalesOrderScheduleLineType">
           <NavigationPropertyBinding Path="owner" Target="SalesOrderItem"/>
           <NavigationPropertyBinding Path="_DelivBlockReasonForSchedLine" Target="DeliveryBlockReasonType"/>
           <NavigationPropertyBinding Path="_OrderQuantityUnit" Target="UnitOfMeasure"/>
           <NavigationPropertyBinding Path="SiblingEntity" Target="SalesOrderScheduleLineType"/>
         </EntitySet>
-        <EntitySet Name="SalesOrderType" EntityType="com.c_salesordermanage_sd.SalesOrderType"/>
-        <EntitySet Name="SalesOrganization" EntityType="com.c_salesordermanage_sd.SalesOrganization"/>
-        <EntitySet Name="ShippingCondition" EntityType="com.c_salesordermanage_sd.ShippingCondition"/>
-        <EntitySet Name="ShippingPoint" EntityType="com.c_salesordermanage_sd.ShippingPoint"/>
-        <EntitySet Name="ShippingType" EntityType="com.c_salesordermanage_sd.ShippingType"/>
-        <EntitySet Name="UnitOfMeasure" EntityType="com.c_salesordermanage_sd.UnitOfMeasure"/>
-        <EntitySet Name="WarrantyYearDetails" EntityType="com.c_salesordermanage_sd.WarrantyYearDetails"/>
-        <ActionImport Name="ReturnInProcess" Action="com.c_salesordermanage_sd.ReturnInProcess" EntitySet="SalesOrderManage"/>
-        <ActionImport Name="UnboundAction" Action="com.c_salesordermanage_sd.UnboundAction" EntitySet="SalesOrderManage"/>
-        <ActionImport Name="addEmptyStatus" Action="com.c_salesordermanage_sd.addEmptyStatus"/>
+        <EntitySet Name="SalesOrderType" EntityType="SalesOrderManage.SalesOrderType"/>
+        <EntitySet Name="SalesOrganization" EntityType="SalesOrderManage.SalesOrganization"/>
+        <EntitySet Name="ShippingCondition" EntityType="SalesOrderManage.ShippingCondition"/>
+        <EntitySet Name="ShippingPoint" EntityType="SalesOrderManage.ShippingPoint"/>
+        <EntitySet Name="ShippingType" EntityType="SalesOrderManage.ShippingType"/>
+        <EntitySet Name="UnitOfMeasure" EntityType="SalesOrderManage.UnitOfMeasure"/>
+        <EntitySet Name="WarrantyYearDetails" EntityType="SalesOrderManage.WarrantyYearDetails"/>
+        <ActionImport Name="ReturnInProcess" Action="SalesOrderManage.ReturnInProcess" EntitySet="SalesOrderManage"/>
+        <ActionImport Name="UnboundAction" Action="SalesOrderManage.UnboundAction" EntitySet="SalesOrderManage"/>
+        <ActionImport Name="addEmptyStatus" Action="SalesOrderManage.addEmptyStatus"/>
       </EntityContainer>
       <EntityType Name="BillingBlockReason">
         <Key>
@@ -273,7 +273,7 @@
         </Key>
         <Property Name="CustomerPaymentTerms" Type="Edm.String" MaxLength="4" Nullable="false"/>
         <Property Name="CustomerPaymentTerms_Text" Type="Edm.String" MaxLength="30"/>
-        <NavigationProperty Name="_CustomerPaymentTermsEx" Type="com.c_salesordermanage_sd.CustomerPaymentTermsExtended">
+        <NavigationProperty Name="_CustomerPaymentTermsEx" Type="SalesOrderManage.CustomerPaymentTermsExtended">
           <ReferentialConstraint Property="CustomerPaymentTerms" ReferencedProperty="CustomerPaymentTerms"/>
         </NavigationProperty>
       </EntityType>
@@ -283,7 +283,7 @@
         </Key>
         <Property Name="CustomerPaymentTerms" Type="Edm.String" MaxLength="4" Nullable="false"/>
         <Property Name="CustomerPaymentTermsExtended_Text" Type="Edm.String" MaxLength="60"/>
-        <NavigationProperty Name="_OriginalCustomerPaymentTerms" Type="com.c_salesordermanage_sd.CustomerPaymentTerms">
+        <NavigationProperty Name="_OriginalCustomerPaymentTerms" Type="SalesOrderManage.CustomerPaymentTerms">
           <ReferentialConstraint Property="CustomerPaymentTerms" ReferencedProperty="CustomerPaymentTerms"/>
         </NavigationProperty>
       </EntityType>
@@ -356,15 +356,15 @@
         <Property Name="CityName" Type="Edm.String" MaxLength="40"/>
         <Property Name="Country" Type="Edm.String" MaxLength="3"/>
         <Property Name="isVerified" Type="Edm.Boolean"/>
-        <NavigationProperty Name="owner" Type="com.c_salesordermanage_sd.SalesOrderManage" Partner="_Partner">
+        <NavigationProperty Name="owner" Type="SalesOrderManage.SalesOrderManage" Partner="_Partner">
           <ReferentialConstraint Property="owner_ID" ReferencedProperty="ID"/>
         </NavigationProperty>
         <Property Name="owner_ID" Type="Edm.Guid"/>
         <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
-        <NavigationProperty Name="DraftAdministrativeData" Type="com.c_salesordermanage_sd.DraftAdministrativeData" ContainsTarget="true"/>
-        <NavigationProperty Name="SiblingEntity" Type="com.c_salesordermanage_sd.HeaderPartner"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="SalesOrderManage.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="SalesOrderManage.HeaderPartner"/>
       </EntityType>
       <EntityType Name="HeaderShipToParty">
         <Key>
@@ -383,14 +383,14 @@
         <Property Name="HouseNumber" Type="Edm.String" MaxLength="10"/>
         <Property Name="isVerified" Type="Edm.Boolean"/>
         <Property Name="isDelivered" Type="Edm.Boolean"/>
-        <NavigationProperty Name="_ShipToPartyVH" Type="com.c_salesordermanage_sd.Customer">
+        <NavigationProperty Name="_ShipToPartyVH" Type="SalesOrderManage.Customer">
           <ReferentialConstraint Property="BusinessPartner" ReferencedProperty="Customer"/>
         </NavigationProperty>
         <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
-        <NavigationProperty Name="DraftAdministrativeData" Type="com.c_salesordermanage_sd.DraftAdministrativeData" ContainsTarget="true"/>
-        <NavigationProperty Name="SiblingEntity" Type="com.c_salesordermanage_sd.HeaderShipToParty"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="SalesOrderManage.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="SalesOrderManage.HeaderShipToParty"/>
       </EntityType>
       <EntityType Name="I_DistributionChannel">
         <Key>
@@ -406,7 +406,7 @@
         <Property Name="Division" Type="Edm.String" MaxLength="2" Nullable="false"/>
         <Property Name="Division_Text" Type="Edm.String" MaxLength="20"/>
         <Property Name="SalesOrganization" Type="Edm.String" MaxLength="4"/>
-        <NavigationProperty Name="_I_SalesOrganization" Type="com.c_salesordermanage_sd.I_SalesOrganization">
+        <NavigationProperty Name="_I_SalesOrganization" Type="SalesOrderManage.I_SalesOrganization">
           <ReferentialConstraint Property="SalesOrganization" ReferencedProperty="SalesOrganization"/>
         </NavigationProperty>
       </EntityType>
@@ -443,10 +443,10 @@
         <Property Name="isHidden" Type="Edm.Boolean"/>
         <Property Name="isUpdatable" Type="Edm.Boolean"/>
         <Property Name="Material_Text" Type="Edm.String" MaxLength="40"/>
-        <NavigationProperty Name="_MaterialGroup" Type="com.c_salesordermanage_sd.MaterialGroup">
+        <NavigationProperty Name="_MaterialGroup" Type="SalesOrderManage.MaterialGroup">
           <ReferentialConstraint Property="_MaterialGroup_MaterialGroup" ReferencedProperty="MaterialGroup"/>
         </NavigationProperty>
-        <NavigationProperty Name="_MaterialRatings" Type="Collection(com.c_salesordermanage_sd.MaterialRatings)" Partner="material">
+        <NavigationProperty Name="_MaterialRatings" Type="Collection(SalesOrderManage.MaterialRatings)" Partner="material">
           <OnDelete Action="Cascade"/>
         </NavigationProperty>
         <Property Name="_MaterialGroup_MaterialGroup" Type="Edm.String" MaxLength="9"/>
@@ -475,28 +475,28 @@
         <Property Name="WarrantyYear" Type="Edm.String" MaxLength="4"/>
         <Property Name="BrandCategory" Type="Edm.String" MaxLength="20"/>
         <Property Name="FabricationCountry" Type="Edm.String" MaxLength="20"/>
-        <NavigationProperty Name="material" Type="com.c_salesordermanage_sd.Material">
+        <NavigationProperty Name="material" Type="SalesOrderManage.Material">
           <ReferentialConstraint Property="material_Material" ReferencedProperty="Material"/>
         </NavigationProperty>
-        <NavigationProperty Name="owner" Type="com.c_salesordermanage_sd.SalesOrderItem" Partner="_MaterialDetails">
+        <NavigationProperty Name="owner" Type="SalesOrderManage.SalesOrderItem" Partner="_MaterialDetails">
           <ReferentialConstraint Property="owner_ID" ReferencedProperty="ID"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ModelYear" Type="com.c_salesordermanage_sd.MaterialYears">
+        <NavigationProperty Name="_ModelYear" Type="SalesOrderManage.MaterialYears">
           <ReferentialConstraint Property="ModelYear" ReferencedProperty="Model_Year"/>
         </NavigationProperty>
-        <NavigationProperty Name="WarrantyYearDetail" Type="com.c_salesordermanage_sd.WarrantyYearDetails">
+        <NavigationProperty Name="WarrantyYearDetail" Type="SalesOrderManage.WarrantyYearDetails">
           <ReferentialConstraint Property="WarrantyYearDetail_ID" ReferencedProperty="ID"/>
         </NavigationProperty>
-        <NavigationProperty Name="_WarrantyYear" Type="com.c_salesordermanage_sd.MaterialYears">
+        <NavigationProperty Name="_WarrantyYear" Type="SalesOrderManage.MaterialYears">
           <ReferentialConstraint Property="_WarrantyYear_Model_Year" ReferencedProperty="Model_Year"/>
         </NavigationProperty>
-        <NavigationProperty Name="_MaterialCountry" Type="com.c_salesordermanage_sd.MaterialCountry">
+        <NavigationProperty Name="_MaterialCountry" Type="SalesOrderManage.MaterialCountry">
           <ReferentialConstraint Property="FabricationCountry" ReferencedProperty="Country"/>
         </NavigationProperty>
-        <NavigationProperty Name="_MaterialCategory" Type="com.c_salesordermanage_sd.MaterialCategory">
+        <NavigationProperty Name="_MaterialCategory" Type="SalesOrderManage.MaterialCategory">
           <ReferentialConstraint Property="BrandCategory" ReferencedProperty="Category"/>
         </NavigationProperty>
-        <NavigationProperty Name="_MaterialRatings" Type="Collection(com.c_salesordermanage_sd.MaterialRatings)" Partner="materialdetail">
+        <NavigationProperty Name="_MaterialRatings" Type="Collection(SalesOrderManage.MaterialRatings)" Partner="materialdetail">
           <OnDelete Action="Cascade"/>
         </NavigationProperty>
         <Property Name="material_Material" Type="Edm.String" MaxLength="18"/>
@@ -506,8 +506,8 @@
         <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
-        <NavigationProperty Name="DraftAdministrativeData" Type="com.c_salesordermanage_sd.DraftAdministrativeData" ContainsTarget="true"/>
-        <NavigationProperty Name="SiblingEntity" Type="com.c_salesordermanage_sd.MaterialDetails"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="SalesOrderManage.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="SalesOrderManage.MaterialDetails"/>
       </EntityType>
       <EntityType Name="MaterialGroup">
         <Key>
@@ -524,16 +524,16 @@
         <Property Name="ID" Type="Edm.Guid" Nullable="false"/>
         <Property Name="Rating" Type="Edm.Decimal" Scale="2" Precision="4"/>
         <Property Name="Title" Type="Edm.String" MaxLength="25"/>
-        <NavigationProperty Name="_Rating" Type="com.c_salesordermanage_sd.Rating">
+        <NavigationProperty Name="_Rating" Type="SalesOrderManage.Rating">
           <ReferentialConstraint Property="Rating" ReferencedProperty="Rating"/>
         </NavigationProperty>
-        <NavigationProperty Name="materialdetail" Type="com.c_salesordermanage_sd.MaterialDetails" Partner="_MaterialRatings">
+        <NavigationProperty Name="materialdetail" Type="SalesOrderManage.MaterialDetails" Partner="_MaterialRatings">
           <ReferentialConstraint Property="materialdetail_ID" ReferencedProperty="ID"/>
         </NavigationProperty>
-        <NavigationProperty Name="material" Type="com.c_salesordermanage_sd.Material" Partner="_MaterialRatings">
+        <NavigationProperty Name="material" Type="SalesOrderManage.Material" Partner="_MaterialRatings">
           <ReferentialConstraint Property="material_Material" ReferencedProperty="Material"/>
         </NavigationProperty>
-        <NavigationProperty Name="_MaterialRatingsDetails" Type="Collection(com.c_salesordermanage_sd.MaterialRatingsDetails)" Partner="materialrating">
+        <NavigationProperty Name="_MaterialRatingsDetails" Type="Collection(SalesOrderManage.MaterialRatingsDetails)" Partner="materialrating">
           <OnDelete Action="Cascade"/>
         </NavigationProperty>
         <Property Name="isDeletable" Type="Edm.Boolean"/>
@@ -542,8 +542,8 @@
         <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
-        <NavigationProperty Name="DraftAdministrativeData" Type="com.c_salesordermanage_sd.DraftAdministrativeData" ContainsTarget="true"/>
-        <NavigationProperty Name="SiblingEntity" Type="com.c_salesordermanage_sd.MaterialRatings"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="SalesOrderManage.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="SalesOrderManage.MaterialRatings"/>
       </EntityType>
       <EntityType Name="MaterialRatingsDetails">
         <Key>
@@ -555,10 +555,10 @@
         <Property Name="CREATEDAT" Type="Edm.DateTimeOffset"/>
         <Property Name="MODIFIEDAT" Type="Edm.DateTimeOffset"/>
         <Property Name="MODIFIEDBY" Type="Edm.String" MaxLength="241"/>
-        <NavigationProperty Name="materialrating" Type="com.c_salesordermanage_sd.MaterialRatings" Partner="_MaterialRatingsDetails">
+        <NavigationProperty Name="materialrating" Type="SalesOrderManage.MaterialRatings" Partner="_MaterialRatingsDetails">
           <ReferentialConstraint Property="materialrating_ID" ReferencedProperty="ID"/>
         </NavigationProperty>
-        <NavigationProperty Name="material" Type="com.c_salesordermanage_sd.Material">
+        <NavigationProperty Name="material" Type="SalesOrderManage.Material">
           <ReferentialConstraint Property="material_Material" ReferencedProperty="Material"/>
         </NavigationProperty>
         <Property Name="materialrating_ID" Type="Edm.Guid"/>
@@ -566,8 +566,8 @@
         <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
-        <NavigationProperty Name="DraftAdministrativeData" Type="com.c_salesordermanage_sd.DraftAdministrativeData" ContainsTarget="true"/>
-        <NavigationProperty Name="SiblingEntity" Type="com.c_salesordermanage_sd.MaterialRatingsDetails"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="SalesOrderManage.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="SalesOrderManage.MaterialRatingsDetails"/>
       </EntityType>
       <EntityType Name="MaterialYears">
         <Key>
@@ -576,7 +576,7 @@
         <Property Name="Model_Year" Type="Edm.String" MaxLength="4" Nullable="false"/>
         <Property Name="Warranty_Expiration" Type="Edm.String" MaxLength="4"/>
         <Property Name="WarrantyYearDetail_ID" Type="Edm.Guid"/>
-        <NavigationProperty Name="WarrantyYearDetail_Association" Type="com.c_salesordermanage_sd.WarrantyYearDetails">
+        <NavigationProperty Name="WarrantyYearDetail_Association" Type="SalesOrderManage.WarrantyYearDetails">
           <ReferentialConstraint Property="WarrantyYearDetail_ID" ReferencedProperty="ID"/>
         </NavigationProperty>
       </EntityType>
@@ -696,56 +696,56 @@
         <Property Name="DistributionChannel" Type="Edm.String" MaxLength="2"/>
         <Property Name="ReferencedSalesOrderID" Type="Edm.Guid"/>
         <Property Name="ReferencedSalesOrderItemID" Type="Edm.Guid"/>
-        <NavigationProperty Name="_CustomerPaymentTerms" Type="com.c_salesordermanage_sd.CustomerPaymentTerms">
+        <NavigationProperty Name="_CustomerPaymentTerms" Type="SalesOrderManage.CustomerPaymentTerms">
           <ReferentialConstraint Property="_CustomerPaymentTerms_CustomerPaymentTerms" ReferencedProperty="CustomerPaymentTerms"/>
         </NavigationProperty>
-        <NavigationProperty Name="_DeliveryPriority" Type="com.c_salesordermanage_sd.DeliveryPriority">
+        <NavigationProperty Name="_DeliveryPriority" Type="SalesOrderManage.DeliveryPriority">
           <ReferentialConstraint Property="_DeliveryPriority_DeliveryPriority" ReferencedProperty="DeliveryPriority"/>
         </NavigationProperty>
-        <NavigationProperty Name="_IncotermsClassification" Type="com.c_salesordermanage_sd.IncotermsClassification">
+        <NavigationProperty Name="_IncotermsClassification" Type="SalesOrderManage.IncotermsClassification">
           <ReferentialConstraint Property="_IncotermsClassification_IncotermsClassification" ReferencedProperty="IncotermsClassification"/>
         </NavigationProperty>
-        <NavigationProperty Name="_IncotermsVersion" Type="com.c_salesordermanage_sd.IncotermsVersion">
+        <NavigationProperty Name="_IncotermsVersion" Type="SalesOrderManage.IncotermsVersion">
           <ReferentialConstraint Property="_IncotermsVersion_IncotermsVersion" ReferencedProperty="IncotermsVersion"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ItemBillingBlockReason" Type="com.c_salesordermanage_sd.BillingBlockReason">
+        <NavigationProperty Name="_ItemBillingBlockReason" Type="SalesOrderManage.BillingBlockReason">
           <ReferentialConstraint Property="_ItemBillingBlockReason_BillingBlockReason" ReferencedProperty="BillingBlockReason"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ItemCategory" Type="com.c_salesordermanage_sd.SalesOrderItemCategory">
+        <NavigationProperty Name="_ItemCategory" Type="SalesOrderManage.SalesOrderItemCategory">
           <ReferentialConstraint Property="_ItemCategory_SalesDocumentItemCategory" ReferencedProperty="SalesDocumentItemCategory"/>
         </NavigationProperty>
-        <Property Name="SAP_Message" Type="Collection(com.c_salesordermanage_sd.c_salesordermanage_sd_sapmessage)" Nullable="false"/>
-        <NavigationProperty Name="_Material" Type="com.c_salesordermanage_sd.Material">
+        <Property Name="SAP_Message" Type="Collection(SalesOrderManage.c_salesordermanage_sd_sapmessage)" Nullable="false"/>
+        <NavigationProperty Name="_Material" Type="SalesOrderManage.Material">
           <ReferentialConstraint Property="Material" ReferencedProperty="Material"/>
         </NavigationProperty>
-        <NavigationProperty Name="_MaterialDetails" Type="Collection(com.c_salesordermanage_sd.MaterialDetails)" Partner="owner">
+        <NavigationProperty Name="_MaterialDetails" Type="Collection(SalesOrderManage.MaterialDetails)" Partner="owner">
           <OnDelete Action="Cascade"/>
         </NavigationProperty>
-        <NavigationProperty Name="_MaterialGroup" Type="com.c_salesordermanage_sd.MaterialGroup">
+        <NavigationProperty Name="_MaterialGroup" Type="SalesOrderManage.MaterialGroup">
           <ReferentialConstraint Property="_MaterialGroup_MaterialGroup" ReferencedProperty="MaterialGroup"/>
         </NavigationProperty>
-        <NavigationProperty Name="_RequestedQuantityUnit" Type="com.c_salesordermanage_sd.UnitOfMeasure">
+        <NavigationProperty Name="_RequestedQuantityUnit" Type="SalesOrderManage.UnitOfMeasure">
           <ReferentialConstraint Property="RequestedQuantityUnit" ReferencedProperty="UnitOfMeasure"/>
         </NavigationProperty>
-        <NavigationProperty Name="_SalesOrder" Type="com.c_salesordermanage_sd.SalesOrderType">
+        <NavigationProperty Name="_SalesOrder" Type="SalesOrderManage.SalesOrderType">
           <ReferentialConstraint Property="_SalesOrder_SalesOrderType" ReferencedProperty="SalesOrderType"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ShippingPoint" Type="com.c_salesordermanage_sd.ShippingPoint">
+        <NavigationProperty Name="_ShippingPoint" Type="SalesOrderManage.ShippingPoint">
           <ReferentialConstraint Property="_ShippingPoint_ShippingPoint" ReferencedProperty="ShippingPoint"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ShippingType" Type="com.c_salesordermanage_sd.ShippingType">
+        <NavigationProperty Name="_ShippingType" Type="SalesOrderManage.ShippingType">
           <ReferentialConstraint Property="_ShippingType_ShippingType" ReferencedProperty="ShippingType"/>
         </NavigationProperty>
-        <NavigationProperty Name="owner" Type="com.c_salesordermanage_sd.SalesOrderManage" Partner="_Item">
+        <NavigationProperty Name="owner" Type="SalesOrderManage.SalesOrderManage" Partner="_Item">
           <ReferentialConstraint Property="owner_ID" ReferencedProperty="ID"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ReferencedSalesOrder" Type="com.c_salesordermanage_sd.SalesOrderManage">
+        <NavigationProperty Name="_ReferencedSalesOrder" Type="SalesOrderManage.SalesOrderManage">
           <ReferentialConstraint Property="ReferencedSalesOrderID" ReferencedProperty="ID"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ReferencedSalesOrderItem" Type="com.c_salesordermanage_sd.SalesOrderItem">
+        <NavigationProperty Name="_ReferencedSalesOrderItem" Type="SalesOrderManage.SalesOrderItem">
           <ReferentialConstraint Property="ReferencedSalesOrderItemID" ReferencedProperty="ID"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ScheduleLine" Type="Collection(com.c_salesordermanage_sd.SalesOrderScheduleLineType)" Partner="owner">
+        <NavigationProperty Name="_ScheduleLine" Type="Collection(SalesOrderManage.SalesOrderScheduleLineType)" Partner="owner">
           <OnDelete Action="Cascade"/>
         </NavigationProperty>
         <Property Name="_CustomerPaymentTerms_CustomerPaymentTerms" Type="Edm.String" MaxLength="4"/>
@@ -762,8 +762,8 @@
         <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
-        <NavigationProperty Name="DraftAdministrativeData" Type="com.c_salesordermanage_sd.DraftAdministrativeData" ContainsTarget="true"/>
-        <NavigationProperty Name="SiblingEntity" Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="SalesOrderManage.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="SalesOrderManage.SalesOrderItem"/>
       </EntityType>
       <EntityType Name="SalesOrderItemCategory">
         <Key>
@@ -840,81 +840,81 @@
         <Property Name="document_name" Type="Edm.String"/>
         <Property Name="document_content" Type="Edm.Stream"/>
         <Property Name="document_type" Type="Edm.String"/>
-        <Property Name="ComplexWithNavigation" Type="Collection(com.c_salesordermanage_sd.c_salesordermanage_sd_complex_withNavigation)" Nullable="false"/>
-        <NavigationProperty Name="_CustomerPaymentTerms" Type="com.c_salesordermanage_sd.CustomerPaymentTerms">
+        <Property Name="ComplexWithNavigation" Type="Collection(SalesOrderManage.c_salesordermanage_sd_complex_withNavigation)" Nullable="false"/>
+        <NavigationProperty Name="_CustomerPaymentTerms" Type="SalesOrderManage.CustomerPaymentTerms">
           <ReferentialConstraint Property="CustomerPaymentTerms" ReferencedProperty="CustomerPaymentTerms"/>
         </NavigationProperty>
-        <NavigationProperty Name="_CustomerPurchaseOrderType" Type="com.c_salesordermanage_sd.CustomerPurchaseOrderType">
+        <NavigationProperty Name="_CustomerPurchaseOrderType" Type="SalesOrderManage.CustomerPurchaseOrderType">
           <ReferentialConstraint Property="_CustomerPurchaseOrderType_CustomerPurchaseOrderType" ReferencedProperty="CustomerPurchaseOrderType"/>
         </NavigationProperty>
-        <NavigationProperty Name="_DeliveryBlockReason" Type="com.c_salesordermanage_sd.DeliveryBlockReason">
+        <NavigationProperty Name="_DeliveryBlockReason" Type="SalesOrderManage.DeliveryBlockReason">
           <ReferentialConstraint Property="_DeliveryBlockReason_DeliveryBlockReason" ReferencedProperty="DeliveryBlockReason"/>
         </NavigationProperty>
-        <NavigationProperty Name="_DistributionChannel" Type="com.c_salesordermanage_sd.DistributionChannel">
+        <NavigationProperty Name="_DistributionChannel" Type="SalesOrderManage.DistributionChannel">
           <ReferentialConstraint Property="_DistributionChannel_DistributionChannel" ReferencedProperty="DistributionChannel"/>
         </NavigationProperty>
-        <NavigationProperty Name="_HeaderBillingBlockReason" Type="com.c_salesordermanage_sd.BillingBlockReason">
+        <NavigationProperty Name="_HeaderBillingBlockReason" Type="SalesOrderManage.BillingBlockReason">
           <ReferentialConstraint Property="_HeaderBillingBlockReason_BillingBlockReason" ReferencedProperty="BillingBlockReason"/>
         </NavigationProperty>
-        <NavigationProperty Name="_IncotermsClassification" Type="com.c_salesordermanage_sd.IncotermsClassification">
+        <NavigationProperty Name="_IncotermsClassification" Type="SalesOrderManage.IncotermsClassification">
           <ReferentialConstraint Property="IncotermsClassification" ReferencedProperty="IncotermsClassification"/>
         </NavigationProperty>
-        <NavigationProperty Name="_IncotermsVersion" Type="com.c_salesordermanage_sd.IncotermsVersion">
+        <NavigationProperty Name="_IncotermsVersion" Type="SalesOrderManage.IncotermsVersion">
           <ReferentialConstraint Property="IncotermsVersion" ReferencedProperty="IncotermsVersion"/>
         </NavigationProperty>
-        <NavigationProperty Name="_Item" Type="Collection(com.c_salesordermanage_sd.SalesOrderItem)" Partner="owner">
+        <NavigationProperty Name="_Item" Type="Collection(SalesOrderManage.SalesOrderItem)" Partner="owner">
           <OnDelete Action="Cascade"/>
         </NavigationProperty>
-        <NavigationProperty Name="_OrganizationDivision" Type="com.c_salesordermanage_sd.OrganizationDivision">
+        <NavigationProperty Name="_OrganizationDivision" Type="SalesOrderManage.OrganizationDivision">
           <ReferentialConstraint Property="_OrganizationDivision_Division" ReferencedProperty="Division"/>
         </NavigationProperty>
-        <NavigationProperty Name="_OverallBillingBlockStatus" Type="com.c_salesordermanage_sd.OverallBillingBlockStatus">
+        <NavigationProperty Name="_OverallBillingBlockStatus" Type="SalesOrderManage.OverallBillingBlockStatus">
           <ReferentialConstraint Property="_OverallBillingBlockStatus_OverallBillingBlockStatus" ReferencedProperty="OverallBillingBlockStatus"/>
         </NavigationProperty>
-        <NavigationProperty Name="_OverallDeliveryBlockStatus" Type="com.c_salesordermanage_sd.OverallDeliveryBlockStatus">
+        <NavigationProperty Name="_OverallDeliveryBlockStatus" Type="SalesOrderManage.OverallDeliveryBlockStatus">
           <ReferentialConstraint Property="_OverallDeliveryBlockStatus_OverallDeliveryBlockStatus" ReferencedProperty="OverallDeliveryBlockStatus"/>
         </NavigationProperty>
-        <NavigationProperty Name="_OverallSDProcessStatus" Type="com.c_salesordermanage_sd.OverallSDProcessStatus">
+        <NavigationProperty Name="_OverallSDProcessStatus" Type="SalesOrderManage.OverallSDProcessStatus">
           <ReferentialConstraint Property="OverallSDProcessStatus" ReferencedProperty="OverallSDProcessStatus"/>
         </NavigationProperty>
-        <NavigationProperty Name="_Partner" Type="Collection(com.c_salesordermanage_sd.HeaderPartner)" Partner="owner">
+        <NavigationProperty Name="_Partner" Type="Collection(SalesOrderManage.HeaderPartner)" Partner="owner">
           <OnDelete Action="Cascade"/>
         </NavigationProperty>
-        <NavigationProperty Name="_CreditLimitDetails" Type="com.c_salesordermanage_sd.CreditLimitDetails">
+        <NavigationProperty Name="_CreditLimitDetails" Type="SalesOrderManage.CreditLimitDetails">
           <ReferentialConstraint Property="SalesOrder" ReferencedProperty="SalesDocument"/>
         </NavigationProperty>
-        <NavigationProperty Name="_SalesDistrict" Type="com.c_salesordermanage_sd.SalesDistrict">
+        <NavigationProperty Name="_SalesDistrict" Type="SalesOrderManage.SalesDistrict">
           <ReferentialConstraint Property="_SalesDistrict_SalesDistrict" ReferencedProperty="SalesDistrict"/>
         </NavigationProperty>
-        <NavigationProperty Name="_SalesGroup" Type="com.c_salesordermanage_sd.SalesGroup">
+        <NavigationProperty Name="_SalesGroup" Type="SalesOrderManage.SalesGroup">
           <ReferentialConstraint Property="_SalesGroup_SalesGroup" ReferencedProperty="SalesGroup"/>
         </NavigationProperty>
-        <NavigationProperty Name="_SalesOffice" Type="com.c_salesordermanage_sd.SalesOffice">
+        <NavigationProperty Name="_SalesOffice" Type="SalesOrderManage.SalesOffice">
           <ReferentialConstraint Property="_SalesOffice_SalesOffice" ReferencedProperty="SalesOffice"/>
         </NavigationProperty>
-        <NavigationProperty Name="_SalesOrderType" Type="com.c_salesordermanage_sd.SalesOrderType">
+        <NavigationProperty Name="_SalesOrderType" Type="SalesOrderManage.SalesOrderType">
           <ReferentialConstraint Property="SalesOrderType" ReferencedProperty="SalesOrderType"/>
         </NavigationProperty>
-        <NavigationProperty Name="_SalesOrganization" Type="com.c_salesordermanage_sd.SalesOrganization">
+        <NavigationProperty Name="_SalesOrganization" Type="SalesOrderManage.SalesOrganization">
           <ReferentialConstraint Property="_SalesOrganization_SalesOrganization" ReferencedProperty="SalesOrganization"/>
         </NavigationProperty>
-        <NavigationProperty Name="_SDDocumentReason" Type="com.c_salesordermanage_sd.SDDocumentReason">
+        <NavigationProperty Name="_SDDocumentReason" Type="SalesOrderManage.SDDocumentReason">
           <ReferentialConstraint Property="_SDDocumentReason_SDDocumentReason" ReferencedProperty="SDDocumentReason"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ShippingCondition" Type="com.c_salesordermanage_sd.ShippingCondition">
+        <NavigationProperty Name="_ShippingCondition" Type="SalesOrderManage.ShippingCondition">
           <ReferentialConstraint Property="ShippingCondition" ReferencedProperty="ShippingCondition"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ShippingType" Type="com.c_salesordermanage_sd.ShippingType">
+        <NavigationProperty Name="_ShippingType" Type="SalesOrderManage.ShippingType">
           <ReferentialConstraint Property="_ShippingType_ShippingType" ReferencedProperty="ShippingType"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ShipToParty" Type="com.c_salesordermanage_sd.HeaderShipToParty">
+        <NavigationProperty Name="_ShipToParty" Type="SalesOrderManage.HeaderShipToParty">
           <OnDelete Action="Cascade"/>
           <ReferentialConstraint Property="_ShipToParty_ID" ReferencedProperty="ID"/>
         </NavigationProperty>
-        <NavigationProperty Name="_SoldToParty" Type="com.c_salesordermanage_sd.Customer">
+        <NavigationProperty Name="_SoldToParty" Type="SalesOrderManage.Customer">
           <ReferentialConstraint Property="SoldToParty" ReferencedProperty="Customer"/>
         </NavigationProperty>
-        <NavigationProperty Name="_ReferencedSalesOrder" Type="com.c_salesordermanage_sd.SalesOrderManage">
+        <NavigationProperty Name="_ReferencedSalesOrder" Type="SalesOrderManage.SalesOrderManage">
           <ReferentialConstraint Property="ReferencedSalesOrderID" ReferencedProperty="ID"/>
         </NavigationProperty>
         <Property Name="_CustomerPurchaseOrderType_CustomerPurchaseOrderType" Type="Edm.String" MaxLength="4"/>
@@ -934,8 +934,8 @@
         <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
-        <NavigationProperty Name="DraftAdministrativeData" Type="com.c_salesordermanage_sd.DraftAdministrativeData" ContainsTarget="true"/>
-        <NavigationProperty Name="SiblingEntity" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="SalesOrderManage.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="SalesOrderManage.SalesOrderManage"/>
       </EntityType>
       <EntityType Name="SalesOrderScheduleLineType">
         <Key>
@@ -953,21 +953,21 @@
         <Property Name="RequestedDeliveryDate" Type="Edm.Date"/>
         <Property Name="ConfirmedDeliveryDate" Type="Edm.Date"/>
         <Property Name="DelivBlockReasonForSchedLine" Type="Edm.String" MaxLength="2"/>
-        <NavigationProperty Name="owner" Type="com.c_salesordermanage_sd.SalesOrderItem" Partner="_ScheduleLine">
+        <NavigationProperty Name="owner" Type="SalesOrderManage.SalesOrderItem" Partner="_ScheduleLine">
           <ReferentialConstraint Property="owner_ID" ReferencedProperty="ID"/>
         </NavigationProperty>
-        <NavigationProperty Name="_DelivBlockReasonForSchedLine" Type="com.c_salesordermanage_sd.DeliveryBlockReasonType">
+        <NavigationProperty Name="_DelivBlockReasonForSchedLine" Type="SalesOrderManage.DeliveryBlockReasonType">
           <ReferentialConstraint Property="DelivBlockReasonForSchedLine" ReferencedProperty="DeliveryBlockReason"/>
         </NavigationProperty>
-        <NavigationProperty Name="_OrderQuantityUnit" Type="com.c_salesordermanage_sd.UnitOfMeasure">
+        <NavigationProperty Name="_OrderQuantityUnit" Type="SalesOrderManage.UnitOfMeasure">
           <ReferentialConstraint Property="OrderQuantityUnit" ReferencedProperty="UnitOfMeasure"/>
         </NavigationProperty>
         <Property Name="owner_ID" Type="Edm.Guid"/>
         <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
         <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
-        <NavigationProperty Name="DraftAdministrativeData" Type="com.c_salesordermanage_sd.DraftAdministrativeData" ContainsTarget="true"/>
-        <NavigationProperty Name="SiblingEntity" Type="com.c_salesordermanage_sd.SalesOrderScheduleLineType"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="SalesOrderManage.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="SalesOrderManage.SalesOrderScheduleLineType"/>
       </EntityType>
       <EntityType Name="SalesOrderType">
         <Key>
@@ -1040,271 +1040,271 @@
       </ComplexType>
       <ComplexType Name="c_salesordermanage_sd_complex_withNavigation">
         <Property Name="name" Type="Edm.String"/>
-        <NavigationProperty Name="_SalesOrderType" Type="com.c_salesordermanage_sd.SalesOrderType">
+        <NavigationProperty Name="_SalesOrderType" Type="SalesOrderManage.SalesOrderType">
           <ReferentialConstraint ReferencedProperty="SalesOrderType" Property="_SalesOrderType_SalesOrderType"/>
         </NavigationProperty>
         <Property Name="_SalesOrderType_SalesOrderType" Type="Edm.String"/>
       </ComplexType>
       <Action Name="ChangeOrderStatus" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.HeaderPartner"/>
-        <ReturnType Type="com.c_salesordermanage_sd.HeaderPartner"/>
+        <Parameter Name="_it" Type="SalesOrderManage.HeaderPartner"/>
+        <ReturnType Type="SalesOrderManage.HeaderPartner"/>
       </Action>
       <Action Name="ChangeOrderStatus" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
         <Parameter Name="OverallSDProcessStatus" Type="Edm.String" MaxLength="1"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="ParentBasedAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.HeaderPartner"/>
-        <ReturnType Type="com.c_salesordermanage_sd.HeaderPartner"/>
+        <Parameter Name="_it" Type="SalesOrderManage.HeaderPartner"/>
+        <ReturnType Type="SalesOrderManage.HeaderPartner"/>
       </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.HeaderPartner"/>
+        <Parameter Name="in" Type="SalesOrderManage.HeaderPartner"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
-        <ReturnType Type="com.c_salesordermanage_sd.HeaderPartner"/>
+        <ReturnType Type="SalesOrderManage.HeaderPartner"/>
       </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.HeaderShipToParty"/>
+        <Parameter Name="in" Type="SalesOrderManage.HeaderShipToParty"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
-        <ReturnType Type="com.c_salesordermanage_sd.HeaderShipToParty"/>
+        <ReturnType Type="SalesOrderManage.HeaderShipToParty"/>
       </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.MaterialDetails"/>
+        <Parameter Name="in" Type="SalesOrderManage.MaterialDetails"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
-        <ReturnType Type="com.c_salesordermanage_sd.MaterialDetails"/>
+        <ReturnType Type="SalesOrderManage.MaterialDetails"/>
       </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.MaterialRatings"/>
+        <Parameter Name="in" Type="SalesOrderManage.MaterialRatings"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
-        <ReturnType Type="com.c_salesordermanage_sd.MaterialRatings"/>
+        <ReturnType Type="SalesOrderManage.MaterialRatings"/>
       </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.MaterialRatingsDetails"/>
+        <Parameter Name="in" Type="SalesOrderManage.MaterialRatingsDetails"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
-        <ReturnType Type="com.c_salesordermanage_sd.MaterialRatingsDetails"/>
+        <ReturnType Type="SalesOrderManage.MaterialRatingsDetails"/>
       </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <Parameter Name="in" Type="SalesOrderManage.SalesOrderItem"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderItem"/>
       </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="in" Type="SalesOrderManage.SalesOrderManage"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.SalesOrderScheduleLineType"/>
+        <Parameter Name="in" Type="SalesOrderManage.SalesOrderScheduleLineType"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderScheduleLineType"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderScheduleLineType"/>
       </Action>
       <Action Name="ChangeAddress" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.HeaderShipToParty"/>
-        <ReturnType Type="com.c_salesordermanage_sd.HeaderShipToParty"/>
+        <Parameter Name="_it" Type="SalesOrderManage.HeaderShipToParty"/>
+        <ReturnType Type="SalesOrderManage.HeaderShipToParty"/>
       </Action>
       <Action Name="MaterialDetailsBoundAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.MaterialDetails"/>
-        <ReturnType Type="com.c_salesordermanage_sd.MaterialDetails"/>
+        <Parameter Name="_it" Type="SalesOrderManage.MaterialDetails"/>
+        <ReturnType Type="SalesOrderManage.MaterialDetails"/>
       </Action>
       <Action Name="MaterialCategoryFormAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.MaterialDetails"/>
+        <Parameter Name="_it" Type="SalesOrderManage.MaterialDetails"/>
         <Parameter Name="BrandCategory" Type="Edm.String" MaxLength="20" Nullable="false"/>
-        <ReturnType Type="com.c_salesordermanage_sd.MaterialDetails"/>
+        <ReturnType Type="SalesOrderManage.MaterialDetails"/>
       </Action>
       <Action Name="MaterialRatingsBoundAction" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.MaterialRatings"/>
-        <ReturnType Type="com.c_salesordermanage_sd.MaterialRatings"/>
+        <Parameter Name="in" Type="SalesOrderManage.MaterialRatings"/>
+        <ReturnType Type="SalesOrderManage.MaterialRatings"/>
       </Action>
       <Action Name="RatingFormAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.MaterialRatings"/>
+        <Parameter Name="_it" Type="SalesOrderManage.MaterialRatings"/>
         <Parameter Name="Rating" Type="Edm.Decimal" Scale="2" Precision="4" Nullable="false"/>
-        <ReturnType Type="com.c_salesordermanage_sd.MaterialRatings"/>
+        <ReturnType Type="SalesOrderManage.MaterialRatings"/>
       </Action>
       <Action Name="MaterialRatingsDetailsBoundAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.MaterialRatingsDetails"/>
-        <ReturnType Type="com.c_salesordermanage_sd.MaterialRatingsDetails"/>
+        <Parameter Name="_it" Type="SalesOrderManage.MaterialRatingsDetails"/>
+        <ReturnType Type="SalesOrderManage.MaterialRatingsDetails"/>
       </Action>
       <Action Name="RatingCommentsFormAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.MaterialRatingsDetails"/>
+        <Parameter Name="_it" Type="SalesOrderManage.MaterialRatingsDetails"/>
         <Parameter Name="Comments" Type="Edm.String" MaxLength="1000" Nullable="false"/>
-        <ReturnType Type="com.c_salesordermanage_sd.MaterialRatingsDetails"/>
+        <ReturnType Type="SalesOrderManage.MaterialRatingsDetails"/>
       </Action>
       <Action Name="DummyBoundAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderItem"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderItem"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderItem"/>
       </Action>
 	  <Action Name="DummyBoundAction" IsBound="true" EntitySetPath="_it">
-		<Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
-		<ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+		<Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
+		<ReturnType Type="SalesOrderManage.SalesOrderManage"/>
 	  </Action>
       <Action Name="IdentificationFormAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderItem"/>
         <Parameter Name="RequestedQuantity" Type="Edm.Decimal" Scale="3" Precision="15" Nullable="false"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderItem"/>
       </Action>
       <Action Name="AddRandomItem" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="Collection(com.c_salesordermanage_sd.SalesOrderItem)"/>
+        <Parameter Name="_it" Type="Collection(SalesOrderManage.SalesOrderItem)"/>
         <Parameter Name="position" Type="Edm.Int32"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderItem"/>
       </Action>
       <Action Name="createMessage" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderItem"/>
         <Parameter Name="message" Type="Edm.String" MaxLength="200"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderItem"/>
       </Action>
       <Action Name="CopyItem" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderItem"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderItem"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderItem"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderItem"/>
       </Action>
       <Action Name="DummyStaticAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="Collection(com.c_salesordermanage_sd.SalesOrderManage)"/>
+        <Parameter Name="_it" Type="Collection(SalesOrderManage.SalesOrderManage)"/>
         <Parameter Name="MessageText" Type="Edm.String" MaxLength="4"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="IncotermsDetermination" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="OPAvailableTrueAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="OPAvailableFalseAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="OPAvailableNullAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="EnableEditAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="CreateWithSalesOrderType" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
         <Parameter Name="SalesOrderType" Type="Edm.String" MaxLength="4" Nullable="false"/>
         <Parameter Name="SalesOrganization" Type="Edm.String" MaxLength="4" Nullable="false"/>
         <Parameter Name="OrganizationDivision" Type="Edm.String" MaxLength="2" Nullable="false"/>
         <Parameter Name="DistributionChannel" Type="Edm.String" MaxLength="2" Nullable="false"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="FacetFormAction" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
         <Parameter Name="ShippingCondition" Type="Edm.String" MaxLength="2" Nullable="false"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="ActionNavigation" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="CopySalesOrder" IsBound="true" EntitySetPath="_it">
-        <Parameter Name="_it" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="_it" Type="SalesOrderManage.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="draftActivate" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="in" Type="SalesOrderManage.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="draftEdit" IsBound="true" EntitySetPath="in">
-        <Parameter Name="in" Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <Parameter Name="in" Type="SalesOrderManage.SalesOrderManage"/>
         <Parameter Name="PreserveChanges" Type="Edm.Boolean"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="ReturnInProcess" IsBound="false">
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="UnboundAction" IsBound="false">
         <Parameter Name="MessageText" Type="Edm.String" MaxLength="4"/>
-        <ReturnType Type="com.c_salesordermanage_sd.SalesOrderManage"/>
+        <ReturnType Type="SalesOrderManage.SalesOrderManage"/>
       </Action>
       <Action Name="addEmptyStatus" IsBound="false"/>
-      <Annotations Target="com.c_salesordermanage_sd.BillingBlockReason">
+      <Annotations Target="SalesOrderManage.BillingBlockReason">
         <Annotation Term="Common.Label" String="Value Help for Billing Block Reason"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.BillingBlockReason/BillingBlockReason">
+      <Annotations Target="SalesOrderManage.BillingBlockReason/BillingBlockReason">
         <Annotation Term="Common.Heading" String="Block"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Billing Block"/>
         <Annotation Term="Common.Text" Path="BillingBlockReason_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.BillingBlockReason/BillingBlockReason_Text">
+      <Annotations Target="SalesOrderManage.BillingBlockReason/BillingBlockReason_Text">
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_MaterialBySlsOrgDistrChnl">
+      <Annotations Target="SalesOrderManage.C_MaterialBySlsOrgDistrChnl">
         <Annotation Term="Common.Label" String="Materials By Sales Org and Distr Channel"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_MaterialBySlsOrgDistrChnl/SalesOrganization">
+      <Annotations Target="SalesOrderManage.C_MaterialBySlsOrgDistrChnl/SalesOrganization">
         <Annotation Term="Common.Heading" String="SOrg."/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Sales Organization"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_MaterialBySlsOrgDistrChnl/DistributionChannel">
+      <Annotations Target="SalesOrderManage.C_MaterialBySlsOrgDistrChnl/DistributionChannel">
         <Annotation Term="Common.Heading" String="DChl"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Distribution Channel"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_MaterialBySlsOrgDistrChnl/Material">
+      <Annotations Target="SalesOrderManage.C_MaterialBySlsOrgDistrChnl/Material">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Material"/>
         <Annotation Term="Common.QuickInfo" String="Material Number"/>
         <Annotation Term="Common.Text" Path="MaterialName"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_MaterialBySlsOrgDistrChnl/MaterialName">
+      <Annotations Target="SalesOrderManage.C_MaterialBySlsOrgDistrChnl/MaterialName">
         <Annotation Term="Common.Label" String="Material Description"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_MaterialBySlsOrgDistrChnl/RequestedQuantityUnit">
+      <Annotations Target="SalesOrderManage.C_MaterialBySlsOrgDistrChnl/RequestedQuantityUnit">
         <Annotation Term="Common.Heading" String="RQ Unit"/>
         <Annotation Term="Common.Label" String="Sales Unit"/>
         <Annotation Term="Common.QuickInfo" String="Requested Quantity Unit"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_MaterialBySlsOrgDistrChnl/MaterialBaseUnit">
+      <Annotations Target="SalesOrderManage.C_MaterialBySlsOrgDistrChnl/MaterialBaseUnit">
         <Annotation Term="Common.Label" String="Base Unit of Measure"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
         <Annotation Term="UI.HiddenFilter" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_MaterialBySlsOrgDistrChnl/SalesMeasureUnit">
+      <Annotations Target="SalesOrderManage.C_MaterialBySlsOrgDistrChnl/SalesMeasureUnit">
         <Annotation Term="Common.Label" String="Sales Unit"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
         <Annotation Term="UI.HiddenFilter" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_NotLockedSalesOrderTypeVH">
+      <Annotations Target="SalesOrderManage.C_NotLockedSalesOrderTypeVH">
         <Annotation Term="Common.Label" String="Sales Order Types"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_NotLockedSalesOrderTypeVH/SalesOrderType">
+      <Annotations Target="SalesOrderManage.C_NotLockedSalesOrderTypeVH/SalesOrderType">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Sales Order Type"/>
         <Annotation Term="Common.Text" Path="SalesOrderType_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_NotLockedSalesOrderTypeVH/SalesOrderType_Text">
+      <Annotations Target="SalesOrderManage.C_NotLockedSalesOrderTypeVH/SalesOrderType_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_NotLockedSalesOrderTypeVH/SalesDocumentTypeLangDepdnt">
+      <Annotations Target="SalesOrderManage.C_NotLockedSalesOrderTypeVH/SalesDocumentTypeLangDepdnt">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Language Key"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_ProductUnitsOfMeasureVH/Product">
+      <Annotations Target="SalesOrderManage.C_ProductUnitsOfMeasureVH/Product">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Material"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_ProductUnitsOfMeasureVH/AlternativeUnit">
+      <Annotations Target="SalesOrderManage.C_ProductUnitsOfMeasureVH/AlternativeUnit">
         <Annotation Term="Common.Label" String="AlternativeUnit"/>
         <Annotation Term="Common.Text" Path="AlternativeUnit_Text"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_ProductUnitsOfMeasureVH/AlternativeUnit_Text">
+      <Annotations Target="SalesOrderManage.C_ProductUnitsOfMeasureVH/AlternativeUnit_Text">
         <Annotation Term="Common.Label" String="UoM Text"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_ProductUnitsOfMeasureVH/QuantityNumerator">
+      <Annotations Target="SalesOrderManage.C_ProductUnitsOfMeasureVH/QuantityNumerator">
         <Annotation Term="Common.Label" String="Numerator"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.C_ProductUnitsOfMeasureVH/QuantityDenominator">
+      <Annotations Target="SalesOrderManage.C_ProductUnitsOfMeasureVH/QuantityDenominator">
         <Annotation Term="Common.Label" String="Denominator"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreditLimitDetails">
+      <Annotations Target="SalesOrderManage.CreditLimitDetails">
         <Annotation Term="Common.Label" String="Bullet Chart"/>
         <Annotation Term="UI.Chart" Qualifier="CreditLimitChart">
           <Record Type="UI.ChartDefinitionType">
@@ -1434,23 +1434,23 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreditLimitDetails/CustomerCreditExposureAmount">
+      <Annotations Target="SalesOrderManage.CreditLimitDetails/CustomerCreditExposureAmount">
         <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreditLimitDetails/Delivered">
+      <Annotations Target="SalesOrderManage.CreditLimitDetails/Delivered">
         <Annotation Term="Common.Label" String="Delivery Status"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreditLimitDetails/CustomerCreditExposureAmountHidden">
+      <Annotations Target="SalesOrderManage.CreditLimitDetails/CustomerCreditExposureAmountHidden">
         <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency"/>
         <Annotation Term="UI.Hidden" Path="Delivered"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreditLimitDetails/CustomerCreditForecast">
+      <Annotations Target="SalesOrderManage.CreditLimitDetails/CustomerCreditForecast">
         <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreditLimitDetails/CustomerCreditLimitAmount">
+      <Annotations Target="SalesOrderManage.CreditLimitDetails/CustomerCreditLimitAmount">
         <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer">
+      <Annotations Target="SalesOrderManage.Customer">
         <Annotation Term="Common.IsNaturalPerson" Bool="true"/>
         <Annotation Term="Common.Label" String="Sold-to Party"/>
         <Annotation Term="Communication.Contact">
@@ -1656,21 +1656,21 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/Customer">
+      <Annotations Target="SalesOrderManage.EntityContainer/Customer">
         <Annotation Term="Capabilities.SearchRestrictions">
           <Record Type="Capabilities.SearchRestrictionsType">
             <PropertyValue Property="Searchable" Bool="true"/>
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/Customer">
+      <Annotations Target="SalesOrderManage.Customer/Customer">
         <Annotation Term="Common.Heading" String="Customer"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Customer"/>
         <Annotation Term="Common.QuickInfo" String="Customer Number"/>
         <Annotation Term="Common.Text" Path="CustomerName"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/CustomerName">
+      <Annotations Target="SalesOrderManage.Customer/CustomerName">
         <Annotation Term="Common.Heading" String="Customer"/>
         <Annotation Term="Common.Label" String="Name"/>
         <Annotation Term="Common.QuickInfo" String="Name of Customer"/>
@@ -1705,58 +1705,58 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/PredefinedField">
+      <Annotations Target="SalesOrderManage.Customer/PredefinedField">
         <Annotation Term="Common.Label" String="PredefinedField"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/Delivered">
+      <Annotations Target="SalesOrderManage.Customer/Delivered">
         <Annotation Term="Common.Label" String="Delivery Status"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/OrganizationBPName1">
+      <Annotations Target="SalesOrderManage.Customer/OrganizationBPName1">
         <Annotation Term="Common.Heading" String="Name 1"/>
         <Annotation Term="Common.Label" String="Name"/>
         <Annotation Term="Common.QuickInfo" String="Name 1"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/OrganizationBPName2">
+      <Annotations Target="SalesOrderManage.Customer/OrganizationBPName2">
         <Annotation Term="Common.Label" String="Name 2"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/BusinessPartnerImageURL">
+      <Annotations Target="SalesOrderManage.Customer/BusinessPartnerImageURL">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/StreetName">
+      <Annotations Target="SalesOrderManage.Customer/StreetName">
         <Annotation Term="Common.Label" String="Street"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/HouseNumber">
+      <Annotations Target="SalesOrderManage.Customer/HouseNumber">
         <Annotation Term="Common.Label" String="House Number"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/PostalCode">
+      <Annotations Target="SalesOrderManage.Customer/PostalCode">
         <Annotation Term="Common.Heading" String="Post. Code"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Postal Code"/>
         <Annotation Term="Common.QuickInfo" String="City Postal Code"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/CityName">
+      <Annotations Target="SalesOrderManage.Customer/CityName">
         <Annotation Term="Common.Label" String="City"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/Country">
+      <Annotations Target="SalesOrderManage.Customer/Country">
         <Annotation Term="Common.Heading" String="Ctr"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Country Key"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/InternationalPhoneNumber">
+      <Annotations Target="SalesOrderManage.Customer/InternationalPhoneNumber">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Telephone Number"/>
         <Annotation Term="Common.QuickInfo" String="Complete Number: Dialling Code+Number+Extension"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Customer/EmailAddress">
+      <Annotations Target="SalesOrderManage.Customer/EmailAddress">
         <Annotation Term="Common.Label" String="Email Address"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CustomerPaymentTerms">
+      <Annotations Target="SalesOrderManage.CustomerPaymentTerms">
         <Annotation Term="Common.Label" String="Customer Payment Terms"/>
         <Annotation Term="UI.FieldGroup" Qualifier="CustomerPaymentGroup">
           <Record Type="UI.FieldGroupType">
@@ -1779,19 +1779,19 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CustomerPaymentTerms/CustomerPaymentTerms">
+      <Annotations Target="SalesOrderManage.CustomerPaymentTerms/CustomerPaymentTerms">
         <Annotation Term="Common.Heading" String="PayT"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Payment Terms"/>
         <Annotation Term="Common.QuickInfo" String="Terms of Payment Key"/>
         <Annotation Term="Common.Text" Path="CustomerPaymentTerms_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CustomerPaymentTerms/CustomerPaymentTerms_Text">
+      <Annotations Target="SalesOrderManage.CustomerPaymentTerms/CustomerPaymentTerms_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Common.QuickInfo" String="Description of terms of payment"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CustomerPaymentTermsExtended">
+      <Annotations Target="SalesOrderManage.CustomerPaymentTermsExtended">
         <Annotation Term="Common.Label" String="Customer Payment Terms Extended"/>
         <Annotation Term="UI.FieldGroup" Qualifier="CustomerPaymentGroup">
           <Record Type="UI.FieldGroupType">
@@ -1814,36 +1814,36 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CustomerPaymentTermsExtended/CustomerPaymentTerms">
+      <Annotations Target="SalesOrderManage.CustomerPaymentTermsExtended/CustomerPaymentTerms">
         <Annotation Term="Common.Heading" String="PayT"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Payment Terms"/>
         <Annotation Term="Common.QuickInfo" String="Terms of Payment Key"/>
         <Annotation Term="Common.Text" Path="CustomerPaymentTermsExtended_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CustomerPaymentTermsExtended/CustomerPaymentTermsExtended_Text">
+      <Annotations Target="SalesOrderManage.CustomerPaymentTermsExtended/CustomerPaymentTermsExtended_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Common.QuickInfo" String="Description of terms of payment"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CustomerPurchaseOrderType">
+      <Annotations Target="SalesOrderManage.CustomerPurchaseOrderType">
         <Annotation Term="Common.Label" String="Customer Purchase Order Type"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CustomerPurchaseOrderType/CustomerPurchaseOrderType">
+      <Annotations Target="SalesOrderManage.CustomerPurchaseOrderType/CustomerPurchaseOrderType">
         <Annotation Term="Common.Heading" String="POtyp"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Purchase Order Type"/>
         <Annotation Term="Common.QuickInfo" String="Customer Purchase Order Type"/>
         <Annotation Term="Common.Text" Path="CustomerPurchaseOrderType_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CustomerPurchaseOrderType/CustomerPurchaseOrderType_Text">
+      <Annotations Target="SalesOrderManage.CustomerPurchaseOrderType/CustomerPurchaseOrderType_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DeliveryBlockReason">
+      <Annotations Target="SalesOrderManage.DeliveryBlockReason">
         <Annotation Term="Common.Label" String="Delivery Block Reason"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DeliveryBlockReason/DeliveryBlockReason">
+      <Annotations Target="SalesOrderManage.DeliveryBlockReason/DeliveryBlockReason">
         <Annotation Term="Common.Heading" String="DB"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Delivery Block"/>
@@ -1851,18 +1851,18 @@
         <Annotation Term="Common.Text" Path="DeliveryBlockReason_Text"/>
         <Annotation Term="UI.HiddenFilter" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DeliveryBlockReason/DeliveryBlockReason_Text">
+      <Annotations Target="SalesOrderManage.DeliveryBlockReason/DeliveryBlockReason_Text">
         <Annotation Term="Common.Heading" String="Delivery Block Description"/>
         <Annotation Term="Common.Label" String="Delivery Block Desc."/>
         <Annotation Term="Common.QuickInfo" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
         <Annotation Term="UI.HiddenFilter" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DeliveryBlockReason/DeliveryDueListBlock">
+      <Annotations Target="SalesOrderManage.DeliveryBlockReason/DeliveryDueListBlock">
         <Annotation Term="Common.Label" String="Delv. Due List Block"/>
         <Annotation Term="Common.QuickInfo" String="Delivery Due List Block"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DeliveryBlockReasonType">
+      <Annotations Target="SalesOrderManage.DeliveryBlockReasonType">
         <Annotation Term="Common.Label" String="Delivery Block Reason"/>
         <Annotation Term="Common.SemanticKey">
           <Collection>
@@ -1870,63 +1870,63 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DeliveryPriority">
+      <Annotations Target="SalesOrderManage.DeliveryPriority">
         <Annotation Term="Common.Label" String="Delivery Priority"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DeliveryPriority/DeliveryPriority">
+      <Annotations Target="SalesOrderManage.DeliveryPriority/DeliveryPriority">
         <Annotation Term="Common.Heading" String="DPrio"/>
         <Annotation Term="Common.IsDigitSequence" Bool="true"/>
         <Annotation Term="Common.Label" String="Delivery Priority"/>
         <Annotation Term="Common.Text" Path="DeliveryPriority_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DeliveryPriority/DeliveryPriority_Text">
+      <Annotations Target="SalesOrderManage.DeliveryPriority/DeliveryPriority_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DistributionChannel">
+      <Annotations Target="SalesOrderManage.DistributionChannel">
         <Annotation Term="Common.Label" String="Distribution Channel"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DistributionChannel/DistributionChannel">
+      <Annotations Target="SalesOrderManage.DistributionChannel/DistributionChannel">
         <Annotation Term="Common.Heading" String="DChl"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Distribution Channel"/>
         <Annotation Term="Common.Text" Path="DistributionChannel_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DistributionChannel/DistributionChannel_Text">
+      <Annotations Target="SalesOrderManage.DistributionChannel/DistributionChannel_Text">
         <Annotation Term="Common.Label" String="Distribution Channel Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DraftAdministrativeData">
+      <Annotations Target="SalesOrderManage.DraftAdministrativeData">
         <Annotation Term="Common.Label" String="Données administratives préliminaires"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DraftAdministrativeData/DraftUUID">
+      <Annotations Target="SalesOrderManage.DraftAdministrativeData/DraftUUID">
         <Annotation Term="Common.Label" String="Version préliminaire (ID technique)"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DraftAdministrativeData/CreationDateTime">
+      <Annotations Target="SalesOrderManage.DraftAdministrativeData/CreationDateTime">
         <Annotation Term="Common.Label" String="Version préliminaire créée le"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DraftAdministrativeData/CreatedByUser">
+      <Annotations Target="SalesOrderManage.DraftAdministrativeData/CreatedByUser">
         <Annotation Term="Common.Label" String="Version préliminaire créée par"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DraftAdministrativeData/DraftIsCreatedByMe">
+      <Annotations Target="SalesOrderManage.DraftAdministrativeData/DraftIsCreatedByMe">
         <Annotation Term="Common.Label" String="Version préliminaire créée par moi"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DraftAdministrativeData/LastChangeDateTime">
+      <Annotations Target="SalesOrderManage.DraftAdministrativeData/LastChangeDateTime">
         <Annotation Term="Common.Label" String="Dernière modification de la version préliminaire le"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DraftAdministrativeData/LastChangedByUser">
+      <Annotations Target="SalesOrderManage.DraftAdministrativeData/LastChangedByUser">
         <Annotation Term="Common.Label" String="Dernière modification de la version préliminaire par"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DraftAdministrativeData/InProcessByUser">
+      <Annotations Target="SalesOrderManage.DraftAdministrativeData/InProcessByUser">
         <Annotation Term="Common.Label" String="Version préliminaire en cours de traitement par"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DraftAdministrativeData/DraftIsProcessedByMe">
+      <Annotations Target="SalesOrderManage.DraftAdministrativeData/DraftIsProcessedByMe">
         <Annotation Term="Common.Label" String="Version préliminaire en cours de traitement par moi"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner">
+      <Annotations Target="SalesOrderManage.HeaderPartner">
         <Annotation Term="Common.Label" String="Manage Sales Order Header Partner"/>
         <Annotation Term="Communication.Contact">
           <Record Type="Communication.ContactType">
@@ -1966,7 +1966,7 @@
                 </Record>
                 <Record Type="UI.DataFieldForAction">
                   <PropertyValue Property="Label" String="Change Order Status (Parent)"/>
-                  <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ParentBasedAction"/>
+                  <PropertyValue Property="Action" String="SalesOrderManage.ParentBasedAction"/>
                 </Record>
               </Collection>
             </PropertyValue>
@@ -1982,7 +1982,7 @@
           <Collection>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Dummy Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ChangeOrderStatus"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.ChangeOrderStatus"/>
             </Record>
             <Record Type="UI.DataFieldForAnnotation">
               <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#multipleActionFields"/>
@@ -2015,7 +2015,7 @@
           <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High"/>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/HeaderPartner">
+      <Annotations Target="SalesOrderManage.EntityContainer/HeaderPartner">
         <Annotation Term="Capabilities.DeleteRestrictions">
           <Record Type="Capabilities.DeleteRestrictionsType">
             <PropertyValue Property="Deletable" Path="owner/ReturnInProcess"/>
@@ -2028,24 +2028,24 @@
         </Annotation>
         <Annotation Term="Common.DraftNode">
           <Record Type="Common.DraftNodeType">
-            <PropertyValue Property="PreparationAction" String="com.c_salesordermanage_sd.draftPrepare"/>
+            <PropertyValue Property="PreparationAction" String="SalesOrderManage.draftPrepare"/>
           </Record>
         </Annotation>
         <Annotation Term="UI.CreateHidden" Path="owner/isCreateHidden"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/ID">
+      <Annotations Target="SalesOrderManage.HeaderPartner/ID">
         <Annotation Term="Common.Label" String="Partner UUID"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/SalesOrder">
+      <Annotations Target="SalesOrderManage.HeaderPartner/SalesOrder">
         <Annotation Term="Common.Label" String="Sales Order No."/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/PartnerFunction">
+      <Annotations Target="SalesOrderManage.HeaderPartner/PartnerFunction">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Partner function"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/BusinessPartner">
+      <Annotations Target="SalesOrderManage.HeaderPartner/BusinessPartner">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Business Partner"/>
@@ -2092,51 +2092,51 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/Rating">
+      <Annotations Target="SalesOrderManage.HeaderPartner/Rating">
         <Annotation Term="Common.Label" String="Rating"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/Progress">
+      <Annotations Target="SalesOrderManage.HeaderPartner/Progress">
         <Annotation Term="Common.Label" String="Progress"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/AddressID">
+      <Annotations Target="SalesOrderManage.HeaderPartner/AddressID">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Address"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/FullName">
+      <Annotations Target="SalesOrderManage.HeaderPartner/FullName">
         <Annotation Term="Common.Label" String="Full Name"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/PhoneNumber">
+      <Annotations Target="SalesOrderManage.HeaderPartner/PhoneNumber">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Telephone"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/PostalCode">
+      <Annotations Target="SalesOrderManage.HeaderPartner/PostalCode">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Postal Code"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/Country">
+      <Annotations Target="SalesOrderManage.HeaderPartner/Country">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Country Key"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/IsActiveEntity">
+      <Annotations Target="SalesOrderManage.HeaderPartner/IsActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/HasActiveEntity">
+      <Annotations Target="SalesOrderManage.HeaderPartner/HasActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/HasDraftEntity">
+      <Annotations Target="SalesOrderManage.HeaderPartner/HasDraftEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderPartner/DraftAdministrativeData">
+      <Annotations Target="SalesOrderManage.HeaderPartner/DraftAdministrativeData">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ChangeOrderStatus(com.c_salesordermanage_sd.HeaderPartner)">
+      <Annotations Target="SalesOrderManage.ChangeOrderStatus(SalesOrderManage.HeaderPartner)">
         <Annotation Term="Common.IsActionCritical" Bool="true"/>
         <Annotation Term="Core.OperationAvailable" Path="_it/isVerified"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ParentBasedAction(com.c_salesordermanage_sd.HeaderPartner)">
+      <Annotations Target="SalesOrderManage.ParentBasedAction(SalesOrderManage.HeaderPartner)">
         <Annotation Term="Core.OperationAvailable" Path="_it/owner/isVerified"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty">
         <Annotation Term="UI.FieldGroup" Qualifier="AddressData">
           <Record Type="UI.FieldGroupType">
             <PropertyValue Property="Data">
@@ -2158,7 +2158,7 @@
                 </Record>
                 <Record Type="UI.DataFieldForAction">
                   <PropertyValue Property="Label" String="Change Address"/>
-                  <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ChangeAddress"/>
+                  <PropertyValue Property="Action" String="SalesOrderManage.ChangeAddress"/>
                   <Annotation Term="UI.Hidden" Path="isHidden"/>
                 </Record>
                 <Record Type="UI.DataField">
@@ -2182,7 +2182,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/HeaderShipToParty">
+      <Annotations Target="SalesOrderManage.EntityContainer/HeaderShipToParty">
         <Annotation Term="Capabilities.DeleteRestrictions">
           <Record Type="Capabilities.DeleteRestrictionsType">
             <PropertyValue Property="Deletable" Bool="false"/>
@@ -2195,16 +2195,16 @@
         </Annotation>
         <Annotation Term="Common.DraftNode">
           <Record Type="Common.DraftNodeType">
-            <PropertyValue Property="PreparationAction" String="com.c_salesordermanage_sd.draftPrepare"/>
+            <PropertyValue Property="PreparationAction" String="SalesOrderManage.draftPrepare"/>
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/ID">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/ID">
         <Annotation Term="Common.Label" String="ID"/>
         <Annotation Term="Core.Computed" Bool="true"/>
         <Annotation Term="UI.HiddenFilter" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/BusinessPartner">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/BusinessPartner">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Customer"/>
         <Annotation Term="Common.QuickInfo" String="Customer Number"/>
@@ -2271,53 +2271,53 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/PostalCode">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/PostalCode">
         <Annotation Term="Common.FieldControl" Path="fieldReadOnly"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Postal Code"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/CityName">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/CityName">
         <Annotation Term="Common.Label" String="City"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/isHidden">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/isHidden">
         <Annotation Term="Common.Label" String="Is Hidden"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/isUpdatable">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/isUpdatable">
         <Annotation Term="Common.Label" String="Is Updatable"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/Country">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/Country">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Country Key"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/StreetName">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/StreetName">
         <Annotation Term="Common.Label" String="Street"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/HouseNumber">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/HouseNumber">
         <Annotation Term="Common.Label" String="House Number"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/IsActiveEntity">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/IsActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/HasActiveEntity">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/HasActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/HasDraftEntity">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/HasDraftEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.HeaderShipToParty/DraftAdministrativeData">
+      <Annotations Target="SalesOrderManage.HeaderShipToParty/DraftAdministrativeData">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ChangeAddress(com.c_salesordermanage_sd.HeaderShipToParty)">
+      <Annotations Target="SalesOrderManage.ChangeAddress(SalesOrderManage.HeaderShipToParty)">
         <Annotation Term="Core.OperationAvailable" Path="_it/isVerified"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_DistributionChannel">
+      <Annotations Target="SalesOrderManage.I_DistributionChannel">
         <Annotation Term="Common.Label" String="Distribution Channel"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_DistributionChannel/DistributionChannel">
+      <Annotations Target="SalesOrderManage.I_DistributionChannel/DistributionChannel">
         <Annotation Term="Common.Heading" String="DChl"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Distribution Channel"/>
@@ -2325,83 +2325,83 @@
           <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextLast"/>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_DistributionChannel/DistributionChannel_Text">
+      <Annotations Target="SalesOrderManage.I_DistributionChannel/DistributionChannel_Text">
         <Annotation Term="Common.Label" String="Distribution Channel Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_OrganizationDivision">
+      <Annotations Target="SalesOrderManage.I_OrganizationDivision">
         <Annotation Term="Common.Label" String="Organization Division"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_OrganizationDivision/Division">
+      <Annotations Target="SalesOrderManage.I_OrganizationDivision/Division">
         <Annotation Term="Common.Heading" String="Dv"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Division"/>
         <Annotation Term="Common.Text" Path="Division_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_OrganizationDivision/Division_Text">
+      <Annotations Target="SalesOrderManage.I_OrganizationDivision/Division_Text">
         <Annotation Term="Common.Label" String="Division Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_OrganizationDivision/SalesOrganization">
+      <Annotations Target="SalesOrderManage.I_OrganizationDivision/SalesOrganization">
         <Annotation Term="Common.Label" String="Sales Organization"/>
         <Annotation Term="Common.Text" Path="_I_SalesOrganization/SalesOrganization_Text">
           <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextLast"/>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_SalesOrganization">
+      <Annotations Target="SalesOrderManage.I_SalesOrganization">
         <Annotation Term="Common.Label" String="Sales Organization"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_SalesOrganization/SalesOrganization">
+      <Annotations Target="SalesOrderManage.I_SalesOrganization/SalesOrganization">
         <Annotation Term="Common.Label" String="Sales Organization"/>
         <Annotation Term="Common.Text" Path="SalesOrganization_Text">
           <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextLast"/>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_SalesOrganization/SalesOrganization_Text">
+      <Annotations Target="SalesOrderManage.I_SalesOrganization/SalesOrganization_Text">
         <Annotation Term="Common.Label" String="Sales Organization Description"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_SalesOrganization/SalesOrganizationCurrency">
+      <Annotations Target="SalesOrderManage.I_SalesOrganization/SalesOrganizationCurrency">
         <Annotation Term="Common.Label" String="Sales Organization Currency"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_SalesOrganization/CompanyCode">
+      <Annotations Target="SalesOrderManage.I_SalesOrganization/CompanyCode">
         <Annotation Term="Common.Label" String="Company Code"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.I_SalesOrganization/IntercompanyBillingCustomer">
+      <Annotations Target="SalesOrderManage.I_SalesOrganization/IntercompanyBillingCustomer">
         <Annotation Term="Common.Label" String="Intercompany Billing Customer"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.IncotermsClassification">
+      <Annotations Target="SalesOrderManage.IncotermsClassification">
         <Annotation Term="Common.Label" String="Incoterms Classification"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.IncotermsClassification/IncotermsClassification">
+      <Annotations Target="SalesOrderManage.IncotermsClassification/IncotermsClassification">
         <Annotation Term="Common.Heading" String="IncoT"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Incoterms"/>
         <Annotation Term="Common.QuickInfo" String="Incoterms (Part 1)"/>
         <Annotation Term="Common.Text" Path="IncotermsClassification_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.IncotermsClassification/IncotermsClassification_Text">
+      <Annotations Target="SalesOrderManage.IncotermsClassification/IncotermsClassification_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.IncotermsClassification/LocationIsMandatory">
+      <Annotations Target="SalesOrderManage.IncotermsClassification/LocationIsMandatory">
         <Annotation Term="Common.Heading" String="Cty"/>
         <Annotation Term="Common.Label" String="Location Mandatory"/>
         <Annotation Term="Common.QuickInfo" String="Location is mandatory"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.IncotermsVersion">
+      <Annotations Target="SalesOrderManage.IncotermsVersion">
         <Annotation Term="Common.Label" String="Incoterms Version"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.IncotermsVersion/IncotermsVersion">
+      <Annotations Target="SalesOrderManage.IncotermsVersion/IncotermsVersion">
         <Annotation Term="Common.Heading" String="IncoV"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Incoterms version"/>
         <Annotation Term="Common.Text" Path="IncotermsVersion_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.IncotermsVersion/IncotermsVersion_Text">
+      <Annotations Target="SalesOrderManage.IncotermsVersion/IncotermsVersion_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Material">
+      <Annotations Target="SalesOrderManage.Material">
         <Annotation Term="Common.Label" String="Material"/>
         <Annotation Term="UI.FieldGroup" Qualifier="MaterialPR">
           <Record Type="UI.FieldGroupType">
@@ -2423,7 +2423,7 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/Material">
+      <Annotations Target="SalesOrderManage.EntityContainer/Material">
         <Annotation Term="Capabilities.DeleteRestrictions">
           <Record Type="Capabilities.DeleteRestrictionsType">
             <PropertyValue Property="Deletable" Bool="false"/>
@@ -2440,28 +2440,28 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Material/Material">
+      <Annotations Target="SalesOrderManage.Material/Material">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Material"/>
         <Annotation Term="Common.Text" Path="Material_Text"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Material/isHidden">
+      <Annotations Target="SalesOrderManage.Material/isHidden">
         <Annotation Term="Common.Label" String="Is Hidden"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Material/isUpdatable">
+      <Annotations Target="SalesOrderManage.Material/isUpdatable">
         <Annotation Term="Common.Label" String="Is Updatable"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Material/Material_Text">
+      <Annotations Target="SalesOrderManage.Material/Material_Text">
         <Annotation Term="Common.Label" String="Material Description"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialCategory">
+      <Annotations Target="SalesOrderManage.MaterialCategory">
         <Annotation Term="Common.Label" String="Material category"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/MaterialCategory">
+      <Annotations Target="SalesOrderManage.EntityContainer/MaterialCategory">
         <Annotation Term="Capabilities.DeleteRestrictions">
           <Record Type="Capabilities.DeleteRestrictionsType">
             <PropertyValue Property="Deletable" Bool="true"/>
@@ -2478,26 +2478,26 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialCategory/Category">
+      <Annotations Target="SalesOrderManage.MaterialCategory/Category">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Category"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialCategory/Category_Text">
+      <Annotations Target="SalesOrderManage.MaterialCategory/Category_Text">
         <Annotation Term="Common.Label" String="Category Code"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialCountry">
+      <Annotations Target="SalesOrderManage.MaterialCountry">
         <Annotation Term="Common.Label" String="Material country"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialCountry/Country">
+      <Annotations Target="SalesOrderManage.MaterialCountry/Country">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Country Code"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialCountry/Country_Text">
+      <Annotations Target="SalesOrderManage.MaterialCountry/Country_Text">
         <Annotation Term="Common.Label" String="Fabrication Country"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails">
+      <Annotations Target="SalesOrderManage.MaterialDetails">
         <Annotation Term="Common.Label" String="Material Details"/>
         <Annotation Term="Common.SemanticKey">
           <Collection>
@@ -2554,7 +2554,7 @@
           <Collection>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Change Material Category"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MaterialCategoryFormAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.MaterialCategoryFormAction"/>
             </Record>
             <Record Type="UI.DataField">
               <PropertyValue Property="Value" Path="ModelYear"/>
@@ -2593,7 +2593,7 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Material Details Bound Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MaterialDetailsBoundAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.MaterialDetailsBoundAction"/>
               <Annotation Term="UI.Hidden" Path="owner/owner/ReturnInProcess"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
@@ -2605,7 +2605,7 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/MaterialDetails">
+      <Annotations Target="SalesOrderManage.EntityContainer/MaterialDetails">
         <Annotation Term="Capabilities.DeleteRestrictions">
           <Record Type="Capabilities.DeleteRestrictionsType">
             <PropertyValue Property="Deletable" Bool="true"/>
@@ -2613,14 +2613,14 @@
         </Annotation>
         <Annotation Term="Common.DraftNode">
           <Record Type="Common.DraftNodeType">
-            <PropertyValue Property="PreparationAction" String="com.c_salesordermanage_sd.draftPrepare"/>
+            <PropertyValue Property="PreparationAction" String="SalesOrderManage.draftPrepare"/>
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails/ID">
+      <Annotations Target="SalesOrderManage.MaterialDetails/ID">
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails/ModelYear">
+      <Annotations Target="SalesOrderManage.MaterialDetails/ModelYear">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Model Year"/>
         <Annotation Term="Common.ValueList">
@@ -2641,12 +2641,12 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails/WarrantyYear">
+      <Annotations Target="SalesOrderManage.MaterialDetails/WarrantyYear">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Warranty Expiration"/>
         <Annotation Term="Common.Text" Path="_WarrantyYear/Warranty_Expiration"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails/BrandCategory">
+      <Annotations Target="SalesOrderManage.MaterialDetails/BrandCategory">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Material Category"/>
         <Annotation Term="Common.Text" Path="_MaterialCategory/Category_Text"/>
@@ -2685,7 +2685,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails/FabricationCountry">
+      <Annotations Target="SalesOrderManage.MaterialDetails/FabricationCountry">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Fabrication Country"/>
         <Annotation Term="Common.Text" Path="_MaterialCountry/Country_Text"/>
@@ -2707,19 +2707,19 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails/IsActiveEntity">
+      <Annotations Target="SalesOrderManage.MaterialDetails/IsActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails/HasActiveEntity">
+      <Annotations Target="SalesOrderManage.MaterialDetails/HasActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails/HasDraftEntity">
+      <Annotations Target="SalesOrderManage.MaterialDetails/HasDraftEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialDetails/DraftAdministrativeData">
+      <Annotations Target="SalesOrderManage.MaterialDetails/DraftAdministrativeData">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialCategoryFormAction(com.c_salesordermanage_sd.MaterialDetails)">
+      <Annotations Target="SalesOrderManage.MaterialCategoryFormAction(SalesOrderManage.MaterialDetails)">
         <Annotation Term="Common.SideEffects">
           <Record Type="Common.SideEffectsType">
             <PropertyValue Property="TargetProperties">
@@ -2730,7 +2730,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialCategoryFormAction(com.c_salesordermanage_sd.MaterialDetails)/BrandCategory">
+      <Annotations Target="SalesOrderManage.MaterialCategoryFormAction(SalesOrderManage.MaterialDetails)/BrandCategory">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Material Category"/>
         <Annotation Term="Common.Text" Path="_MaterialCategory/Category_Text"/>
@@ -2769,7 +2769,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialGroup">
+      <Annotations Target="SalesOrderManage.MaterialGroup">
         <Annotation Term="Common.Label" String="Material Group"/>
         <Annotation Term="UI.FieldGroup" Qualifier="MaterialGroupPR">
           <Record Type="UI.FieldGroupType">
@@ -2791,18 +2791,18 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialGroup/MaterialGroup">
+      <Annotations Target="SalesOrderManage.MaterialGroup/MaterialGroup">
         <Annotation Term="Common.Heading" String="Prd Group"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Product Group"/>
         <Annotation Term="Common.Text" Path="MaterialGroup_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialGroup/MaterialGroup_Text">
+      <Annotations Target="SalesOrderManage.MaterialGroup/MaterialGroup_Text">
         <Annotation Term="Common.Label" String="Product Group Desc."/>
         <Annotation Term="Common.QuickInfo" String="Product Group Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatings">
+      <Annotations Target="SalesOrderManage.MaterialRatings">
         <Annotation Term="Common.Label" String="Material Rating"/>
         <Annotation Term="Common.SemanticKey">
           <Collection>
@@ -2854,7 +2854,7 @@
           <Collection>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Change Current Rating"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.RatingFormAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.RatingFormAction"/>
             </Record>
             <Record Type="UI.DataFieldForAnnotation">
               <PropertyValue Property="Target" AnnotationPath="@UI.DataPoint#Rating"/>
@@ -2878,7 +2878,7 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Material Ratings Bound Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MaterialRatingsBoundAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.MaterialRatingsBoundAction"/>
               <Annotation Term="UI.Hidden" Path="material/isHidden"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
@@ -2890,7 +2890,7 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/MaterialRatings">
+      <Annotations Target="SalesOrderManage.EntityContainer/MaterialRatings">
         <Annotation Term="Capabilities.DeleteRestrictions">
           <Record Type="Capabilities.DeleteRestrictionsType">
             <PropertyValue Property="Deletable" Path="isDeletable"/>
@@ -2903,14 +2903,14 @@
         </Annotation>
         <Annotation Term="Common.DraftNode">
           <Record Type="Common.DraftNodeType">
-            <PropertyValue Property="PreparationAction" String="com.c_salesordermanage_sd.draftPrepare"/>
+            <PropertyValue Property="PreparationAction" String="SalesOrderManage.draftPrepare"/>
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatings/ID">
+      <Annotations Target="SalesOrderManage.MaterialRatings/ID">
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatings/Rating">
+      <Annotations Target="SalesOrderManage.MaterialRatings/Rating">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Rating"/>
         <Annotation Term="Common.Text" Path="_Rating/Rating_Text"/>
@@ -2932,23 +2932,23 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatings/Title">
+      <Annotations Target="SalesOrderManage.MaterialRatings/Title">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Title"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatings/IsActiveEntity">
+      <Annotations Target="SalesOrderManage.MaterialRatings/IsActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatings/HasActiveEntity">
+      <Annotations Target="SalesOrderManage.MaterialRatings/HasActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatings/HasDraftEntity">
+      <Annotations Target="SalesOrderManage.MaterialRatings/HasDraftEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatings/DraftAdministrativeData">
+      <Annotations Target="SalesOrderManage.MaterialRatings/DraftAdministrativeData">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.RatingFormAction(com.c_salesordermanage_sd.MaterialRatings)">
+      <Annotations Target="SalesOrderManage.RatingFormAction(SalesOrderManage.MaterialRatings)">
         <Annotation Term="Common.SideEffects">
           <Record Type="Common.SideEffectsType">
             <PropertyValue Property="TargetProperties">
@@ -2959,7 +2959,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.RatingFormAction(com.c_salesordermanage_sd.MaterialRatings)/Rating">
+      <Annotations Target="SalesOrderManage.RatingFormAction(SalesOrderManage.MaterialRatings)/Rating">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Rating"/>
         <Annotation Term="Common.Text" Path="_Rating/Rating_Text"/>
@@ -2981,7 +2981,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails">
         <Annotation Term="Common.Label" String="Material Rating Details"/>
         <Annotation Term="UI.Facets">
           <Collection>
@@ -3012,7 +3012,7 @@
           <Collection>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Change Current Comments"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.RatingCommentsFormAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.RatingCommentsFormAction"/>
             </Record>
             <Record Type="UI.DataField">
               <PropertyValue Property="Value" Path="CREATEDAT"/>
@@ -3052,13 +3052,13 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Ratings Details Bound Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MaterialRatingsDetailsBoundAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.MaterialRatingsDetailsBoundAction"/>
               <Annotation Term="UI.Hidden" Path="material/isHidden"/>
             </Record>
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/MaterialRatingsDetails">
+      <Annotations Target="SalesOrderManage.EntityContainer/MaterialRatingsDetails">
         <Annotation Term="Capabilities.SearchRestrictions">
           <Record Type="Capabilities.SearchRestrictionsType">
             <PropertyValue Property="Searchable" Bool="true"/>
@@ -3066,42 +3066,42 @@
         </Annotation>
         <Annotation Term="Common.DraftNode">
           <Record Type="Common.DraftNodeType">
-            <PropertyValue Property="PreparationAction" String="com.c_salesordermanage_sd.draftPrepare"/>
+            <PropertyValue Property="PreparationAction" String="SalesOrderManage.draftPrepare"/>
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails/ID">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails/ID">
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails/Comments">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails/Comments">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Comments"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails/CREATEDAT">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails/CREATEDAT">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Created At"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails/MODIFIEDAT">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails/MODIFIEDAT">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Modified At"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails/MODIFIEDBY">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails/MODIFIEDBY">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Modified By"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails/IsActiveEntity">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails/IsActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails/HasActiveEntity">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails/HasActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails/HasDraftEntity">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails/HasDraftEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialRatingsDetails/DraftAdministrativeData">
+      <Annotations Target="SalesOrderManage.MaterialRatingsDetails/DraftAdministrativeData">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.RatingCommentsFormAction(com.c_salesordermanage_sd.MaterialRatingsDetails)">
+      <Annotations Target="SalesOrderManage.RatingCommentsFormAction(SalesOrderManage.MaterialRatingsDetails)">
         <Annotation Term="Common.SideEffects">
           <Record Type="Common.SideEffectsType">
             <PropertyValue Property="TargetProperties">
@@ -3112,146 +3112,146 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.RatingCommentsFormAction(com.c_salesordermanage_sd.MaterialRatingsDetails)/Comments">
+      <Annotations Target="SalesOrderManage.RatingCommentsFormAction(SalesOrderManage.MaterialRatingsDetails)/Comments">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Comments"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialYears">
+      <Annotations Target="SalesOrderManage.MaterialYears">
         <Annotation Term="Common.Label" String="Material years"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialYears/Model_Year">
+      <Annotations Target="SalesOrderManage.MaterialYears/Model_Year">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Model Year"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.MaterialYears/Warranty_Expiration">
+      <Annotations Target="SalesOrderManage.MaterialYears/Warranty_Expiration">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Warranty Expiration"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OrganizationDivision">
+      <Annotations Target="SalesOrderManage.OrganizationDivision">
         <Annotation Term="Common.Label" String="Division"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OrganizationDivision/Division">
+      <Annotations Target="SalesOrderManage.OrganizationDivision/Division">
         <Annotation Term="Common.Heading" String="Dv"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Division"/>
         <Annotation Term="Common.Text" Path="Division_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OrganizationDivision/Division_Text">
+      <Annotations Target="SalesOrderManage.OrganizationDivision/Division_Text">
         <Annotation Term="Common.Label" String="Division Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OverallBillingBlockStatus">
+      <Annotations Target="SalesOrderManage.OverallBillingBlockStatus">
         <Annotation Term="Common.Label" String="Overall Billing Block Status"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OverallBillingBlockStatus/OverallBillingBlockStatus">
+      <Annotations Target="SalesOrderManage.OverallBillingBlockStatus/OverallBillingBlockStatus">
         <Annotation Term="Common.Text" Path="OverallBillingBlockStatus_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OverallBillingBlockStatus/OverallBillingBlockStatus_Text">
+      <Annotations Target="SalesOrderManage.OverallBillingBlockStatus/OverallBillingBlockStatus_Text">
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OverallDeliveryBlockStatus">
+      <Annotations Target="SalesOrderManage.OverallDeliveryBlockStatus">
         <Annotation Term="Common.Label" String="Overall Delivery Block Status"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OverallDeliveryBlockStatus/OverallDeliveryBlockStatus">
+      <Annotations Target="SalesOrderManage.OverallDeliveryBlockStatus/OverallDeliveryBlockStatus">
         <Annotation Term="Common.Text" Path="OverallDeliveryBlockStatus_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OverallDeliveryBlockStatus/OverallDeliveryBlockStatus_Text">
+      <Annotations Target="SalesOrderManage.OverallDeliveryBlockStatus/OverallDeliveryBlockStatus_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Common.QuickInfo" String="Status Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OverallSDProcessStatus">
+      <Annotations Target="SalesOrderManage.OverallSDProcessStatus">
         <Annotation Term="Common.Label" String="Overall SD Process Status"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/OverallSDProcessStatus">
+      <Annotations Target="SalesOrderManage.EntityContainer/OverallSDProcessStatus">
         <Annotation Term="Capabilities.SearchRestrictions">
           <Record Type="Capabilities.SearchRestrictionsType">
             <PropertyValue Property="Searchable" Bool="false"/>
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OverallSDProcessStatus/OverallSDProcessStatus">
+      <Annotations Target="SalesOrderManage.OverallSDProcessStatus/OverallSDProcessStatus">
         <Annotation Term="Common.Label" String="Overall Status"/>
         <Annotation Term="Common.Text" Path="OverallSDProcessStatus_Text">
           <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextFirst"/>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OverallSDProcessStatus/OverallSDProcessStatus_Text">
+      <Annotations Target="SalesOrderManage.OverallSDProcessStatus/OverallSDProcessStatus_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Common.QuickInfo" String="Status Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Rating">
+      <Annotations Target="SalesOrderManage.Rating">
         <Annotation Term="Common.Label" String="Rating"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Rating/Rating">
+      <Annotations Target="SalesOrderManage.Rating/Rating">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Material Rating"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.Rating/Rating_Text">
+      <Annotations Target="SalesOrderManage.Rating/Rating_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ReturnInProcess()">
+      <Annotations Target="SalesOrderManage.ReturnInProcess()">
         <Annotation Term="Common.IsActionCritical" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SDDocumentReason">
+      <Annotations Target="SalesOrderManage.SDDocumentReason">
         <Annotation Term="Common.Label" String="SD Document Reason"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SDDocumentReason/SDDocumentReason">
+      <Annotations Target="SalesOrderManage.SDDocumentReason/SDDocumentReason">
         <Annotation Term="Common.Heading" String="OrdRs"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Order Reason"/>
         <Annotation Term="Common.QuickInfo" String="Order Reason (Reason for the Business Transaction)"/>
         <Annotation Term="Common.Text" Path="SDDocumentReason_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SDDocumentReason/SDDocumentReason_Text">
+      <Annotations Target="SalesOrderManage.SDDocumentReason/SDDocumentReason_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesDistrict">
+      <Annotations Target="SalesOrderManage.SalesDistrict">
         <Annotation Term="Common.Label" String="Sales District"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesDistrict/SalesDistrict">
+      <Annotations Target="SalesOrderManage.SalesDistrict/SalesDistrict">
         <Annotation Term="Common.Heading" String="SDst"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Sales District"/>
         <Annotation Term="Common.Text" Path="SalesDistrict_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesDistrict/SalesDistrict_Text">
+      <Annotations Target="SalesOrderManage.SalesDistrict/SalesDistrict_Text">
         <Annotation Term="Common.Label" String="District name"/>
         <Annotation Term="Common.QuickInfo" String="Name of the district"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesGroup">
+      <Annotations Target="SalesOrderManage.SalesGroup">
         <Annotation Term="Common.Label" String="Sales Group"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesGroup/SalesGroup">
+      <Annotations Target="SalesOrderManage.SalesGroup/SalesGroup">
         <Annotation Term="Common.Heading" String="SGrp"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Sales Group"/>
         <Annotation Term="Common.Text" Path="SalesGroup_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesGroup/SalesGroup_Text">
+      <Annotations Target="SalesOrderManage.SalesGroup/SalesGroup_Text">
         <Annotation Term="Common.Label" String="Sales Group Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOffice">
+      <Annotations Target="SalesOrderManage.SalesOffice">
         <Annotation Term="Common.Label" String="Sales Office"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOffice/SalesOffice">
+      <Annotations Target="SalesOrderManage.SalesOffice/SalesOffice">
         <Annotation Term="Common.Heading" String="SOff."/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Sales Office"/>
         <Annotation Term="Common.Text" Path="SalesOffice_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOffice/SalesOffice_Text">
+      <Annotations Target="SalesOrderManage.SalesOffice/SalesOffice_Text">
         <Annotation Term="Common.Label" String="Sales Office Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem">
+      <Annotations Target="SalesOrderManage.SalesOrderItem">
         <Annotation Term="Common.Label" String="Manage Sales Order Item (Transacl Procg)"/>
         <Annotation Term="Common.Messages" Path="SAP_Message"/>
         <Annotation Term="Common.SemanticKey">
@@ -3733,11 +3733,11 @@
           <Collection>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Identification Form Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.IdentificationFormAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.IdentificationFormAction"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Create Message"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.createMessage"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.createMessage"/>
             </Record>
           </Collection>
         </Annotation>
@@ -3777,7 +3777,7 @@
           <Collection>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Add random item"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.AddRandomItem"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.AddRandomItem"/>
               <Annotation Term="UI.Hidden" Path="owner/IsActiveEntity"/>
             </Record>
             <Record Type="UI.DataFieldWithUrl">
@@ -3788,11 +3788,11 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="{@i18n&gt;CopyActionText}"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.CopyItem"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.CopyItem"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Menu Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MenuDataFieldForAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.MenuDataFieldForAction"/>
               <Annotation Term="UI.Hidden" Path="owner/ReturnInProcess"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
@@ -3867,7 +3867,7 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="View Return Status"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.EntityContainer/ReturnInProcess"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.EntityContainer/ReturnInProcess"/>
               <Annotation Term="UI.Hidden" Path="owner/ReturnInProcess"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
@@ -3878,13 +3878,13 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Dummy Bound Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.DummyBoundAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.DummyBoundAction"/>
               <Annotation Term="UI.Hidden" Path="owner/ReturnInProcess"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Bound Action"/>
               <PropertyValue Property="Inline" Bool="true"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.DummyBoundAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.DummyBoundAction"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
               <PropertyValue Property="SemanticObject" String="SalesOrder"/>
@@ -3913,7 +3913,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/SalesOrderItem">
+      <Annotations Target="SalesOrderManage.EntityContainer/SalesOrderItem">
         <Annotation Term="Capabilities.DeleteRestrictions">
           <Record Type="Capabilities.DeleteRestrictionsType">
             <PropertyValue Property="Deletable" Path="isVerified"/>
@@ -3947,31 +3947,31 @@
         </Annotation>
         <Annotation Term="Common.DraftNode">
           <Record Type="Common.DraftNodeType">
-            <PropertyValue Property="PreparationAction" String="com.c_salesordermanage_sd.draftPrepare"/>
+            <PropertyValue Property="PreparationAction" String="SalesOrderManage.draftPrepare"/>
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/ID">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/ID">
         <Annotation Term="Common.Label" String="Sales Order Item UUID"/>
         <Annotation Term="Core.Computed" Bool="true"/>
         <Annotation Term="PersonalData.IsPotentiallySensitive" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/SalesOrder">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/SalesOrder">
         <Annotation Term="Common.Label" String="Sales Order No."/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/SalesOrderItem">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/SalesOrderItem">
         <Annotation Term="Common.Label" String="Item"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/Route">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/Route">
         <Annotation Term="Common.Label" String="Route"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/HigherLevelItem">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/HigherLevelItem">
         <Annotation Term="Common.Label" String="Higher-Level Item"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/SalesOrderItemCategory">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/SalesOrderItemCategory">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Item Category"/>
         <Annotation Term="Common.Text" Path="_ItemCategory/SalesDocumentItemCategory_Text"/>
@@ -3997,10 +3997,10 @@
         </Annotation>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/fieldControlType_item">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/fieldControlType_item">
         <Annotation Term="Common.Label" String="FieldControlType for Items Table"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/Material">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/Material">
         <Annotation Term="Common.FieldControl" Path="fieldControlType_item"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Material"/>
@@ -4035,14 +4035,14 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/RequestedDeliveryDate">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/RequestedDeliveryDate">
         <Annotation Term="Common.Label" String="Delivery Date"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/RequestedQuantity">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/RequestedQuantity">
         <Annotation Term="Common.Label" String="Requested Quantity"/>
         <Annotation Term="Measures.Unit" Path="RequestedQuantityUnit"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/RequestedQuantityUnit">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/RequestedQuantityUnit">
         <Annotation Term="Common.FieldControl" Path="owner/fieldControlType_item"/>
         <Annotation Term="Common.Label" String="Requested Qty Unit"/>
         <Annotation Term="Common.Text" Path="_RequestedQuantityUnit/UnitOfMeasure_Text"/>
@@ -4074,50 +4074,50 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/PricingDate">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/PricingDate">
         <Annotation Term="Common.Label" String="Pricing Date"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/NetAmount">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/NetAmount">
         <Annotation Term="Analytics.Measure" Bool="true"/>
         <Annotation Term="Common.FieldControl" Path="owner/fieldControlType_item"/>
         <Annotation Term="Common.Label" String="Net Value"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
         <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/NetAmountHidden">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/NetAmountHidden">
         <Annotation Term="Common.Label" String="Net Value"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
         <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency"/>
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/TargetAmount">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/TargetAmount">
         <Annotation Term="Common.Label" String="Target Value"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
         <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency"/>
         <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/isVerified">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/isVerified">
         <Annotation Term="Common.Label" String="Verified Material"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/SAP_Message">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/SAP_Message">
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/IsActiveEntity">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/IsActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/HasActiveEntity">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/HasActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/HasDraftEntity">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/HasDraftEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItem/DraftAdministrativeData">
+      <Annotations Target="SalesOrderManage.SalesOrderItem/DraftAdministrativeData">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DummyBoundAction(com.c_salesordermanage_sd.SalesOrderItem)">
+      <Annotations Target="SalesOrderManage.DummyBoundAction(SalesOrderManage.SalesOrderItem)">
         <Annotation Term="Core.OperationAvailable" Path="_it/owner/_ShipToParty/isVerified"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.IdentificationFormAction(com.c_salesordermanage_sd.SalesOrderItem)">
+      <Annotations Target="SalesOrderManage.IdentificationFormAction(SalesOrderManage.SalesOrderItem)">
         <Annotation Term="Common.SideEffects">
           <Record Type="Common.SideEffectsType">
             <PropertyValue Property="TargetProperties">
@@ -4130,10 +4130,10 @@
         </Annotation>
         <Annotation Term="Core.OperationAvailable" Path="_it/isVerified"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.IdentificationFormAction(com.c_salesordermanage_sd.SalesOrderItem)/RequestedQuantity">
+      <Annotations Target="SalesOrderManage.IdentificationFormAction(SalesOrderManage.SalesOrderItem)/RequestedQuantity">
         <Annotation Term="Common.Label" String="Requested Quantity"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.AddRandomItem(Collection(com.c_salesordermanage_sd.SalesOrderItem))">
+      <Annotations Target="SalesOrderManage.AddRandomItem(Collection(SalesOrderManage.SalesOrderItem))">
         <Annotation Term="Common.SideEffects">
           <Record Type="Common.SideEffectsType">
             <PropertyValue Property="TargetEntities">
@@ -4149,32 +4149,32 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.AddRandomItem(Collection(com.c_salesordermanage_sd.SalesOrderItem))/position">
+      <Annotations Target="SalesOrderManage.AddRandomItem(Collection(SalesOrderManage.SalesOrderItem))/position">
         <Annotation Term="Common.Label" String="New row position"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.createMessage(com.c_salesordermanage_sd.SalesOrderItem)/message">
+      <Annotations Target="SalesOrderManage.createMessage(SalesOrderManage.SalesOrderItem)/message">
         <Annotation Term="Common.Label" String="Message"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItemCategory">
+      <Annotations Target="SalesOrderManage.SalesOrderItemCategory">
         <Annotation Term="Common.Label" String="Sales Document Item Category"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItemCategory/SalesDocumentItemCategory">
+      <Annotations Target="SalesOrderManage.SalesOrderItemCategory/SalesDocumentItemCategory">
         <Annotation Term="Common.Heading" String="ItCa"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Item Category"/>
         <Annotation Term="Common.QuickInfo" String="Sales Document Item Category"/>
         <Annotation Term="Common.Text" Path="SalesDocumentItemCategory"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItemCategory/SalesDocumentItemCategory_Text">
+      <Annotations Target="SalesOrderManage.SalesOrderItemCategory/SalesDocumentItemCategory_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderItemCategory/ScheduleLineIsAllowed">
+      <Annotations Target="SalesOrderManage.SalesOrderItemCategory/ScheduleLineIsAllowed">
         <Annotation Term="Common.Heading" String="SchAl"/>
         <Annotation Term="Common.Label" String="Sched.lines allowed"/>
         <Annotation Term="Common.QuickInfo" String="Schedule lines allowed"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage">
+      <Annotations Target="SalesOrderManage.SalesOrderManage">
         <Annotation Term="Common.Label" String="Manage Sales Order"/>
         <Annotation Term="Common.SemanticKey">
           <Collection>
@@ -4226,7 +4226,7 @@
                 <String>IncotermsLocation1</String>
               </Collection>
             </PropertyValue>
-            <PropertyValue Property="TriggerAction" String="com.c_salesordermanage_sd.IncotermsDetermination"/>
+            <PropertyValue Property="TriggerAction" String="SalesOrderManage.IncotermsDetermination"/>
           </Record>
         </Annotation>
         <Annotation Term="Common.SideEffects" Qualifier="ItemCreationOrDeletion">
@@ -4465,12 +4465,12 @@
                 </Record>
                 <Record Type="UI.DataFieldForAction">
                   <PropertyValue Property="Label" String="Facet Form Action"/>
-                  <PropertyValue Property="Action" String="com.c_salesordermanage_sd.FacetFormAction"/>
+                  <PropertyValue Property="Action" String="SalesOrderManage.FacetFormAction"/>
                   <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High"/>
                 </Record>
                 <Record Type="UI.DataFieldForAction">
                   <PropertyValue Property="Label" String="Navigate via Action (Form)"/>
-                  <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ActionNavigation"/>
+                  <PropertyValue Property="Action" String="SalesOrderManage.ActionNavigation"/>
                 </Record>
                 <Record Type="UI.DataFieldWithNavigationPath">
                   <PropertyValue Property="Label" String="Referenced Sales Order"/>
@@ -4758,55 +4758,55 @@
           <Collection>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Enable Edit"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.EnableEditAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.EnableEditAction"/>
               <Annotation Term="UI.Hidden" Path="editActionIsEnabled"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Change Order Status (Header)"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ChangeOrderStatus"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.ChangeOrderStatus"/>
               <Annotation Term="UI.Hidden" Path="editActionIsDisabled"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Navigate via Action (Header)"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ActionNavigation"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.ActionNavigation"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Menu Navigate via Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MenuActionNavigation"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.MenuActionNavigation"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Menu Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MenuDataFieldForAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.MenuDataFieldForAction"/>
               <Annotation Term="UI.Hidden" Path="ReturnInProcess"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Determining" Bool="true"/>
               <PropertyValue Property="Label" String="Positive (Dummy)"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.DummyBoundAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.DummyBoundAction"/>
               <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Positive"/>
               <Annotation Term="UI.Hidden" Path="Delivered"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Determining" Bool="true"/>
               <PropertyValue Property="Label" String="Negative (Dummy)"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.EntityContainer/UnboundAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.EntityContainer/UnboundAction"/>
               <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Negative"/>
               <Annotation Term="UI.Hidden" Path="Delivered"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Change Order Status (Footer)"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ChangeOrderStatus"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.ChangeOrderStatus"/>
               <PropertyValue Property="Determining" Bool="true"/>
               <Annotation Term="UI.Hidden" Path="editActionIsDisabled"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Navigate via Action (Footer)"/>
               <PropertyValue Property="Determining" Bool="true"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ActionNavigation"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.ActionNavigation"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Bound Action with params"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.CreateWithSalesOrderType"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.CreateWithSalesOrderType"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
               <PropertyValue Property="SemanticObject" String="v4Freestyle"/>
@@ -4888,7 +4888,7 @@
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Bound Inline"/>
               <PropertyValue Property="Inline" Bool="true"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.CreateWithSalesOrderType"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.CreateWithSalesOrderType"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
               <PropertyValue Property="SemanticObject" String="v4Freestyle"/>
@@ -4898,12 +4898,12 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Navigate via Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ActionNavigation"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.ActionNavigation"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Navigate via Action"/>
               <PropertyValue Property="Inline" Bool="true"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ActionNavigation"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.ActionNavigation"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
               <PropertyValue Property="SemanticObject" String="v4Freestyle"/>
@@ -4927,19 +4927,19 @@
           <Collection>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Bound Action with params"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.CreateWithSalesOrderType"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.CreateWithSalesOrderType"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Copy"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.CopySalesOrder"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.CopySalesOrder"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Unbound Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.EntityContainer/UnboundAction"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.EntityContainer/UnboundAction"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Confirmation Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.EntityContainer/ReturnInProcess"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.EntityContainer/ReturnInProcess"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
               <PropertyValue Property="SemanticObject" String="SalesOrder"/>
@@ -4950,7 +4950,7 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Static Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.DummyStaticAction(com.c_salesordermanage_sd.SalesOrderManage)"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.DummyStaticAction(SalesOrderManage.SalesOrderManage)"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
               <PropertyValue Property="SemanticObject" String="v4Freestyle"/>
@@ -5006,7 +5006,7 @@
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Bound Inline"/>
               <PropertyValue Property="Inline" Bool="true"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.CreateWithSalesOrderType"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.CreateWithSalesOrderType"/>
               <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/Low"/>
             </Record>
             <Record Type="UI.DataFieldForIntentBasedNavigation">
@@ -5017,11 +5017,11 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Navigate via Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ActionNavigation"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.ActionNavigation"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Navigate via Action"/>
-              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.ActionNavigation"/>
+              <PropertyValue Property="Action" String="SalesOrderManage.ActionNavigation"/>
               <PropertyValue Property="Inline" Bool="true"/>
               <PropertyValue Property="IconUrl" String="sap-icon://arrow-right"/>
               <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/Low"/>
@@ -5164,7 +5164,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/SalesOrderManage">
+      <Annotations Target="SalesOrderManage.EntityContainer/SalesOrderManage">
         <Annotation Term="Capabilities.DeleteRestrictions">
           <Record Type="Capabilities.DeleteRestrictionsType">
             <PropertyValue Property="Deletable" Path="isDeletable"/>
@@ -5218,37 +5218,37 @@
         </Annotation>
         <Annotation Term="Common.DraftRoot">
           <Record Type="Common.DraftRootType">
-            <PropertyValue Property="ActivationAction" String="com.c_salesordermanage_sd.draftActivate"/>
-            <PropertyValue Property="EditAction" String="com.c_salesordermanage_sd.draftEdit"/>
-            <PropertyValue Property="PreparationAction" String="com.c_salesordermanage_sd.draftPrepare"/>
+            <PropertyValue Property="ActivationAction" String="SalesOrderManage.draftActivate"/>
+            <PropertyValue Property="EditAction" String="SalesOrderManage.draftEdit"/>
+            <PropertyValue Property="PreparationAction" String="SalesOrderManage.draftPrepare"/>
           </Record>
         </Annotation>
         <Annotation Term="UI.DeleteHidden" Path="isDeleteHidden"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/ID">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/ID">
         <Annotation Term="Common.Label" String="Sales Order"/>
         <Annotation Term="Common.Text" Path="SalesOrder">
           <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextOnly"/>
         </Annotation>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/SalesOrder">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/SalesOrder">
         <Annotation Term="Common.Label" String="Sales Order No."/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/Delivered">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/Delivered">
         <Annotation Term="Common.Label" String="Delivery Status"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/CFhidden">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/CFhidden">
         <Annotation Term="Common.Label" String="Custom Field Status"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/CF2hidden">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/CF2hidden">
         <Annotation Term="Common.Label" String="Custom Field2 Status"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/ReturnInProcess">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/ReturnInProcess">
         <Annotation Term="Common.Label" String="Return Status"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/SalesOrderType">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/SalesOrderType">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Order Type"/>
         <Annotation Term="Common.Text" Path="_SalesOrderType/SalesOrderType_Text">
@@ -5256,11 +5256,11 @@
         </Annotation>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/ImageUrl">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/ImageUrl">
         <Annotation Term="Common.Label" String="Image"/>
         <Annotation Term="UI.IsImageURL" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/SoldToParty">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/SoldToParty">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Heading" String="Sold-To"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
@@ -5331,10 +5331,10 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/SalesOrganization">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/SalesOrganization">
         <Annotation Term="Common.Label" String="Sales Organization"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/Rating">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/Rating">
         <Annotation Term="Common.Label" String="Rating"/>
         <Annotation Term="UI.DataFieldDefault" Qualifier="changedLabel">
           <Record Type="UI.DataField">
@@ -5350,13 +5350,13 @@
         </Annotation>
         <Annotation Term="UI.HiddenFilter" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/Progress">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/Progress">
         <Annotation Term="Common.Label" String="Progress"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/DistributionChannel">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/DistributionChannel">
         <Annotation Term="Common.Label" String="Distribution Channel"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/OrganizationDivision">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/OrganizationDivision">
         <Annotation Term="Common.Label" String="Division"/>
         <Annotation Term="Common.SemanticObject" String="SalesOrder"/>
         <Annotation Term="Common.SemanticObjectMapping">
@@ -5379,13 +5379,13 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/PurchaseOrderByCustomer">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/PurchaseOrderByCustomer">
         <Annotation Term="Common.Label" String="Customer Reference"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/PricingDate">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/PricingDate">
         <Annotation Term="Common.Label" String="Pricing Date"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/ShippingCondition">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/ShippingCondition">
         <Annotation Term="Common.Heading" String="SC"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Shipping Conditions"/>
@@ -5415,10 +5415,10 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/CompleteDeliveryIsDefined">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/CompleteDeliveryIsDefined">
         <Annotation Term="Common.Label" String="Complete Delivery"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/IncotermsClassification">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/IncotermsClassification">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Incoterms"/>
         <Annotation Term="Common.Text" Path="_IncotermsClassification/IncotermsClassification_Text"/>
@@ -5443,7 +5443,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/IncotermsVersion">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/IncotermsVersion">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Incoterms Version"/>
         <Annotation Term="Common.Text" Path="_IncotermsVersion/IncotermsVersion_Text"/>
@@ -5466,29 +5466,29 @@
         </Annotation>
         <Annotation Term="Common.ValueListForValidation" String=""/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/fieldControlType_item">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/fieldControlType_item">
         <Annotation Term="Common.Label" String="FieldControlType for Items Table"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/fieldControlType">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/fieldControlType">
         <Annotation Term="Common.Label" String="fieldControlType"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/TrialInt64">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/TrialInt64">
         <Annotation Term="Common.Label" String="Int64"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/TrialDouble">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/TrialDouble">
         <Annotation Term="Common.Label" String="Double"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/TrialTOD">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/TrialTOD">
         <Annotation Term="Common.Label" String="Time Of Day"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/IncotermsLocation1">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/IncotermsLocation1">
         <Annotation Term="Common.Label" String="Incoterms Version 1"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/IncotermsLocation2">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/IncotermsLocation2">
         <Annotation Term="Common.Label" String="Incoterms Location 2"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/CustomerPaymentTerms">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/CustomerPaymentTerms">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Terms of Payment"/>
         <Annotation Term="Common.Text" Path="_CustomerPaymentTerms/CustomerPaymentTerms_Text">
@@ -5514,22 +5514,22 @@
         <Annotation Term="Common.ValueListWithFixedValues" Bool="true"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/TotalNetAmount">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/TotalNetAmount">
         <Annotation Term="Common.Label" String="Net Amount"/>
         <Annotation Term="Core.Computed" Bool="true"/>
         <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/TotalNetAmount2">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/TotalNetAmount2">
         <Annotation Term="Common.Label" String="Net Amount2"/>
         <Annotation Term="Core.Computed" Bool="true"/>
         <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/TransactionCurrency">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/TransactionCurrency">
         <Annotation Term="Common.Heading" String="Curr."/>
         <Annotation Term="Common.Label" String="Document Currency"/>
         <Annotation Term="Common.QuickInfo" String="SD document currency"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/OverallSDProcessStatus">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/OverallSDProcessStatus">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Overall Status"/>
         <Annotation Term="Common.Text" Path="_OverallSDProcessStatus/OverallSDProcessStatus_Text"/>
@@ -5553,58 +5553,58 @@
         <Annotation Term="Common.ValueListWithFixedValues" Bool="false"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/LastChangedDateTime">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/LastChangedDateTime">
         <Annotation Term="Common.Label" String="Last Change Date"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/SalesOrderDate">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/SalesOrderDate">
         <Annotation Term="Common.Label" String="Document Date"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/SalesOrderTypeName">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/SalesOrderTypeName">
         <Annotation Term="Common.Label" String="Sales Document Type"/>
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/DescriptionFieldForOPACleanup">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/DescriptionFieldForOPACleanup">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/document_name">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/document_name">
         <Annotation Term="Common.Label" String="File Name"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/document_content">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/document_content">
         <Annotation Term="Common.Label" String="Document"/>
         <Annotation Term="Core.MediaType" Path="document_type"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/document_type">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/document_type">
         <Annotation Term="Core.IsMediaType" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/IsActiveEntity">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/IsActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/HasActiveEntity">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/HasActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/HasDraftEntity">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/HasDraftEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderManage/DraftAdministrativeData">
+      <Annotations Target="SalesOrderManage.SalesOrderManage/DraftAdministrativeData">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.DummyStaticAction(Collection(com.c_salesordermanage_sd.SalesOrderManage))/MessageText">
+      <Annotations Target="SalesOrderManage.DummyStaticAction(Collection(SalesOrderManage.SalesOrderManage))/MessageText">
         <Annotation Term="Common.Label" String="Message"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OPAvailableTrueAction(com.c_salesordermanage_sd.SalesOrderManage)">
+      <Annotations Target="SalesOrderManage.OPAvailableTrueAction(SalesOrderManage.SalesOrderManage)">
         <Annotation Term="Common.IsActionCritical" Bool="true"/>
         <Annotation Term="Core.OperationAvailable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OPAvailableFalseAction(com.c_salesordermanage_sd.SalesOrderManage)">
+      <Annotations Target="SalesOrderManage.OPAvailableFalseAction(SalesOrderManage.SalesOrderManage)">
         <Annotation Term="Core.OperationAvailable" Bool="false"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.OPAvailableNullAction(com.c_salesordermanage_sd.SalesOrderManage)">
+      <Annotations Target="SalesOrderManage.OPAvailableNullAction(SalesOrderManage.SalesOrderManage)">
         <Annotation Term="Core.OperationAvailable">
           <Null/>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EnableEditAction(com.c_salesordermanage_sd.SalesOrderManage)">
+      <Annotations Target="SalesOrderManage.EnableEditAction(SalesOrderManage.SalesOrderManage)">
         <Annotation Term="Common.SideEffects">
           <Record Type="Common.SideEffectsType">
             <PropertyValue Property="TargetProperties">
@@ -5616,7 +5616,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreateWithSalesOrderType(com.c_salesordermanage_sd.SalesOrderManage)">
+      <Annotations Target="SalesOrderManage.CreateWithSalesOrderType(SalesOrderManage.SalesOrderManage)">
         <Annotation Term="Common.IsActionCritical" Bool="true"/>
         <Annotation Term="Common.SideEffects">
           <Record Type="Common.SideEffectsType">
@@ -5626,12 +5626,12 @@
                 <String>_it/SalesOrderTypeName</String>
               </Collection>
             </PropertyValue>
-            <PropertyValue Property="TriggerAction" String="com.c_salesordermanage_sd.IncotermsDetermination"/>
+            <PropertyValue Property="TriggerAction" String="SalesOrderManage.IncotermsDetermination"/>
           </Record>
         </Annotation>
         <Annotation Term="Core.OperationAvailable" Path="_it/isVerified"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreateWithSalesOrderType(com.c_salesordermanage_sd.SalesOrderManage)/SalesOrderType">
+      <Annotations Target="SalesOrderManage.CreateWithSalesOrderType(SalesOrderManage.SalesOrderManage)/SalesOrderType">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Sales Order Type"/>
@@ -5657,7 +5657,7 @@
         </Annotation>
         <Annotation Term="UI.ParameterDefaultValue" Path="_it/SalesOrderType"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreateWithSalesOrderType(com.c_salesordermanage_sd.SalesOrderManage)/SalesOrganization">
+      <Annotations Target="SalesOrderManage.CreateWithSalesOrderType(SalesOrderManage.SalesOrderManage)/SalesOrganization">
         <Annotation Term="Common.Label" String="Sales Organization"/>
         <Annotation Term="Common.ValueList">
           <Record Type="Common.ValueListType">
@@ -5690,7 +5690,7 @@
         </Annotation>
         <Annotation Term="UI.ParameterDefaultValue" String="0002"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreateWithSalesOrderType(com.c_salesordermanage_sd.SalesOrderManage)/OrganizationDivision">
+      <Annotations Target="SalesOrderManage.CreateWithSalesOrderType(SalesOrderManage.SalesOrderManage)/OrganizationDivision">
         <Annotation Term="Common.Heading" String="Dv"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Division"/>
@@ -5716,7 +5716,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.CreateWithSalesOrderType(com.c_salesordermanage_sd.SalesOrderManage)/DistributionChannel">
+      <Annotations Target="SalesOrderManage.CreateWithSalesOrderType(SalesOrderManage.SalesOrderManage)/DistributionChannel">
         <Annotation Term="Common.Heading" String="DChl"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Distribution Channel"/>
@@ -5738,7 +5738,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ChangeOrderStatus(com.c_salesordermanage_sd.SalesOrderManage)">
+      <Annotations Target="SalesOrderManage.ChangeOrderStatus(SalesOrderManage.SalesOrderManage)">
         <Annotation Term="Common.SideEffects">
           <Record Type="Common.SideEffectsType">
             <PropertyValue Property="TargetProperties">
@@ -5750,7 +5750,7 @@
         </Annotation>
         <Annotation Term="Core.OperationAvailable" Path="_it/_ShipToParty/isVerified"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ChangeOrderStatus(com.c_salesordermanage_sd.SalesOrderManage)/OverallSDProcessStatus">
+      <Annotations Target="SalesOrderManage.ChangeOrderStatus(SalesOrderManage.SalesOrderManage)/OverallSDProcessStatus">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Overall Status"/>
         <Annotation Term="Common.Text">
@@ -5774,7 +5774,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.FacetFormAction(com.c_salesordermanage_sd.SalesOrderManage)">
+      <Annotations Target="SalesOrderManage.FacetFormAction(SalesOrderManage.SalesOrderManage)">
         <Annotation Term="Common.SideEffects">
           <Record Type="Common.SideEffectsType">
             <PropertyValue Property="TargetProperties">
@@ -5786,7 +5786,7 @@
         </Annotation>
         <Annotation Term="Core.OperationAvailable" Path="_it/_ShipToParty/isVerified"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.FacetFormAction(com.c_salesordermanage_sd.SalesOrderManage)/ShippingCondition">
+      <Annotations Target="SalesOrderManage.FacetFormAction(SalesOrderManage.SalesOrderManage)/ShippingCondition">
         <Annotation Term="Common.Heading" String="SC"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Shipping Conditions"/>
@@ -5808,7 +5808,7 @@
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderScheduleLineType">
+      <Annotations Target="SalesOrderManage.SalesOrderScheduleLineType">
         <Annotation Term="Common.Label" String="Manage Sales Order Schedule Line (TP)"/>
         <Annotation Term="Common.SemanticKey">
           <Collection>
@@ -5816,159 +5816,159 @@
           </Collection>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.EntityContainer/SalesOrderScheduleLineType">
+      <Annotations Target="SalesOrderManage.EntityContainer/SalesOrderScheduleLineType">
         <Annotation Term="Common.DraftNode">
           <Record Type="Common.DraftNodeType">
-            <PropertyValue Property="PreparationAction" String="com.c_salesordermanage_sd.draftPrepare"/>
+            <PropertyValue Property="PreparationAction" String="SalesOrderManage.draftPrepare"/>
           </Record>
         </Annotation>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderScheduleLineType/ID">
+      <Annotations Target="SalesOrderManage.SalesOrderScheduleLineType/ID">
         <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderScheduleLineType/SalesOrder">
+      <Annotations Target="SalesOrderManage.SalesOrderScheduleLineType/SalesOrder">
         <Annotation Term="Common.Heading" String="Sales Doc."/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Sales Document"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderScheduleLineType/IsActiveEntity">
+      <Annotations Target="SalesOrderManage.SalesOrderScheduleLineType/IsActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderScheduleLineType/HasActiveEntity">
+      <Annotations Target="SalesOrderManage.SalesOrderScheduleLineType/HasActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderScheduleLineType/HasDraftEntity">
+      <Annotations Target="SalesOrderManage.SalesOrderScheduleLineType/HasDraftEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderScheduleLineType/DraftAdministrativeData">
+      <Annotations Target="SalesOrderManage.SalesOrderScheduleLineType/DraftAdministrativeData">
         <Annotation Term="UI.Hidden" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderType">
+      <Annotations Target="SalesOrderManage.SalesOrderType">
         <Annotation Term="Common.Label" String="Sales Order Types"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderType/SalesOrderType">
+      <Annotations Target="SalesOrderManage.SalesOrderType/SalesOrderType">
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Sales Order Type"/>
         <Annotation Term="Common.Text" Path="SalesOrderType_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderType/SalesOrderType_Text">
+      <Annotations Target="SalesOrderManage.SalesOrderType/SalesOrderType_Text">
         <Annotation Term="Common.Label" String="Sales Document Type"/>
         <Annotation Term="Common.QuickInfo" String="Sales Document Type Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderType/SalesOrderProcessingType">
+      <Annotations Target="SalesOrderManage.SalesOrderType/SalesOrderProcessingType">
         <Annotation Term="Common.Heading" String="C"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Indicator"/>
         <Annotation Term="Common.QuickInfo" String="Sales document indicator (for display in TVAK only)"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrderType/OrderTypeForBillingRequest">
+      <Annotations Target="SalesOrderManage.SalesOrderType/OrderTypeForBillingRequest">
         <Annotation Term="Common.Heading" String="Req."/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Billing Request"/>
         <Annotation Term="Common.QuickInfo" String="Order type for request for billing"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.SalesOrganization/SalesOrganization">
+      <Annotations Target="SalesOrderManage.SalesOrganization/SalesOrganization">
         <Annotation Term="Common.Label" String="Sales Organization"/>
         <Annotation Term="Common.Text" Path="SalesOrganization_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingCondition">
+      <Annotations Target="SalesOrderManage.ShippingCondition">
         <Annotation Term="Common.Label" String="Shipping Condition"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingCondition/ShippingCondition">
+      <Annotations Target="SalesOrderManage.ShippingCondition/ShippingCondition">
         <Annotation Term="Common.Heading" String="SC"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Shipping Conditions"/>
         <Annotation Term="Common.Text" Path="ShippingCondition_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingCondition/ShippingCondition_Text">
+      <Annotations Target="SalesOrderManage.ShippingCondition/ShippingCondition_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Common.QuickInfo" String="Shipping Conditions Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingCondition/SoldToParty">
+      <Annotations Target="SalesOrderManage.ShippingCondition/SoldToParty">
         <Annotation Term="Common.Heading" String="Customer"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="SoldToParty"/>
         <Annotation Term="Common.QuickInfo" String="Customer Number"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingPoint">
+      <Annotations Target="SalesOrderManage.ShippingPoint">
         <Annotation Term="Common.Label" String="Shipping Point"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingPoint/ShippingPoint">
+      <Annotations Target="SalesOrderManage.ShippingPoint/ShippingPoint">
         <Annotation Term="Common.Heading" String="ShPt"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Shipping Point"/>
         <Annotation Term="Common.QuickInfo" String="Shipping Point / Receiving Point"/>
         <Annotation Term="Common.Text" Path="ShippingPoint_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingPoint/ShippingPoint_Text">
+      <Annotations Target="SalesOrderManage.ShippingPoint/ShippingPoint_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingType">
+      <Annotations Target="SalesOrderManage.ShippingType">
         <Annotation Term="Common.Label" String="Shipping Type"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingType/ShippingType">
+      <Annotations Target="SalesOrderManage.ShippingType/ShippingType">
         <Annotation Term="Common.Heading" String="ST"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Shipping Type"/>
         <Annotation Term="Common.Text" Path="ShippingType_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.ShippingType/ShippingType_Text">
+      <Annotations Target="SalesOrderManage.ShippingType/ShippingType_Text">
         <Annotation Term="Common.Label" String="Description"/>
         <Annotation Term="Common.QuickInfo" String="Shipping Type Description"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.UnboundAction()/MessageText">
+      <Annotations Target="SalesOrderManage.UnboundAction()/MessageText">
         <Annotation Term="Common.Label" String="Message"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.UnitOfMeasure">
+      <Annotations Target="SalesOrderManage.UnitOfMeasure">
         <Annotation Term="Common.Label" String="Unit of Measure"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.UnitOfMeasure/UnitOfMeasure">
+      <Annotations Target="SalesOrderManage.UnitOfMeasure/UnitOfMeasure">
         <Annotation Term="Common.Heading" String="MU"/>
         <Annotation Term="Common.Label" String="Internal UoM"/>
         <Annotation Term="Common.QuickInfo" String="Unit of Measurement"/>
         <Annotation Term="Common.Text" Path="UnitOfMeasure_Text"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.UnitOfMeasure/UnitOfMeasure_Text">
+      <Annotations Target="SalesOrderManage.UnitOfMeasure/UnitOfMeasure_Text">
         <Annotation Term="Common.Heading" String="Measurement unit text"/>
         <Annotation Term="Common.Label" String="UoM Text"/>
         <Annotation Term="Common.QuickInfo" String="Unit of Measurement Text (Maximum 30 Characters)"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.UnitOfMeasure/UnitOfMeasureDimension">
+      <Annotations Target="SalesOrderManage.UnitOfMeasure/UnitOfMeasureDimension">
         <Annotation Term="Common.Heading" String="Dimen."/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="Dimension"/>
         <Annotation Term="Common.QuickInfo" String="Dimension Key"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.UnitOfMeasure/UnitOfMeasureISOCode">
+      <Annotations Target="SalesOrderManage.UnitOfMeasure/UnitOfMeasureISOCode">
         <Annotation Term="Common.Heading" String="ISO"/>
         <Annotation Term="Common.IsUpperCase" Bool="true"/>
         <Annotation Term="Common.Label" String="ISO Code"/>
         <Annotation Term="Common.QuickInfo" String="ISO Code for Unit of Measurement"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.UnitOfMeasure/UnitOfMeasureNumberOfDecimals">
+      <Annotations Target="SalesOrderManage.UnitOfMeasure/UnitOfMeasureNumberOfDecimals">
         <Annotation Term="Common.Heading" String="DeR"/>
         <Annotation Term="Common.Label" String="Decimal Rounding"/>
         <Annotation Term="Common.QuickInfo" String="Number of Decimal Places for Rounding"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.UnitOfMeasure/UnitOfMeasureDspNmbrOfDcmls">
+      <Annotations Target="SalesOrderManage.UnitOfMeasure/UnitOfMeasureDspNmbrOfDcmls">
         <Annotation Term="Common.Heading" String="Dec"/>
         <Annotation Term="Common.Label" String="Decimal Places"/>
         <Annotation Term="Common.QuickInfo" String="Number of Decimal Places for Number Display"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.WarrantyYearDetails">
+      <Annotations Target="SalesOrderManage.WarrantyYearDetails">
         <Annotation Term="Common.Label" String="Warranty Years Details"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.WarrantyYearDetails/WarrantyExpiration">
+      <Annotations Target="SalesOrderManage.WarrantyYearDetails/WarrantyExpiration">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Warranty Expiration (Association)"/>
         <Annotation Term="Core.Immutable" Bool="true"/>
       </Annotations>
-      <Annotations Target="com.c_salesordermanage_sd.WarrantyYearDetails/WarrantyYearsDetail">
+      <Annotations Target="SalesOrderManage.WarrantyYearDetails/WarrantyYearsDetail">
         <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
         <Annotation Term="Common.Label" String="Warranty Years Detail (Association)"/>
         <Annotation Term="Core.Immutable" Bool="true"/>


### PR DESCRIPTION
Fix for #570 
Currently we were only evaluating that the path was starting with the schema namespace, when in reality a `.` is required to identify that we have a complex object.

We could have had additional failure if somehow the namespace was the first part of an entityset name ...