### PR TITLE
chore: remove version from pnpm/action-setup to use packageManager

### DIFF
--- a/.github/workflows/lockfiles-command.yml
+++ b/.github/workflows/lockfiles-command.yml
@@ -21,7 +21,6 @@ jobs:
               uses: pnpm/action-setup@v2.2.4
               if: success()
               with:
-                  version: 8.6.0
                   run_install: false
 
             - name: Pnpm Install recursive

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,7 +22,6 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.4
               with:
-                  version: 8.6.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3
@@ -68,7 +67,6 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.4
               with:
-                  version: 8.6.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3
@@ -114,7 +112,6 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.4
               with:
-                  version: 8.6.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3


### PR DESCRIPTION
The GitHub action `pnpm/action-setup@{version}` does not need a version property, if a `packageManager` field in `package.json` is present, see also https://github.com/pnpm/action-setup#version.

This PR removes all `version` fields for `pnpm/action-setup`. This allows to control the version of `pnpm` solely in one place:
https://github.com/SAP/open-ux-odata/blob/3efa8cda8fb0614049eb7ac43db0850ab78d0777/package.json#L52