### PR TITLE
fix: $target can be undefined

### DIFF
--- a/.changeset/gentle-rivers-doubt.md
+++ b/.changeset/gentle-rivers-doubt.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux/annotation-converter': patch
+'@sap-ux/fe-mockserver-core': patch
+'@sap-ux/vocabularies-types': patch
+---
+
+The `$target` property of types `PropertyPath`, `NavigationPropertyPath`, `AnnotationPath` and `PathAnnotationExpression` can now be undefined

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -509,7 +509,9 @@ function mapPath(
         type: 'Path',
         path: path.Path,
         fullyQualifiedName: fullyQualifiedName,
-        getValue(): any {},
+        getValue(): any {
+            return undefined; // TODO: Required according to the type...
+        },
         [ANNOTATION_TARGET]: currentTarget
     };
 

--- a/packages/annotation-converter/test/fixtures/v4/invalidReferences.xml
+++ b/packages/annotation-converter/test/fixtures/v4/invalidReferences.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+    <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="Entity" EntityType="TestService.Entity"/>
+      </EntityContainer>
+      <EntityType Name="Entity">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <Annotations Target="TestService.Entity">
+        <Annotation Term="UI.SelectionFields">
+          <Collection>
+            <PropertyPath>doesNotExist1</PropertyPath>
+            <PropertyPath></PropertyPath>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup">
+          <Record Type="UI.FieldGroupType">
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="doesNotExist2"/>
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path=""/>
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -28,21 +28,24 @@ import type {
 // Generated EDM Types for the converter
 
 export type PropertyPath = {
-    fullyQualifiedName: string;
     type: 'PropertyPath';
+    fullyQualifiedName: FullyQualifiedName;
     value: string;
-    $target: Property;
+    $target: Property | undefined;
 };
+
 export type NavigationPropertyPath = {
     type: 'NavigationPropertyPath';
+    fullyQualifiedName: FullyQualifiedName;
     value: string;
-    $target: NavigationProperty;
+    $target: NavigationProperty | undefined;
 };
 
 export type AnnotationPath<P> = {
     type: 'AnnotationPath';
+    fullyQualifiedName: FullyQualifiedName;
     value: string;
-    $target: AnnotationTerm<P> & { term: string };
+    $target: (AnnotationTerm<P> & { term: string }) | undefined;
 };
 
 type PrimitiveTypeCast<P, G> =
@@ -73,8 +76,9 @@ export type PropertyOfType<P extends keyof TypeToString1> = Property & {
 
 export type PathAnnotationExpression<P> = {
     type: 'Path';
+    fullyQualifiedName: FullyQualifiedName;
     path: string; // The defined path
-    $target: Property;
+    $target: Property | undefined;
     getValue(): P;
 };
 
@@ -469,7 +473,7 @@ export type ServiceObject =
 export type ServiceObjectAndAnnotation = ServiceObject | AnyAnnotation;
 
 export type ResolutionTarget<T> = {
-    target: undefined | null | T;
+    target: undefined | T;
     objectPath: ServiceObjectAndAnnotation[];
     messages: { message: string }[];
 };


### PR DESCRIPTION
The vocabulary types now allow `undefined` as values for the `$target` property of types `PropertyPath`, `NavigationPropertyPath`, `AnnotationPath` and `PathAnnotationExpression`.

This required adjustments to the annotation converter and mockserver implementations. The annotation converter output now better adheres to the defined types.

Fixes #589