### PR TITLE
fix: remove leading and trailing apostrophes from string keys

### DIFF
--- a/.changeset/tasty-pigs-shop.md
+++ b/.changeset/tasty-pigs-shop.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Leading and trailing apostrophes are now removed from string values in keys

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -294,7 +294,12 @@ export default class ODataRequest {
                 keysList.forEach((keyValue) => {
                     const [key, value] = keyValue.split('=');
                     if (value) {
-                        keys[key] = decodeURIComponent(value.replace(/^(?:')$/g, ''));
+                        if (value.startsWith("'") && value.endsWith("'")) {
+                            // string value
+                            keys[key] = decodeURIComponent(value.substring(1, value.length - 1));
+                        } else {
+                            keys[key] = value;
+                        }
                     } else {
                         keys[key] = undefined;
                     }

--- a/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
@@ -630,4 +630,28 @@ describe('OData Request', () => {
             }).toMatchSnapshot();
         });
     });
+
+    test('It can parse keys', () => {
+        const myRequest = new ODataRequest(
+            {
+                method: 'POST',
+                url: "/Entity(StringKey='string%2Fvalue',NumericKey=123,BooleanKeyTrue=true,BooleanKeyFalse=false,UUIDKey=03bf61bc-c2f5-447e-8e3c-9d598fc8d098)"
+            },
+            fakeDataAccess
+        );
+        expect(myRequest.queryPath).toMatchInlineSnapshot(`
+            [
+              {
+                "keys": {
+                  "BooleanKeyFalse": "false",
+                  "BooleanKeyTrue": "true",
+                  "NumericKey": "123",
+                  "StringKey": "string/value",
+                  "UUIDKey": "03bf61bc-c2f5-447e-8e3c-9d598fc8d098",
+                },
+                "path": "Entity",
+              },
+            ]
+        `);
+    });
 });


### PR DESCRIPTION
`key='abc'` was parsed to `{ key: "'abc'" }`, preserving the apostrophes. Now they are stripped from the string, resulting in `{ key: "abc" }`.

There is no further conversion applied: All value remain strings (as before). That is, `key=123` will result in `{ key: "123" }`.

Fixes #540