### PR TITLE
feat: strict mode is now properly evaluated on the request

### DIFF
--- a/.changeset/lemon-bears-pretend.md
+++ b/.changeset/lemon-bears-pretend.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Strict mode is now properly evaluated on the odataRequest

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -13,10 +13,10 @@ export type MockDataContributor<T extends object> = {
     removeEntry?: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => void;
     hasEntry?: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => boolean;
     hasEntries?: (odataRequest: ODataRequest) => boolean;
-    fetchEntries?: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => object[];
-    getAllEntries?: (odataRequest: ODataRequest) => object[];
-    getEmptyObject?: (odataRequest: ODataRequest) => object;
-    getDefaultElement?: (odataRequest: ODataRequest) => object;
+    fetchEntries?: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => T[];
+    getAllEntries?: (odataRequest: ODataRequest) => T[];
+    getEmptyObject?: (odataRequest: ODataRequest) => T;
+    getDefaultElement?: (odataRequest: ODataRequest) => T;
 
     getReferentialConstraints?: (
         _navigationProperty: NavigationProperty
@@ -86,11 +86,11 @@ export type MockDataContributor<T extends object> = {
         updateEntry: (keyValues: KeyDefinitions, newData: T, odataRequest: ODataRequest) => Promise<void>;
         removeEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => Promise<void>;
         hasEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => boolean;
-        fetchEntries: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => object[];
+        fetchEntries: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => T[];
         hasEntries: (odataRequest: ODataRequest) => boolean;
-        getAllEntries: (odataRequest: ODataRequest) => object[];
-        getEmptyObject: (odataRequest: ODataRequest) => object;
-        getDefaultElement: (odataRequest: ODataRequest) => object;
+        getAllEntries: (odataRequest: ODataRequest) => T[];
+        getEmptyObject: (odataRequest: ODataRequest) => T;
+        getDefaultElement: (odataRequest: ODataRequest) => T;
         getParentEntityInterface: () => Promise<FileBasedMockData | undefined>;
         getEntityInterface: (entityName: string) => Promise<FileBasedMockData | undefined>;
         checkSearchQuery: (mockData: any, searchQuery: string, odataRequest: ODataRequest) => boolean;

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -41,6 +41,7 @@ export type QueryPath = {
 
 export default class ODataRequest {
     private isMinimalRepresentation: boolean;
+    public isStrictMode: boolean;
     public tenantId: string;
     public queryPath: QueryPath[];
     public searchQuery: string[];
@@ -75,6 +76,7 @@ export default class ODataRequest {
             this.addResponseHeader('sap-tenantid', this.tenantId);
         }
         this.isMinimalRepresentation = requestContent.headers?.['prefer'] === 'return=minimal';
+        this.isStrictMode = requestContent.headers?.['prefer']?.includes('handling=strict') ?? false;
         this.queryPath = this.parsePath(parsedUrl.pathname.substring(1));
         this.parseParameters(parsedUrl.searchParams);
     }

--- a/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
+++ b/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
@@ -265,7 +265,7 @@ export class ODataV4ObjectRequest<T> extends ODataRequest<T> {
         targetPath: string,
         protected objectKey: ODataKey = {},
         protected method: string = 'GET',
-        protected headers: Record<string, string> = {}
+        public headers: Record<string, string> = {}
     ) {
         super(odataRootUri, targetPath);
 

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
@@ -13,6 +13,9 @@ module.exports = {
             case 'boundActionReturnsVoid':
                 return undefined;
             case 'baseFunction':
+                if (odataRequest.isStrictMode) {
+                    return `STRICT :: ${actionData.data}`;
+                }
                 return actionData.data;
             default:
                 this.throwError('Not implemented', 501, {

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.json
@@ -1,7 +1,7 @@
 [
     {
         "ID": 1,
-        "Prop1": "SomethingElse",
+        "Prop1": "First Prop",
         "Prop2": "Second Prop",
         "isBoundAction1Hidden": false,
         "isBoundAction2Hidden": false,

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -103,6 +103,12 @@ describe('V4 Requestor', function () {
             )
             .execute('GET');
         expect(dataRes).toMatchInlineSnapshot(`"I am data"`);
+        const dataResStrict = dataRequestor.callGETAction(
+            "/RootElement(ID=1,IsActiveEntity=true)/sap.fe.core.ActionVisibility.baseFunction(data='I am data')"
+        );
+        dataResStrict.headers['Prefer'] = 'handling=strict';
+        const strictResult = await dataResStrict.execute('GET');
+        expect(strictResult).toMatchInlineSnapshot(`"STRICT :: I am data"`);
         const dataRes2 = await dataRequestor
             .callGETAction('/RootElement(ID=1,IsActiveEntity=true)/_Elements')
             .execute('GET');
@@ -344,6 +350,13 @@ describe('V4 Requestor', function () {
         return myPromise;
     });
     beforeAll(() => {
+        const myJSON = JSON.parse(
+            fs.readFileSync(path.join(__dirname, '__testData', 'RootElement.json')).toString('utf-8')
+        );
+        myJSON[0].Prop1 = 'First Prop';
+        fs.writeFileSync(path.join(__dirname, '__testData', 'RootElement.json'), JSON.stringify(myJSON, null, 4));
+    });
+    afterAll(() => {
         const myJSON = JSON.parse(
             fs.readFileSync(path.join(__dirname, '__testData', 'RootElement.json')).toString('utf-8')
         );


### PR DESCRIPTION
Odata request can be sent with Prefer:handling=strict which should fail in case user manual approval is required (412 status code).
Up until now we couldn't evaluate this