### PR TITLE
fix: navigation properties will no longer be called as actions

### DIFF
--- a/.changeset/seven-books-jump.md
+++ b/.changeset/seven-books-jump.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Navigation properties will no longer be mistaken for actions

--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -171,7 +171,7 @@ export class DataAccess implements DataAccessInterface {
                 }
                 // Fallback with local resolving, useful for function where the FQN also include all parameter types
                 const functionDefinition = currentEntityType.resolvePath(actionName);
-                if (functionDefinition) {
+                if (functionDefinition?._type === 'Function' || functionDefinition?._type === 'Action') {
                     return (await this.getMockEntitySet(entitySetName)).executeAction(
                         functionDefinition,
                         actionData,

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
@@ -1,7 +1,7 @@
 [
     {
         "ID": 1,
-        "Prop1": "SomethingElse",
+        "Prop1": "First Prop",
         "Prop2": "Second Prop",
         "isBoundAction1Hidden": false,
         "isBoundAction2Hidden": false,

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -103,6 +103,54 @@ describe('V4 Requestor', function () {
             )
             .execute('GET');
         expect(dataRes).toMatchInlineSnapshot(`"I am data"`);
+        const dataRes2 = await dataRequestor
+            .callGETAction('/RootElement(ID=1,IsActiveEntity=true)/_Elements')
+            .execute('GET');
+        expect(dataRes2).toMatchInlineSnapshot(`
+            {
+              "@odata.context": "$metadata#RootElement(ID=1,IsActiveEntity=true)/_Elements",
+              "@odata.count": 3,
+              "@odata.metadataEtag": "W/"606c-jGYf/2yxvlcG7Z+VRm6krl+f58U"",
+              "value": [
+                {
+                  "HasActiveEntity": true,
+                  "HasDraftEntity": false,
+                  "ID": 1,
+                  "IsActiveEntity": true,
+                  "SubProp1": "First Prop for 1-1",
+                  "SubProp2": "Second Prop for 1-1",
+                  "isBoundAction3Hidden": false,
+                  "isBoundAction4Hidden": false,
+                  "owner_ID": 1,
+                  "sibling_ID": 2,
+                },
+                {
+                  "HasActiveEntity": true,
+                  "HasDraftEntity": false,
+                  "ID": 2,
+                  "IsActiveEntity": true,
+                  "SubProp1": "First Prop for 1-2",
+                  "SubProp2": "Second Prop for 1-2",
+                  "isBoundAction3Hidden": true,
+                  "isBoundAction4Hidden": true,
+                  "owner_ID": 1,
+                  "sibling_ID": 1,
+                },
+                {
+                  "HasActiveEntity": true,
+                  "HasDraftEntity": false,
+                  "ID": 3,
+                  "IsActiveEntity": true,
+                  "SubProp1": "First Prop for 1-3",
+                  "SubProp2": "Second Prop for 1-3",
+                  "isBoundAction3Hidden": false,
+                  "isBoundAction4Hidden": false,
+                  "owner_ID": 1,
+                  "sibling_ID": 3,
+                },
+              ],
+            }
+        `);
     });
     it('can get the metadata', async () => {
         const dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');


### PR DESCRIPTION
Fix for #633 

Resolving the path from the entity type also grabbed things that were not actions :)