### PR TITLE
feat: Annotation values are no longer dynamic by default

### DIFF
--- a/.changeset/rude-pugs-taste.md
+++ b/.changeset/rude-pugs-taste.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/vocabularies-types': minor
+---
+
+Annotation values are no longer dynamic by default, only specific ones are defined as such

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -6,7 +6,6 @@ import type {
     ConvertedMetadata,
     EntitySet,
     EntityType,
-    EnumValue,
     NavigationProperty,
     PathAnnotationExpression,
     Property,
@@ -19,7 +18,7 @@ import { CommonAnnotationTypes } from '@sap-ux/vocabularies-types/vocabularies/C
 import type { ContactType } from '@sap-ux/vocabularies-types/vocabularies/Communication';
 import { CommunicationAnnotationTypes } from '@sap-ux/vocabularies-types/vocabularies/Communication';
 import type {
-    CriticalityType,
+    Criticality,
     DataField,
     DataFieldAbstractTypes,
     DataFieldForAction,
@@ -698,10 +697,10 @@ describe('Annotation Converter', () => {
         const parsedEDMX = parse(await loadFixture('v4/sdMeta.xml'));
         const convertedTypes = convert(parsedEDMX);
         if (convertedTypes.entityTypes[39].annotations?.UI?.LineItem) {
-            const criticality: EnumValue<CriticalityType> = {
+            const criticality: Criticality = {
                 path: 'OverallSDStatus',
                 type: 'Path'
-            } as EnumValue<CriticalityType>;
+            } as Criticality;
             const LineItem = convertedTypes.entityTypes[39].annotations.UI.LineItem;
             LineItem.annotations = { UI: { Criticality: criticality } };
             const transformedLineItem = revertTermToGenericType(defaultReferences, LineItem) as any;

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -203,8 +203,11 @@ export type LeAnnotationExpression<P> = {
     Le: LeConditionalExpression[];
 };
 
-export type PropertyAnnotationValue<P> =
-    | P
+type Evilify<P> = Omit<P, 'toString' | 'valueOf'>;
+// export type PropertyAnnotationValue<P> = Evilify<P> | DynamicAnnotationExpression<P>;
+export type PropertyAnnotationValue<P> = DynamicAnnotationExpression<P>;
+
+export type DynamicAnnotationExpression<P> =
     | PathAnnotationExpression<P>
     | ApplyAnnotationExpression<P>
     | AndAnnotationExpression<P>
@@ -278,8 +281,6 @@ export type PrimitiveType =
 // | Edm.GeometryMultiLineString
 // | Edm.GeometryMultiPolygon
 // | Edm.GeometryCollection;
-
-export type EnumValue<P> = P | PathAnnotationExpression<P> | ApplyAnnotationExpression<P> | IfAnnotationExpression<P>;
 
 export type String = InstanceType<StringConstructor>;
 export type Boolean = InstanceType<BooleanConstructor>;

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -203,8 +203,7 @@ export type LeAnnotationExpression<P> = {
     Le: LeConditionalExpression[];
 };
 
-type Evilify<P> = Omit<P, 'toString' | 'valueOf'>;
-// export type PropertyAnnotationValue<P> = Evilify<P> | DynamicAnnotationExpression<P>;
+//type ConstantAnnotationExpression<P> = Omit<P, 'toString' | 'valueOf'>;
 export type PropertyAnnotationValue<P> = DynamicAnnotationExpression<P>;
 
 export type DynamicAnnotationExpression<P> =

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -203,7 +203,6 @@ export type LeAnnotationExpression<P> = {
     Le: LeConditionalExpression[];
 };
 
-//type ConstantAnnotationExpression<P> = Omit<P, 'toString' | 'valueOf'>;
 export type PropertyAnnotationValue<P> = DynamicAnnotationExpression<P>;
 
 export type DynamicAnnotationExpression<P> =

--- a/packages/vocabularies-types/utils/generate_types.ts
+++ b/packages/vocabularies-types/utils/generate_types.ts
@@ -60,6 +60,7 @@ const KNOWN_DYNAMIC_EXPRESSIONS: Record<string, Record<string, boolean | Record<
         SelectionVariantType: {
             Text: true
         },
+        ValueListRelevantQualifiers: true,
         //ValueCriticality: true,
         DataFieldAbstract: {
             Criticality: true

--- a/packages/vocabularies-types/utils/generate_types.ts
+++ b/packages/vocabularies-types/utils/generate_types.ts
@@ -60,7 +60,7 @@ const KNOWN_DYNAMIC_EXPRESSIONS: Record<string, Record<string, boolean | Record<
         SelectionVariantType: {
             Text: true
         },
-        ValueListRelevantQualifiers: true,
+
         //ValueCriticality: true,
         DataFieldAbstract: {
             Criticality: true
@@ -88,7 +88,8 @@ const KNOWN_DYNAMIC_EXPRESSIONS: Record<string, Record<string, boolean | Record<
         FieldControl: true,
         QuickInfo: true,
         //Label: true,
-        Timezone: true
+        Timezone: true,
+        ValueListRelevantQualifiers: true
     },
     Capabilities: {
         DeleteRestrictionsType: {


### PR DESCRIPTION
Only a list pre-curated will be.

This came from the realization that we have too many case where we downcast them as static value instead of thinking about the case.
By reducing the case where this is needed we should have a bit more clarity / control over what is supposed to be dynamic.

This list is maybe not 100% complete as i'm basing it against sap.fe code where there might still be some `any` type around...