### PR TITLE
fix: return the right references

### DIFF
--- a/.changeset/fuzzy-bikes-push.md
+++ b/.changeset/fuzzy-bikes-push.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/annotation-converter': patch
+'@sap-ux/edmx-parser': patch
+---
+
+The annotation converter now returns the correct references

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -1553,7 +1553,7 @@ export function convert(rawMetadata: RawMetadata): ConvertedMetadata {
         version: rawMetadata.version,
         namespace: rawMetadata.schema.namespace,
         annotations: rawMetadata.schema.annotations,
-        references: VocabularyReferences.concat(rawMetadata.references),
+        references: VocabularyReferences,
         diagnostics: []
     } as any;
 

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -33,7 +33,6 @@ import type {
     RawTypeDefinition,
     RawV2NavigationProperty,
     RawV4NavigationProperty,
-    Reference,
     RemoveAnnotationAndType,
     ResolutionTarget,
     Singleton,
@@ -1542,48 +1541,6 @@ function convertTypeDefinition(converter: Converter, rawTypeDefinition: RawTypeD
     return convertedTypeDefinition;
 }
 
-function getReferences(converter: Converter, rawMetadataReferences: Reference[]) {
-    if (rawMetadataReferences.length === 0) {
-        return VocabularyReferences;
-    }
-
-    const references: Reference[] = [];
-    const duplicates = new Set<Reference>();
-
-    const collides = (a: Reference, b: Reference) => a.namespace === b.namespace || a.alias === b.alias;
-
-    // process the raw references, making sure they are unique (first one wins)
-    for (const reference of rawMetadataReferences) {
-        const collisions = references.filter((existingReference) => collides(existingReference, reference));
-
-        if (collisions.length > 0) {
-            collisions.forEach((reference) => duplicates.add(reference));
-            duplicates.add(reference);
-        } else {
-            references.push(reference);
-        }
-    }
-
-    // add default vocabulary references (if not there already). Do not report conflicts as errors.
-    references.push(
-        ...VocabularyReferences.filter((reference) =>
-            references.every((existingReference) => !collides(existingReference, reference))
-        )
-    );
-
-    if (duplicates.size > 0) {
-        converter.logError(
-            `The following references are not unique. Check if they are imported multiple times.\n${JSON.stringify(
-                Array.from(duplicates),
-                null,
-                2
-            )}`
-        );
-    }
-
-    return references;
-}
-
 /**
  * Convert a RawMetadata into an object representation to be used to easily navigate a metadata object and its annotation.
  *
@@ -1596,13 +1553,17 @@ export function convert(rawMetadata: RawMetadata): ConvertedMetadata {
         version: rawMetadata.version,
         namespace: rawMetadata.schema.namespace,
         annotations: rawMetadata.schema.annotations,
+        references: VocabularyReferences.concat(rawMetadata.references),
         diagnostics: []
     } as any;
 
+    // fall back on the default references if the caller does not specify any
+    if (rawMetadata.references.length === 0) {
+        rawMetadata.references = VocabularyReferences;
+    }
+
     // Converter
     const converter = new Converter(rawMetadata, convertedOutput);
-
-    lazy(convertedOutput, 'references', () => getReferences(converter, rawMetadata.references));
 
     lazy(
         convertedOutput,

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -33,6 +33,7 @@ import {
     UIAnnotationTerms,
     UIAnnotationTypes
 } from '@sap-ux/vocabularies-types/vocabularies/UI';
+import { VocabularyReferences } from '@sap-ux/vocabularies-types/vocabularies/VocabularyReferences';
 import { convert, defaultReferences, revertTermToGenericType } from '../src';
 import { loadFixture } from './fixturesHelper';
 
@@ -1047,5 +1048,42 @@ describe('Annotation Converter', () => {
         dataFields?.forEach((dataField) => {
             expect(dataField.Value).toBeDefined();
         });
+    });
+
+    it('returns the right set of references', () => {
+        const convertedTypes = convert({
+            identification: '',
+            references: [{ alias: 'MyAlias', namespace: 'MyNamespace', uri: 'MyUri' }],
+            version: '4.0',
+            schema: {
+                namespace: '',
+                actions: [],
+                annotations: {},
+                entityTypes: [],
+                entitySets: [],
+                associations: [],
+                actionImports: [],
+                complexTypes: [],
+                entityContainer: {
+                    _type: 'EntityContainer',
+                    name: '',
+                    fullyQualifiedName: ''
+                },
+                singletons: [],
+                typeDefinitions: [],
+                associationSets: []
+            }
+        });
+
+        expect(convertedTypes.references).toEqual(VocabularyReferences);
+
+        const hasCollision = convertedTypes.references.some((reference) =>
+            convertedTypes.references.some(
+                (otherReference) =>
+                    otherReference !== reference &&
+                    (otherReference.alias === reference.alias || otherReference.namespace === reference.namespace)
+            )
+        );
+        expect(hasCollision).toBeFalsy();
     });
 });

--- a/packages/annotation-converter/test/fixtures/v2/metadataWithApply.xml
+++ b/packages/annotation-converter/test/fixtures/v2/metadataWithApply.xml
@@ -49,8 +49,23 @@
 	</edmx:Reference>
 	<edmx:Reference
 		xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"
+		Uri="https://odata.example:443/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='vocabularies.Communication.v1',Version='0001',SAP__Origin='LOCAL')/$value">
+		<edmx:Include Namespace="com.sap.vocabularies.Communication.v1" Alias="vCard"/>
+	</edmx:Reference>
+	<edmx:Reference
+		xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"
+		Uri="https://odata.example:443/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='Measures.V1',Version='0001',SAP__Origin='LOCAL')/$value">
+		<edmx:Include Namespace="Org.OData.Measures.V1" Alias="CQP"/>
+	</edmx:Reference>
+	<edmx:Reference
+		xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"
 		Uri="https://odata.example:443/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='Core.V1',Version='0001',SAP__Origin='LOCAL')/$value">
 		<edmx:Include Namespace="Org.OData.Core.V1" Alias="Core"/>
+	</edmx:Reference>
+	<edmx:Reference
+		xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"
+		Uri="https://odata.example:443/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='vocabularies.Common.v1',Version='0001',SAP__Origin='LOCAL')/$value">
+		<edmx:Include Namespace="com.sap.vocabularies.Common.v1" Alias="Common"/>
 	</edmx:Reference>
 	<edmx:Reference
 		xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"

--- a/packages/annotation-converter/test/fixtures/v4/metamodelEnums.xml
+++ b/packages/annotation-converter/test/fixtures/v4/metamodelEnums.xml
@@ -3,11 +3,11 @@
     <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.xml">
         <edmx:Include Alias="Capabilities" Namespace="Org.OData.Capabilities.V1"/>
     </edmx:Reference>
+    <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.xml">
+        <edmx:Include Alias="MyCapabilities" Namespace="Org.OData.Capabilities.V1"/>
+    </edmx:Reference>
     <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
         <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
-    </edmx:Reference>
-    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Communication.xml">
-        <edmx:Include Alias="MyCommunication" Namespace="com.sap.vocabularies.Communication.v1"/>
     </edmx:Reference>
     <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
         <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
@@ -34,14 +34,12 @@
             <Annotations Target="sap.fe.test.JestService.EntityContainer/Entities">
                 <Annotation Term="Capabilities.SearchRestrictions">
                     <Record Type="Capabilities.SearchRestrictionsType">
-                        <PropertyValue Property="UnsupportedExpressions"
-                                       EnumMember="Capabilities.SearchExpressions/AND Capabilities.SearchExpressions/group Capabilities.SearchExpressions/phrase"/>
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="Capabilities.SearchExpressions/AND Capabilities.SearchExpressions/group Capabilities.SearchExpressions/phrase"/>
                     </Record>
                 </Annotation>
                 <Annotation Term="Capabilities.SearchRestrictions" Qualifier="Alone">
                     <Record Type="Capabilities.SearchRestrictionsType">
-                        <PropertyValue Property="UnsupportedExpressions"
-                                       EnumMember="Capabilities.SearchExpressions/AND"/>
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="Capabilities.SearchExpressions/AND"/>
                     </Record>
                 </Annotation>
                 <Annotation Term="Capabilities.SearchRestrictions" Qualifier="Empty">
@@ -49,36 +47,24 @@
                         <PropertyValue Property="UnsupportedExpressions" EnumMember=""/>
                     </Record>
                 </Annotation>
+                <Annotation Term="Capabilities.SearchRestrictions" Qualifier="NonStandardAlias">
+                    <Record Type="Capabilities.SearchRestrictionsType">
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="MyCapabilities.SearchExpressions/AND"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="Capabilities.SearchRestrictions" Qualifier="NonStandardAliasMultiple">
+                    <Record Type="Capabilities.SearchRestrictionsType">
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="MyCapabilities.SearchExpressions/AND MyCapabilities.SearchExpressions/group MyCapabilities.SearchExpressions/phrase"/>
+                    </Record>
+                </Annotation>
                 <Annotation Term="Capabilities.NavigationRestrictions">
                     <Record Type="Capabilities.NavigationRestrictionsType">
                         <PropertyValue Property="Navigability" EnumMember="Capabilities.NavigationType/Single"/>
                     </Record>
                 </Annotation>
-            </Annotations>
-            <Annotations Target="sap.fe.test.JestService.Entities">
-                <Annotation Term="MyCommunication.Contact" Qualifier="NonStandardAlias">
-                    <Record Type="MyCommunication.ContactType">
-                        <PropertyValue Property="tel">
-                            <Collection>
-                                <Record Type="MyCommunication.PhoneNumberType">
-                                    <PropertyValue Property="type"
-                                                   EnumMember="MyCommunication.PhoneType/cell"/>
-                                </Record>
-                            </Collection>
-                        </PropertyValue>
-                        <PropertyValue Property="gender" EnumMember="MyCommunication.GenderType/F"/>
-                    </Record>
-                </Annotation>
-                <Annotation Term="MyCommunication.Contact" Qualifier="NonStandardAliasMultiple">
-                    <Record Type="MyCommunication.ContactType">
-                        <PropertyValue Property="tel">
-                            <Collection>
-                                <Record Type="MyCommunication.PhoneNumberType">
-                                    <PropertyValue Property="type"
-                                                   EnumMember="MyCommunication.PhoneType/cell MyCommunication.PhoneType/fax MyCommunication.PhoneType/voice"/>
-                                </Record>
-                            </Collection>
-                        </PropertyValue>
+                <Annotation Term="Capabilities.NavigationRestrictions" Qualifier="NonStandardAlias">
+                    <Record Type="Capabilities.NavigationRestrictionsType">
+                        <PropertyValue Property="Navigability" EnumMember="MyCapabilities.NavigationType/Single"/>
                     </Record>
                 </Annotation>
             </Annotations>

--- a/packages/edmx-parser/src/utils.ts
+++ b/packages/edmx-parser/src/utils.ts
@@ -120,7 +120,7 @@ export class MergedRawMetadata implements RawMetadataInstance {
      */
     public addParserOutput(parserOutput: RawMetadata): void {
         this._parserOutput.push(parserOutput);
-        this.mergeReferences(parserOutput.references);
+        this._references = this._references.concat(parserOutput.references);
         this._associations = this._associations.concat(parserOutput.schema.associations);
         this._associationSets = this._associationSets.concat(parserOutput.schema.associationSets);
         this._annotations = Object.assign(this._annotations, parserOutput.schema.annotations);
@@ -133,19 +133,6 @@ export class MergedRawMetadata implements RawMetadataInstance {
         this._typeDefinitions = this._typeDefinitions.concat(parserOutput.schema.typeDefinitions);
         if (parserOutput.schema.entityContainer.fullyQualifiedName.length > 0) {
             this._entityContainer = Object.assign(this._entityContainer, parserOutput.schema.entityContainer);
-        }
-    }
-
-    private mergeReferences(references: Reference[]) {
-        for (const reference of references) {
-            const clash = this._references.find(
-                (r) => r.namespace === reference.namespace || r.alias === reference.alias
-            );
-            // Assuming that the parser output passed to addParserOutput() is unaliased, it is safe to ignore
-            // non-unique references here. If it is not, then this is going to be problematic
-            if (!clash) {
-                this._references.push(reference);
-            }
         }
     }
 }

--- a/packages/edmx-parser/test/__snapshots__/merge.spec.ts.snap
+++ b/packages/edmx-parser/test/__snapshots__/merge.spec.ts.snap
@@ -4504,6 +4504,21 @@ MergedRawMetadata {
       "uri": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml",
     },
     {
+      "alias": "Common",
+      "namespace": "com.sap.vocabularies.Common.v1",
+      "uri": "https://sap.github.io/odata-vocabularies/vocabularies/Common.xml",
+    },
+    {
+      "alias": "Core",
+      "namespace": "Org.OData.Core.V1",
+      "uri": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml",
+    },
+    {
+      "alias": "UI",
+      "namespace": "com.sap.vocabularies.UI.v1",
+      "uri": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml",
+    },
+    {
       "alias": "ActionVisibility",
       "namespace": "sap.fe.core.ActionVisibility",
       "uri": "/sap/fe/core/mock/action-visibility/$metadata",


### PR DESCRIPTION
The converter now always returns the fixed `VocabularyReferences`.

Fixes #593 