### PR TITLE
fix: annotations on parameters of unbound actions

### DIFF
--- a/.changeset/quiet-cougars-sit.md
+++ b/.changeset/quiet-cougars-sit.md
@@ -1,0 +1,9 @@
+---
+'@sap-ux/annotation-converter': minor
+'@sap-ux/vocabularies-types': minor
+'@sap-ux/edmx-parser': minor
+---
+
+
+- NavigationPropertyBindings are now resolved by the annotation converter. This is a breaking change for consumers of types `RawSingleton` or `RawEntitySet` from package @sap-ux/vocabularies-types (the type of property `navigationPropertyBinding` changed).
+- Annotations of action parameters are now also resolved for unbound actions and unbound functions. The fully-qualified name of unbound actions and unbound functions changed - they now always include their overloads. E.g., in case of unbound actions: old `myAction`, new: `myAction()` - `()` denotes the "unbound overload".

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -705,19 +705,19 @@ function parseRecord(
 
     if (isDataFieldWithForAction(record)) {
         lazy(record, 'ActionTarget', () => {
-            const actionTargetFQN = converter.unalias(record.Action?.toString());
+            const actionName = converter.unalias(record.Action?.toString());
 
             // (1) Bound action of the annotation target?
-            let actionTarget = currentTarget.actions?.[actionTargetFQN];
+            let actionTarget = currentTarget.actions[actionName];
 
             if (!actionTarget) {
                 // (2) ActionImport (= unbound action)?
-                actionTarget = converter.getConvertedActionImport(actionTargetFQN)?.action;
+                actionTarget = converter.getConvertedActionImport(actionName)?.action;
             }
 
             if (!actionTarget) {
-                // (3) Bound action of a different EntityType
-                actionTarget = converter.getConvertedAction(actionTargetFQN);
+                // (3) Bound action of a different EntityType (the actionName is fully qualified in this case)
+                actionTarget = converter.getConvertedAction(actionName);
                 if (!actionTarget?.isBound) {
                     actionTarget = undefined;
                 }
@@ -725,7 +725,7 @@ function parseRecord(
 
             if (!actionTarget) {
                 converter.logError(
-                    `${record.fullyQualifiedName}: Unable to resolve '${record.Action}' ('${actionTargetFQN}')`
+                    `${record.fullyQualifiedName}: Unable to resolve '${record.Action}' ('${actionName}')`
                 );
             }
             return actionTarget;
@@ -1388,7 +1388,20 @@ function convertActionImport(converter: Converter, rawActionImport: RawActionImp
 
     lazy(convertedActionImport, 'annotations', resolveAnnotations(converter, rawActionImport));
 
-    lazy(convertedActionImport, 'action', () => converter.getConvertedAction(rawActionImport.actionName));
+    lazy(convertedActionImport, 'action', () => {
+        const rawActions = converter.rawSchema.actions.filter(
+            (rawAction) => !rawAction.isBound && rawAction.fullyQualifiedName.startsWith(rawActionImport.actionName)
+        );
+
+        // this always resolves to a unique unbound action, but resolution of unbound functions can be ambiguous:
+        // unbound function FQNs have overloads depending on all of their parameters
+        if (rawActions.length > 1) {
+            converter.logError(`Ambiguous reference in action import: ${rawActionImport.fullyQualifiedName}`);
+        }
+
+        // return the first matching action or function
+        return converter.getConvertedAction(rawActions[0].fullyQualifiedName)!;
+    });
 
     return convertedActionImport;
 }
@@ -1414,28 +1427,39 @@ function convertAction(converter: Converter, rawAction: RawAction): Action {
     lazy(convertedAction, 'parameters', converter.convert(rawAction.parameters, convertActionParameter));
 
     lazy(convertedAction, 'annotations', () => {
-        const action = substringBeforeFirst(rawAction.fullyQualifiedName, '(');
+        /*
+            Annotation resolution rule for actions:
 
-        // if the action is unbound (e.g. "myAction"), the annotation target is "myAction()"
-        const annotationTargetFQN = rawAction.isBound
-            ? rawAction.fullyQualifiedName
-            : `${rawAction.fullyQualifiedName}()`;
+            (1) annotation target: the specific unbound or bound overload, e.g.
+                    - for actions:   "x.y.z.unboundAction()" / "x.y.z.boundAction(x.y.z.Entity)"
+                    - for functions: "x.y.z.unboundFunction(Edm.String)" / "x.y.z.unboundFunction(x.y.z.Entity,Edm.String)"
+            (2) annotation target: unspecified overload, e.g.
+                - for actions:   "x.y.z.unboundAction" / "x.y.z.boundAction"
+                - for functions: "x.y.z.unboundFunction" / "x.y.z.unboundFunction"
 
-        const rawAnnotations = converter.getAnnotations(annotationTargetFQN);
-        const baseAnnotations = converter.getAnnotations(action);
+            When resolving (1) takes precedence over (2). That is, annotations on the specific overload overwrite
+            annotations on the unspecific overload, on term/qualifier level.
+        */
 
-        for (const baseAnnotation of baseAnnotations) {
+        const unspecificOverloadTarget = substringBeforeFirst(rawAction.fullyQualifiedName, '(');
+        const specificOverloadTarget = rawAction.fullyQualifiedName;
+
+        const effectiveAnnotations = converter.getAnnotations(specificOverloadTarget);
+        const unspecificAnnotations = converter.getAnnotations(unspecificOverloadTarget);
+
+        for (const unspecificAnnotation of unspecificAnnotations) {
             if (
-                !rawAnnotations.some(
+                !effectiveAnnotations.some(
                     (annotation) =>
-                        annotation.term === baseAnnotation.term && annotation.qualifier === baseAnnotation.qualifier
+                        annotation.term === unspecificAnnotation.term &&
+                        annotation.qualifier === unspecificAnnotation.qualifier
                 )
             ) {
-                rawAnnotations.push(baseAnnotation);
+                effectiveAnnotations.push(unspecificAnnotation);
             }
         }
 
-        return createAnnotationsObject(converter, rawAction, rawAnnotations);
+        return createAnnotationsObject(converter, rawAction, effectiveAnnotations);
     });
 
     return convertedAction;
@@ -1463,7 +1487,28 @@ function convertActionParameter(
             converter.getConvertedTypeDefinition(rawActionParameter.type)
     );
 
-    lazy(convertedActionParameter, 'annotations', resolveAnnotations(converter, rawActionParameter));
+    lazy(convertedActionParameter, 'annotations', () => {
+        // annotations on action parameters are resolved following the rules for actions
+        const unspecificOverloadTarget = rawActionParameter.fullyQualifiedName.replace(/\(.*\)/, '');
+        const specificOverloadTarget = rawActionParameter.fullyQualifiedName;
+
+        const effectiveAnnotations = converter.getAnnotations(specificOverloadTarget);
+        const unspecificAnnotations = converter.getAnnotations(unspecificOverloadTarget);
+
+        for (const unspecificAnnotation of unspecificAnnotations) {
+            if (
+                !effectiveAnnotations.some(
+                    (annotation) =>
+                        annotation.term === unspecificAnnotation.term &&
+                        annotation.qualifier === unspecificAnnotation.qualifier
+                )
+            ) {
+                effectiveAnnotations.push(unspecificAnnotation);
+            }
+        }
+
+        return createAnnotationsObject(converter, rawActionParameter, effectiveAnnotations);
+    });
 
     return convertedActionParameter;
 }

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -1489,7 +1489,9 @@ function convertActionParameter(
 
     lazy(convertedActionParameter, 'annotations', () => {
         // annotations on action parameters are resolved following the rules for actions
-        const unspecificOverloadTarget = rawActionParameter.fullyQualifiedName.replace(/\(.*\)/, '');
+        const unspecificOverloadTarget =
+            rawActionParameter.fullyQualifiedName.substring(0, rawActionParameter.fullyQualifiedName.indexOf('(')) +
+            rawActionParameter.fullyQualifiedName.substring(rawActionParameter.fullyQualifiedName.indexOf(')') + 1);
         const specificOverloadTarget = rawActionParameter.fullyQualifiedName;
 
         const effectiveAnnotations = converter.getAnnotations(specificOverloadTarget);

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -865,7 +865,7 @@ describe('Annotation Converter', () => {
         const convertedTypes = convert(parsedMetadata);
 
         function getAction(name: string) {
-            const result = convertedTypes.actions.find((action) => action.fullyQualifiedName === name);
+            const result = convertedTypes.actions.by_fullyQualifiedName(name);
             expect(result).toBeDefined();
             return result;
         }
@@ -873,19 +873,19 @@ describe('Annotation Converter', () => {
         const dataFields1 = convertedTypes.entityTypes[0]?.annotations.UI?.LineItem as any[];
         expect(dataFields1[0].ActionTarget).toBe(getAction('TestService.action(TestService.Entity1)'));
         expect(dataFields1[1].ActionTarget).toBe(getAction('TestService.function(TestService.Entity1)'));
-        expect(dataFields1[2].ActionTarget).toBe(getAction('TestService.action'));
-        expect(dataFields1[3].ActionTarget).toBe(getAction('TestService.function'));
+        expect(dataFields1[2].ActionTarget).toBe(getAction('TestService.action()'));
+        expect(dataFields1[3].ActionTarget).toBe(getAction('TestService.function()'));
         expect(dataFields1[4].ActionTarget).toBe(getAction('TestService.action(TestService.Entity1)'));
         expect(dataFields1[5].ActionTarget).toBe(undefined);
         expect(dataFields1[6].ActionTarget).toBe(getAction('TestService.action2(TestService.Entity2)'));
-        expect(dataFields1[7].ActionTarget).toBe(getAction('TestService.action'));
-        expect(dataFields1[8].ActionTarget).toBe(getAction('TestService.function'));
+        expect(dataFields1[7].ActionTarget).toBe(getAction('TestService.action()'));
+        expect(dataFields1[8].ActionTarget).toBe(getAction('TestService.function()'));
 
         const dataFields2 = convertedTypes.entityTypes[1]?.annotations.UI?.LineItem as any[];
         expect(dataFields2[0].ActionTarget).toBe(getAction('TestService.action(TestService.Entity2)'));
         expect(dataFields2[1].ActionTarget).toBe(getAction('TestService.function(TestService.Entity2)'));
-        expect(dataFields2[2].ActionTarget).toBe(getAction('TestService.action'));
-        expect(dataFields2[3].ActionTarget).toBe(getAction('TestService.function'));
+        expect(dataFields2[2].ActionTarget).toBe(getAction('TestService.action()'));
+        expect(dataFields2[3].ActionTarget).toBe(getAction('TestService.function()'));
         expect(dataFields2[4].ActionTarget).toBe(getAction('TestService.action(TestService.Entity1)'));
     });
 
@@ -1006,12 +1006,12 @@ describe('Annotation Converter', () => {
                 {
                     dataFieldIndex: 2,
                     expectedDataFieldAction: 'doSomethingUnbound',
-                    expectedDataFieldActionTargetFQN: 'sap.fe.test.JestService.doSomethingUnbound'
+                    expectedDataFieldActionTargetFQN: 'sap.fe.test.JestService.doSomethingUnbound()'
                 },
                 {
                     dataFieldIndex: 3,
                     expectedDataFieldAction: 'MyServiceAlias.EntityContainer/doSomethingUnbound',
-                    expectedDataFieldActionTargetFQN: 'sap.fe.test.JestService.doSomethingUnbound'
+                    expectedDataFieldActionTargetFQN: 'sap.fe.test.JestService.doSomethingUnbound()'
                 }
             ])(
                 '$expectedDataFieldAction',
@@ -1085,5 +1085,97 @@ describe('Annotation Converter', () => {
             )
         );
         expect(hasCollision).toBeFalsy();
+    });
+
+    describe('Annotations on Action Parameters', () => {
+        let convertedTypes: ConvertedMetadata;
+
+        beforeAll(async () => {
+            const metadata = await loadFixture('v4/action-parameters.xml');
+            const parsedEDMX = parse(metadata);
+            convertedTypes = convert(parsedEDMX);
+        });
+
+        it('Actions: Parameters with annotations on the specific overload', () => {
+            // Unbound action: param1
+            let action = convertedTypes.actions.by_fullyQualifiedName('TestService.action()');
+            expect(action?.parameters.by_name('param1')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[specific unbound overload] action/param1'
+            );
+
+            // Bound action on Entity1: param1
+            action = convertedTypes.entityTypes.by_name('Entity1')?.actions['TestService.action'];
+
+            expect(action?.parameters.by_name('param1')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[specific bound overload] Entity1/action/param1'
+            );
+        });
+
+        it('Functions: Parameters with annotations on the specific overload', () => {
+            // Unbound function: param1
+            let action = convertedTypes.actions.by_fullyQualifiedName('TestService.function(Edm.String,Edm.String)');
+            expect(action?.parameters.by_name('param1')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[specific unbound overload] function/param1'
+            );
+
+            // Bound function on Entity1: param1
+            action = convertedTypes.entityTypes.by_name('Entity1')?.actions['TestService.function'];
+
+            expect(action?.parameters.by_name('param1')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[specific bound overload] Entity1/function/param1'
+            );
+        });
+
+        it('Actions: Parameters without annotations on the specific overload', () => {
+            // Unbound action: param2
+            let action = convertedTypes.actions.by_fullyQualifiedName('TestService.action()');
+            expect(action?.parameters.by_name('param2')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[unspecific] action/param2'
+            );
+
+            // Bound action on Entity1: param2
+            action = convertedTypes.entityTypes.by_name('Entity1')?.actions['TestService.action'];
+
+            expect(action?.parameters.by_name('param2')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[unspecific] action/param2'
+            );
+
+            // Bound action on Entity2: param1 + param2
+            action = convertedTypes.entityTypes.by_name('Entity2')?.actions['TestService.action'];
+
+            expect(action?.parameters.by_name('param1')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[unspecific] action/param1'
+            );
+
+            expect(action?.parameters.by_name('param2')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[unspecific] action/param2'
+            );
+        });
+
+        it('Functions: Parameters without annotations on the specific overload', () => {
+            // Unbound function: param2
+            let action = convertedTypes.actions.by_fullyQualifiedName('TestService.function(Edm.String,Edm.String)');
+            expect(action?.parameters.by_name('param2')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[unspecific] function/param2'
+            );
+
+            // Bound function on Entity1: param2
+            action = convertedTypes.entityTypes.by_name('Entity1')?.actions['TestService.function'];
+
+            expect(action?.parameters.by_name('param2')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[unspecific] function/param2'
+            );
+
+            // Bound function on Entity2: param1 + param2
+            action = convertedTypes.entityTypes.by_name('Entity2')?.actions['TestService.function'];
+
+            expect(action?.parameters.by_name('param1')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[unspecific] function/param1'
+            );
+
+            expect(action?.parameters.by_name('param2')?.annotations.Common?.Label?.valueOf()).toEqual(
+                '[unspecific] function/param2'
+            );
+        });
     });
 });

--- a/packages/annotation-converter/test/fixtures/v4/action-parameters.xml
+++ b/packages/annotation-converter/test/fixtures/v4/action-parameters.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="Entity1" EntityType="TestService.Entity1"/>
+        <EntitySet Name="Entity2" EntityType="TestService.Entity2"/>
+        <ActionImport Name="action" Action="TestService.action"/>
+        <FunctionImport Name="function" Function="TestService.function"/>
+      </EntityContainer>
+      <EntityType Name="Entity1">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="Entity2">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <Action Name="action" IsBound="true">
+        <Parameter Name="in" Type="TestService.Entity1"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+      </Action>
+      <Action Name="action" IsBound="true">
+        <Parameter Name="in" Type="TestService.Entity2"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+      </Action>
+      <Action Name="action" IsBound="false">
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+      </Action>
+      <Function Name="function" IsBound="true" IsComposable="false">
+        <Parameter Name="in" Type="TestService.Entity1"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Function>
+      <Function Name="function" IsBound="true" IsComposable="false">
+        <Parameter Name="in" Type="TestService.Entity2"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Function>
+      <Function Name="function" IsBound="false" IsComposable="false">
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Function>
+      <Annotations Target="TestService.action(TestService.Entity1)/param1">
+        <Annotation Term="Common.Label" String="[specific bound overload] Entity1/action/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.function(TestService.Entity1,Edm.String,Edm.String)/param1">
+        <Annotation Term="Common.Label" String="[specific bound overload] Entity1/function/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.function(Edm.String,Edm.String)/param1">
+        <Annotation Term="Common.Label" String="[specific unbound overload] function/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.action()/param1">
+        <Annotation Term="Common.Label" String="[specific unbound overload] action/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.action/param1">
+        <Annotation Term="Common.Label" String="[unspecific] action/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.action/param2">
+        <Annotation Term="Common.Label" String="[unspecific] action/param2"/>
+      </Annotations>
+      <Annotations Target="TestService.function/param1">
+        <Annotation Term="Common.Label" String="[unspecific] function/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.function/param2">
+        <Annotation Term="Common.Label" String="[unspecific] function/param2"/>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -554,10 +554,20 @@ function parseActions(actions: (EDMX.Action | EDMX.Function)[], namespace: strin
         const parameters = ensureArray(action.Parameter);
         const isBound = action._attributes.IsBound === 'true';
 
-        const fullyQualifiedName: string = isBound
-            ? `${namespace}.${action._attributes.Name}(${unaliasType(parameters[0]._attributes.Type).type})`
-            : `${namespace}.${action._attributes.Name}`;
+        let overload: string;
+        if (isFunction) {
+            // function
+            // https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_FunctionOverloads
+            // Unbound: "The combination of function name and ordered set of parameter types MUST be unique within a schema."
+            // Bound:   "The combination of function name, binding parameter type, and ordered set of parameter types MUST be unique within a schema."
+            //  ==> consider all parameters for the FQN
+            overload = parameters.map((parameter) => unaliasType(parameter._attributes.Type).type).join(',');
+        } else {
+            // action
+            overload = isBound ? unaliasType(parameters[0]._attributes.Type).type : ''; // '' = the unbound overload
+        }
 
+        const fullyQualifiedName: FullyQualifiedName = `${namespace}.${action._attributes.Name}(${overload})`;
         return {
             _type: 'Action',
             name: action._attributes.Name,

--- a/packages/edmx-parser/test/fixtures/v4/action-parameters.xml
+++ b/packages/edmx-parser/test/fixtures/v4/action-parameters.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="Entity1" EntityType="TestService.Entity1"/>
+        <EntitySet Name="Entity2" EntityType="TestService.Entity2"/>
+        <ActionImport Name="action" Action="TestService.action"/>
+        <FunctionImport Name="function" Function="TestService.function"/>
+      </EntityContainer>
+      <EntityType Name="Entity1">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="Entity2">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <Action Name="action" IsBound="true">
+        <Parameter Name="in" Type="TestService.Entity1"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+      </Action>
+      <Action Name="action" IsBound="true">
+        <Parameter Name="in" Type="TestService.Entity2"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+      </Action>
+      <Action Name="action" IsBound="false">
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+      </Action>
+      <Function Name="function" IsBound="true" IsComposable="false">
+        <Parameter Name="in" Type="TestService.Entity1"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Function>
+      <Function Name="function" IsBound="true" IsComposable="false">
+        <Parameter Name="in" Type="TestService.Entity2"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Function>
+      <Function Name="function" IsBound="false" IsComposable="false">
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Function>
+      <Annotations Target="TestService.action(TestService.Entity1)/param1">
+        <Annotation Term="Common.Label" String="[specific bound overload] Entity1/action/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.function(TestService.Entity1,Edm.String,Edm.String)/param1">
+        <Annotation Term="Common.Label" String="[specific bound overload] Entity1/function/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.function(Edm.String,Edm.String)/param1">
+        <Annotation Term="Common.Label" String="[specific unbound overload] function/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.action()/param1">
+        <Annotation Term="Common.Label" String="[specific unbound overload] action/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.action/param1">
+        <Annotation Term="Common.Label" String="[unspecific] action/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.action/param2">
+        <Annotation Term="Common.Label" String="[unspecific] action/param2"/>
+      </Annotations>
+      <Annotations Target="TestService.function/param1">
+        <Annotation Term="Common.Label" String="[unspecific] function/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.function/param2">
+        <Annotation Term="Common.Label" String="[unspecific] function/param2"/>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/edmx-parser/test/parser.spec.ts
+++ b/packages/edmx-parser/test/parser.spec.ts
@@ -107,4 +107,21 @@ describe('Parser', function () {
         const schema: RawMetadata = parse(xmlFile);
         expect(schema).toMatchSnapshot();
     });
+
+    it('creates the correct fully-qualified names for functions and actions', async () => {
+        const xmlFile = await loadFixture('v4/action-parameters.xml');
+        const schema = parse(xmlFile);
+
+        const fqns = schema.schema.actions.map((action) => action.fullyQualifiedName);
+        expect(fqns).toMatchInlineSnapshot(`
+            [
+              "TestService.action(TestService.Entity1)",
+              "TestService.action(TestService.Entity2)",
+              "TestService.action()",
+              "TestService.function(TestService.Entity1,Edm.String,Edm.String)",
+              "TestService.function(TestService.Entity2,Edm.String,Edm.String)",
+              "TestService.function(Edm.String,Edm.String)",
+            ]
+        `);
+    });
 });

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -455,7 +455,7 @@ export type ActionImport = {
     name: SimpleIdentifier;
     fullyQualifiedName: SimpleIdentifier;
     actionName: string;
-    action?: Action;
+    action: Action;
     annotations: ActionImportAnnotations;
 };
 
@@ -491,7 +491,7 @@ export type ConvertedMetadata = {
     version: string;
     annotations: Record<string, AnnotationList[]>;
     namespace: string;
-    actions: ArrayWithIndex<Action, 'name' | 'fullyQualifiedName'>;
+    actions: ArrayWithIndex<Action, 'fullyQualifiedName'>;
     actionImports: ArrayWithIndex<ActionImport, 'name' | 'fullyQualifiedName'>;
     entityContainer: EntityContainer;
     complexTypes: ArrayWithIndex<ComplexType, 'name' | 'fullyQualifiedName'>;
@@ -519,6 +519,7 @@ export type RemoveAnnotationAndType<T> = {
         | 'entitySets'
         | 'singletons'
         | 'actionImports'
+        | 'action'
     >]: T[K] extends object
         ? T[K] extends Array<infer Item>
             ? RemoveAnnotationAndType<Item>[]


### PR DESCRIPTION
This should now resolve annotations on action (and function) parameters, also for unbound ones.

Action parameter annotations are uniquely resolved since an action is either uniquely bound to an entity type or the single unbound action of the specified name.

This might be different for functions because they can be overloaded not only with respect to their bound entity type, but to all parameters, which could make resolution ambiguous. The first matching function is used in this case.