### PR TITLE
Allow dynamic expression for UI.CreateHidden annotation

### DIFF
--- a/.changeset/eighty-pugs-trade.md
+++ b/.changeset/eighty-pugs-trade.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/vocabularies-types": patch
+---
+
+Allow dynamic expression for UI.CreateHidden annotation

--- a/packages/vocabularies-types/utils/generate_types.ts
+++ b/packages/vocabularies-types/utils/generate_types.ts
@@ -50,6 +50,7 @@ const ANNOTATION_TARGETS = [
 const KNOWN_DYNAMIC_EXPRESSIONS: Record<string, Record<string, boolean | Record<string, boolean>>> = {
     UI: {
         Hidden: true,
+        CreateHidden: true,
         DeleteHidden: true,
         UpdateHidden: true,
         Criticality: true,


### PR DESCRIPTION
UI.CreateHidden can be used dynamically (pointing to the parent or to a singleton), for evaluation in StandardAction.ts, this has to be supported by generates type