### PR TITLE
fix: ancestors queries can parse sub items

### DIFF
--- a/.changeset/clean-owls-check.md
+++ b/.changeset/clean-owls-check.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+ancestor queries can be parsed on complex navigation

--- a/packages/fe-mockserver-core/src/request/applyParser.ts
+++ b/packages/fe-mockserver-core/src/request/applyParser.ts
@@ -501,19 +501,23 @@ export class ApplyParser extends FilterParser {
             this.CONSUME(COMMA);
             const recHierQualifier = this.CONSUME2(SIMPLEIDENTIFIER);
             this.CONSUME2(COMMA);
-            const recHierPropertyPath = this.CONSUME3(SIMPLEIDENTIFIER);
+            let recHierPropertyPath = this.CONSUME3(SIMPLEIDENTIFIER).image;
+            this.OPTION2(() => {
+                this.CONSUME(SLASH);
+                recHierPropertyPath += '/' + this.CONSUME4(SIMPLEIDENTIFIER).image;
+            });
             this.CONSUME3(COMMA);
             const subTransformations: TransformationDefinition[] = [];
             this.SUBRULE(this.preservingTrafo, { ARGS: [subTransformations] });
             let maximumDistance = -1;
             // There can be more but we ignore them for now
-            this.OPTION2(() => {
+            this.OPTION3(() => {
                 this.CONSUME4(COMMA);
                 maximumDistance = parseInt(this.CONSUME2(LITERAL).image, 10);
             });
             let shouldKeepStart = false;
             //                  [ COMMA BWS %s"keep start" BWS ]
-            this.OPTION3(() => {
+            this.OPTION4(() => {
                 this.CONSUME5(COMMA);
                 shouldKeepStart = this.CONSUME(KEEP_START_TOKEN).image === 'keep start';
             });
@@ -522,7 +526,7 @@ export class ApplyParser extends FilterParser {
                 parameters: {
                     hierarchyRoot: rootExpr,
                     qualifier: recHierQualifier.image,
-                    propertyPath: recHierPropertyPath.image,
+                    propertyPath: recHierPropertyPath,
                     maximumDistance: maximumDistance,
                     keepStart: shouldKeepStart,
                     inputSetTransformations: subTransformations

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -1911,4 +1911,67 @@ describe('Hierarchy Access', () => {
             ]
         `);
     });
+    test('apply queries', () => {
+        const odataRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url:
+                    '/SalesOrganizations?$apply=ancestors(' +
+                    '$root/PurchaseRequisitionItem,' +
+                    'I_PPS_ProcPurReqnItemHNRltn,__HierarchyPropertiesForI_PPS_ProcPurReqnItemHNRltn/NodeId,' +
+                    "filter((PPSLoggedInUsrIsRespPurr%20eq%20true)%20and%20(PPSPurReqnItemCompletionStatus%20eq%20'0')),keep%20start)/com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/PurchaseRequisitionItem,HierarchyQualifier='I_PPS_ProcPurReqnItemHNRltn',NodeProperty='__HierarchyPropertiesForI_PPS_ProcPurReqnItemHNRltn/NodeId',Levels=1)"
+            },
+            dataAccess
+        );
+        expect(odataRequest.applyDefinition).toMatchInlineSnapshot(`
+            [
+              {
+                "parameters": {
+                  "hierarchyRoot": "$root/PurchaseRequisitionItem",
+                  "inputSetTransformations": [
+                    {
+                      "filterExpr": {
+                        "expressions": [
+                          {
+                            "expressions": [
+                              {
+                                "identifier": "PPSLoggedInUsrIsRespPurr",
+                                "literal": "true",
+                                "operator": "eq",
+                              },
+                            ],
+                            "isGroup": true,
+                            "operator": undefined,
+                          },
+                          {
+                            "identifier": "PPSPurReqnItemCompletionStatus",
+                            "literal": "'0'",
+                            "operator": "eq",
+                          },
+                        ],
+                        "operator": "AND",
+                      },
+                      "type": "filter",
+                    },
+                  ],
+                  "keepStart": true,
+                  "maximumDistance": -1,
+                  "propertyPath": "__HierarchyPropertiesForI_PPS_ProcPurReqnItemHNRltn/NodeId",
+                  "qualifier": "I_PPS_ProcPurReqnItemHNRltn",
+                },
+                "type": "ancestors",
+              },
+              {
+                "name": "com.sap.vocabularies.Hierarchy.v1.TopLevels",
+                "parameters": {
+                  "HierarchyNodes": "$root/PurchaseRequisitionItem",
+                  "HierarchyQualifier": "'I_PPS_ProcPurReqnItemHNRltn'",
+                  "Levels": "1",
+                  "NodeProperty": "'__HierarchyPropertiesForI_PPS_ProcPurReqnItemHNRltn/NodeId'",
+                },
+                "type": "customFunction",
+              },
+            ]
+        `);
+    });
 });


### PR DESCRIPTION
I cannot guarantee it will work but the request won't fail outright