### PR TITLE
resolve NavigationPropertyBindings in the converter only

### DIFF
--- a/packages/edmx-parser/test/__snapshots__/merge.spec.ts.snap
+++ b/packages/edmx-parser/test/__snapshots__/merge.spec.ts.snap
@@ -1791,19 +1791,9 @@ MergedRawMetadata {
       "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
       "name": "RootElement",
       "navigationPropertyBinding": {
-        "Sibling": [Circular],
-        "SiblingEntity": [Circular],
-        "_Elements": {
-          "_type": "EntitySet",
-          "entityTypeName": "sap.fe.core.ActionVisibility.SubElement",
-          "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
-          "name": "SubElement",
-          "navigationPropertyBinding": {
-            "Sibling": [Circular],
-            "SiblingEntity": [Circular],
-            "owner": [Circular],
-          },
-        },
+        "Sibling": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+        "SiblingEntity": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+        "_Elements": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
       },
     },
     {
@@ -1812,19 +1802,9 @@ MergedRawMetadata {
       "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
       "name": "SubElement",
       "navigationPropertyBinding": {
-        "Sibling": [Circular],
-        "SiblingEntity": [Circular],
-        "owner": {
-          "_type": "EntitySet",
-          "entityTypeName": "sap.fe.core.ActionVisibility.RootElement",
-          "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
-          "name": "RootElement",
-          "navigationPropertyBinding": {
-            "Sibling": [Circular],
-            "SiblingEntity": [Circular],
-            "_Elements": [Circular],
-          },
-        },
+        "Sibling": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+        "SiblingEntity": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+        "owner": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
       },
     },
   ],
@@ -3798,19 +3778,9 @@ MergedRawMetadata {
             "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
             "name": "RootElement",
             "navigationPropertyBinding": {
-              "Sibling": [Circular],
-              "SiblingEntity": [Circular],
-              "_Elements": {
-                "_type": "EntitySet",
-                "entityTypeName": "sap.fe.core.ActionVisibility.SubElement",
-                "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
-                "name": "SubElement",
-                "navigationPropertyBinding": {
-                  "Sibling": [Circular],
-                  "SiblingEntity": [Circular],
-                  "owner": [Circular],
-                },
-              },
+              "Sibling": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+              "SiblingEntity": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
+              "_Elements": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
             },
           },
           {
@@ -3819,19 +3789,9 @@ MergedRawMetadata {
             "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
             "name": "SubElement",
             "navigationPropertyBinding": {
-              "Sibling": [Circular],
-              "SiblingEntity": [Circular],
-              "owner": {
-                "_type": "EntitySet",
-                "entityTypeName": "sap.fe.core.ActionVisibility.RootElement",
-                "fullyQualifiedName": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
-                "name": "RootElement",
-                "navigationPropertyBinding": {
-                  "Sibling": [Circular],
-                  "SiblingEntity": [Circular],
-                  "_Elements": [Circular],
-                },
-              },
+              "Sibling": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+              "SiblingEntity": "sap.fe.core.ActionVisibility.EntityContainer/SubElement",
+              "owner": "sap.fe.core.ActionVisibility.EntityContainer/RootElement",
             },
           },
         ],

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -405,7 +405,7 @@ export type Singleton = {
     fullyQualifiedName: SimpleIdentifier;
     entityType: EntityType;
     nullable: boolean;
-    navigationPropertyBinding: Record<string, Singleton | EntitySet>; //above for entity set?
+    navigationPropertyBinding: Record<string, EntitySet | Singleton>;
     annotations: SingletonAnnotations;
 };
 
@@ -516,6 +516,7 @@ export type RemoveAnnotationAndType<T> = {
         | 'resolvePath'
         | 'entityType'
         | 'navigationProperties'
+        | 'navigationPropertyBinding'
         | 'entitySets'
         | 'singletons'
         | 'actionImports'
@@ -578,9 +579,17 @@ export type RawActionParameter = RemoveAnnotationAndType<ActionParameter>;
 export type RawEntityType = RemoveAnnotationAndType<EntityType> & {
     navigationProperties: (RawV2NavigationProperty | RawV4NavigationProperty)[];
 };
-export type RawEntitySet = RemoveAnnotationAndType<EntitySet>;
 export type RawProperty = RemoveAnnotationAndType<Property>;
-export type RawSingleton = RemoveAnnotationAndType<Singleton>;
+export type RawNavigationPropertyBinding = Record<string, FullyQualifiedName>;
+
+export type RawEntitySet = RemoveAnnotationAndType<EntitySet> & {
+    navigationPropertyBinding: RawNavigationPropertyBinding;
+};
+
+export type RawSingleton = RemoveAnnotationAndType<Singleton> & {
+    navigationPropertyBinding: RawNavigationPropertyBinding;
+};
+
 export type RawEntityContainer = RemoveAnnotationAndType<EntityContainer>;
 export type RawTypeDefinition = RemoveAnnotationAndType<TypeDefinition>;
 export type RawComplexType = RemoveAnnotationAndType<ComplexType> & {


### PR DESCRIPTION
The combination of edmx-parser and annotation-converter resulted in a duplicate resolution of NavigationPropertyBindings: The parser did it on raw metadata level, and the converter then only took the target's fully-qualified name to look up the target again.

This can be simplified by parsing the bindings into fully-qualified names only, and then do the linking during conversion.


