### PR TITLE
fix: fractional second support in the filters

### DIFF
--- a/.changeset/three-cougars-brake.md
+++ b/.changeset/three-cougars-brake.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+DateTime can also include fractional seconds

--- a/packages/fe-mockserver-core/src/request/commonTokens.ts
+++ b/packages/fe-mockserver-core/src/request/commonTokens.ts
@@ -29,7 +29,7 @@ export const TYPEDEF = createToken({ name: 'Typedef', pattern: /Edm\.[a-zA-Z]+/ 
 export const LITERAL = createToken({
     name: 'Literal',
     pattern:
-        /(:?null|true|false|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|guid(:?'|%27)[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(:?'|%27)|datetime'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})*'|\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:.\d{3}Z|\+\d{2}:\d{2}))*|-?(:?0|[1-9]\d*)(\.\d+)?(:?[eE][+-]?\d+)?|'[^\\"\n\r\']*')/
+        /(:?null|true|false|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|guid(:?'|%27)[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(:?'|%27)|datetime'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})*'|\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:.\d{7})*(?:.\d{3}Z|\+\d{2}:\d{2}))*|-?(:?0|[1-9]\d*)(\.\d+)?(:?[eE][+-]?\d+)?|'[^\\"\n\r\']*')/
 });
 //ee1a9172-f3c3-47ce-b0f7-dd28c740210c
 export const LOGICAL_OPERATOR = createToken({ name: 'Logical', pattern: /(:?eq|ne|lt|le|gt|ge)/ });

--- a/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
@@ -42,6 +42,12 @@ describe('Filter Parser', () => {
         expect(dateBetween?.expressions[1].operator).toBe('lt');
         expect(dateBetween?.expressions[1].literal).toBe('2022-05-16T21:59:59.000Z');
 
+        const dateTZ = parseFilter(
+            'EventDateTimeFrom eq 2023-05-02T08:00:00.0000000+08:00 and EventDateTimeTo eq 2023-05-03T07:59:59.0000000+08:00'
+        );
+        expect(dateTZ?.expressions[0].identifier).toBe('EventDateTimeFrom');
+        expect(dateTZ?.expressions[0].operator).toBe('eq');
+
         const dateBetweenTZ = parseFilter(
             'DateTime ge 2022-05-16T00:00:00+02:00 and DateTime le 2022-05-22T23:59:59+02:00'
         );


### PR DESCRIPTION
Internal Incident where filter

`'EventDateTimeFrom eq 2023-05-02T08:00:00.0000000+08:00 and EventDateTimeTo eq 2023-05-03T07:59:59.0000000+08:00'` results in parser failure
