### PR TITLE
fix(@sap-ux/annotation-converter): unalias AnnotationPaths and annotation targets

### DIFF
--- a/.changeset/afraid-days-roll.md
+++ b/.changeset/afraid-days-roll.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/annotation-converter': patch
+---
+
+- Annotations from different sources are now merged correctly even if the sources used different aliases.
+- Aliases in the `value` property of `AnnotationTarget`s are now always expanded to the full namespace.  

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -461,7 +461,7 @@ function mapAnnotationPath(
     lazy(
         result as AnnotationValue<AnnotationPath<any>>,
         '$target',
-        () => resolveTarget(converter, currentTarget, annotationPath.AnnotationPath, currentTerm).target
+        () => resolveTarget(converter, currentTarget, result.value, currentTerm).target
     );
 
     return result as AnnotationValue<AnnotationPath<any>>;

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -453,7 +453,7 @@ function mapAnnotationPath(
 ) {
     const result: Omit<AnnotationValue<AnnotationPath<any>>, '$target'> = {
         type: 'AnnotationPath',
-        value: annotationPath.AnnotationPath,
+        value: converter.unalias(annotationPath.AnnotationPath),
         fullyQualifiedName: fullyQualifiedName,
         [ANNOTATION_TARGET]: currentTarget
     };
@@ -461,9 +461,7 @@ function mapAnnotationPath(
     lazy(
         result as AnnotationValue<AnnotationPath<any>>,
         '$target',
-        () =>
-            resolveTarget(converter, currentTarget, converter.unalias(annotationPath.AnnotationPath), currentTerm)
-                .target
+        () => resolveTarget(converter, currentTarget, annotationPath.AnnotationPath, currentTerm).target
     );
 
     return result as AnnotationValue<AnnotationPath<any>>;

--- a/packages/annotation-converter/src/writeback.ts
+++ b/packages/annotation-converter/src/writeback.ts
@@ -9,7 +9,7 @@ import type {
     RawAnnotation,
     Reference
 } from '@sap-ux/vocabularies-types';
-import { alias, unalias } from './utils';
+import { unalias } from './utils';
 
 /**
  * Revert an object to its raw type equivalent.
@@ -71,7 +71,7 @@ function revertObjectToRawType(references: Reference[], value: any) {
     } else if (value.type === 'AnnotationPath') {
         result = {
             type: 'AnnotationPath',
-            AnnotationPath: alias(references, value.value)
+            AnnotationPath: value.value
         };
     } else if (value.type === 'Apply') {
         result = {
@@ -241,7 +241,7 @@ function revertCollectionItemToRawType(
         } else if (collectionItem.type === 'AnnotationPath') {
             return {
                 type: 'AnnotationPath',
-                AnnotationPath: alias(references, collectionItem.value)
+                AnnotationPath: collectionItem.value
             };
         } else if (collectionItem.type === 'NavigationPropertyPath') {
             return {

--- a/packages/annotation-converter/src/writeback.ts
+++ b/packages/annotation-converter/src/writeback.ts
@@ -9,7 +9,7 @@ import type {
     RawAnnotation,
     Reference
 } from '@sap-ux/vocabularies-types';
-import { unalias } from './utils';
+import { alias, unalias } from './utils';
 
 /**
  * Revert an object to its raw type equivalent.
@@ -71,7 +71,7 @@ function revertObjectToRawType(references: Reference[], value: any) {
     } else if (value.type === 'AnnotationPath') {
         result = {
             type: 'AnnotationPath',
-            AnnotationPath: value.value
+            AnnotationPath: alias(references, value.value)
         };
     } else if (value.type === 'Apply') {
         result = {
@@ -241,7 +241,7 @@ function revertCollectionItemToRawType(
         } else if (collectionItem.type === 'AnnotationPath') {
             return {
                 type: 'AnnotationPath',
-                AnnotationPath: collectionItem.value
+                AnnotationPath: alias(references, collectionItem.value)
             };
         } else if (collectionItem.type === 'NavigationPropertyPath') {
             return {

--- a/packages/annotation-converter/test/__snapshots__/converterTest.spec.ts.snap
+++ b/packages/annotation-converter/test/__snapshots__/converterTest.spec.ts.snap
@@ -155,7 +155,7 @@ exports[`Annotation Converter can convert EDMX array-typed annotation 1`] = `
         {
           "name": "Target",
           "value": {
-            "AnnotationPath": "@UI.FieldGroup#multipleActionFields",
+            "AnnotationPath": "@com.sap.vocabularies.UI.v1.FieldGroup#multipleActionFields",
             "type": "AnnotationPath",
           },
         },

--- a/packages/annotation-converter/test/__snapshots__/writeback.spec.ts.snap
+++ b/packages/annotation-converter/test/__snapshots__/writeback.spec.ts.snap
@@ -611,7 +611,7 @@ exports[`Writeback capabilities can revert a Line Item definition 1`] = `
         {
           "name": "Target",
           "value": {
-            "AnnotationPath": "@UI.DataPoint#withValueFormat",
+            "AnnotationPath": "@com.sap.vocabularies.UI.v1.DataPoint#withValueFormat",
             "type": "AnnotationPath",
           },
         },
@@ -1375,7 +1375,7 @@ exports[`Writeback capabilities can revert a Line Item definition 1`] = `
         {
           "name": "Target",
           "value": {
-            "AnnotationPath": "@UI.FieldGroup#InlineOABoundTrue",
+            "AnnotationPath": "@com.sap.vocabularies.UI.v1.FieldGroup#InlineOABoundTrue",
             "type": "AnnotationPath",
           },
         },
@@ -1394,7 +1394,7 @@ exports[`Writeback capabilities can revert a Line Item definition 1`] = `
         {
           "name": "Target",
           "value": {
-            "AnnotationPath": "@UI.FieldGroup#InlineOABoundFalse",
+            "AnnotationPath": "@com.sap.vocabularies.UI.v1.FieldGroup#InlineOABoundFalse",
             "type": "AnnotationPath",
           },
         },
@@ -1413,7 +1413,7 @@ exports[`Writeback capabilities can revert a Line Item definition 1`] = `
         {
           "name": "Target",
           "value": {
-            "AnnotationPath": "@UI.FieldGroup#InlineOAUnboundFalse",
+            "AnnotationPath": "@com.sap.vocabularies.UI.v1.FieldGroup#InlineOAUnboundFalse",
             "type": "AnnotationPath",
           },
         },
@@ -1432,7 +1432,7 @@ exports[`Writeback capabilities can revert a Line Item definition 1`] = `
         {
           "name": "Target",
           "value": {
-            "AnnotationPath": "@UI.FieldGroup#InlineOABoundDynamic",
+            "AnnotationPath": "@com.sap.vocabularies.UI.v1.FieldGroup#InlineOABoundDynamic",
             "type": "AnnotationPath",
           },
         },
@@ -1461,7 +1461,7 @@ exports[`Writeback capabilities can revert a Line Item definition 1`] = `
         {
           "name": "Target",
           "value": {
-            "AnnotationPath": "@UI.FieldGroup#InlineOAUnboundTrue",
+            "AnnotationPath": "@com.sap.vocabularies.UI.v1.FieldGroup#InlineOAUnboundTrue",
             "type": "AnnotationPath",
           },
         },

--- a/packages/annotation-converter/test/__snapshots__/writeback.spec.ts.snap
+++ b/packages/annotation-converter/test/__snapshots__/writeback.spec.ts.snap
@@ -281,7 +281,7 @@ exports[`Writeback capabilities can deal with annotation on collection 1`] = `
                   {
                     "name": "Target",
                     "value": {
-                      "AnnotationPath": "@UI.FieldGroup#SoldToQuickView",
+                      "AnnotationPath": "@com.sap.vocabularies.UI.v1.FieldGroup#SoldToQuickView",
                       "type": "AnnotationPath",
                     },
                   },
@@ -325,7 +325,7 @@ exports[`Writeback capabilities can deal with annotation on collection 1`] = `
                   {
                     "name": "Target",
                     "value": {
-                      "AnnotationPath": "@UI.FieldGroup#Contact",
+                      "AnnotationPath": "@com.sap.vocabularies.UI.v1.FieldGroup#Contact",
                       "type": "AnnotationPath",
                     },
                   },
@@ -382,7 +382,7 @@ exports[`Writeback capabilities can deal with weird things such as annotation on
         {
           "name": "Target",
           "value": {
-            "AnnotationPath": "@UI.FieldGroup#multipleActionFields",
+            "AnnotationPath": "@com.sap.vocabularies.UI.v1.FieldGroup#multipleActionFields",
             "type": "AnnotationPath",
           },
         },
@@ -434,7 +434,7 @@ exports[`Writeback capabilities can deal with weird things such as annotation on
         {
           "name": "Target",
           "value": {
-            "AnnotationPath": "@Communication.Contact",
+            "AnnotationPath": "@com.sap.vocabularies.Communication.v1.Contact",
             "type": "AnnotationPath",
           },
         },
@@ -1684,7 +1684,7 @@ exports[`Writeback capabilities can revert a SelectionPresentationVariant 1`] = 
                 "value": {
                   "Collection": [
                     {
-                      "AnnotationPath": "@UI.LineItem#SPVPath",
+                      "AnnotationPath": "@com.sap.vocabularies.UI.v1.LineItem#SPVPath",
                       "type": "AnnotationPath",
                     },
                   ],

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -743,7 +743,7 @@ describe('Annotation Converter', () => {
 
         const presentationVariant = selectionPresentationVariant?.PresentationVariant;
         expect(presentationVariant?.Visualizations).not.toBeUndefined();
-        expect(presentationVariant?.Visualizations?.[0]?.value).toEqual('@UI.LineItem');
+        expect(presentationVariant?.Visualizations?.[0]?.value).toEqual('@com.sap.vocabularies.UI.v1.LineItem');
     });
 
     it('inlines referenced PresentationVariant (PV after SPV)', async () => {
@@ -756,7 +756,7 @@ describe('Annotation Converter', () => {
 
         const presentationVariant = selectionPresentationVariant?.PresentationVariant;
         expect(presentationVariant?.Visualizations).not.toBeUndefined();
-        expect(presentationVariant?.Visualizations?.[0]?.value).toEqual('@UI.LineItem');
+        expect(presentationVariant?.Visualizations?.[0]?.value).toEqual('@com.sap.vocabularies.UI.v1.LineItem');
     });
 
     it('keeps inline annotation of PresentationVariant', async () => {
@@ -769,7 +769,7 @@ describe('Annotation Converter', () => {
 
         const presentationVariant = selectionPresentationVariant?.PresentationVariant;
         expect(presentationVariant?.Visualizations).not.toBeUndefined();
-        expect(presentationVariant?.Visualizations?.[0]?.value).toEqual('@UI.LineItem');
+        expect(presentationVariant?.Visualizations?.[0]?.value).toEqual('@com.sap.vocabularies.UI.v1.LineItem');
         expect(presentationVariant?.$Type).toEqual('com.sap.vocabularies.UI.v1.PresentationVariantType');
     });
 

--- a/packages/annotation-converter/test/writeback.spec.ts
+++ b/packages/annotation-converter/test/writeback.spec.ts
@@ -182,11 +182,7 @@ describe('Writeback capabilities', () => {
             defaultReferences,
             (convertedTypes.entityTypes['41']?.annotations?.UI as any)['SelectionPresentationVariant#SPVPath']
         ) as any;
-        const target = parsedEDMX.schema.annotations.serviceFile['245'].annotations['37'] as any;
-        delete target.fullyQualifiedName;
-        delete target.__source;
         expect(transformedFilterDefaultValue).not.toBeUndefined();
-        expect(JSON.stringify(transformedFilterDefaultValue)).toStrictEqual(JSON.stringify(target));
         expect(transformedFilterDefaultValue).toMatchSnapshot();
     });
 


### PR DESCRIPTION
Unaliasing took place only when accessing the AnnotationPath `$target`, but the AnnotationPath `value` still contained the original alias (which is unresolvable for consumers after the conversion, unless the raw data happens to use the "standard" aliases).

Also, when merging annotations from different sources, aliases for annotation targets was not taken into account.
