### PR TITLE
fix: update dynamic types list for Communication vocabulary

### DIFF
--- a/.changeset/strange-onions-wash.md
+++ b/.changeset/strange-onions-wash.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/vocabularies-types": patch
+---
+
+fix: update dynamic types list for Communication vocabulary

--- a/packages/vocabularies-types/utils/generate_types.ts
+++ b/packages/vocabularies-types/utils/generate_types.ts
@@ -83,8 +83,51 @@ const KNOWN_DYNAMIC_EXPRESSIONS: Record<string, Record<string, boolean | Record<
         }
     },
     Communication: {
+        AddressType: {
+            building: true,
+            street: true,
+            district: true,
+            locality: true,
+            region: true,
+            code: true,
+            country: true,
+            pobox: true,
+            ext: true,
+            careof: true,
+            label: true
+        },
         ContactType: {
-            fn: true
+            fn: true,
+            nickname: true,
+            photo: true,
+            bday: true,
+            anniversary: true,
+            gender: true,
+            title: true,
+            role: true,
+            org: true,
+            orgunit: true,
+            kind: true,
+            note: true
+        },
+        EmailAddressType: {
+            address: true
+        },
+        GeoDataType: {
+            uri: true
+        },
+        NameType: {
+            surname: true,
+            given: true,
+            additional: true,
+            prefix: true,
+            suffix: true
+        },
+        PhoneNumberType: {
+            uri: true
+        },
+        UrlType: {
+            uri: true
         }
     },
     Common: {
@@ -214,6 +257,7 @@ function isEnumType(schemaElement: SchemaElement): schemaElement is EnumType {
 
 /**
  * Returns true if the target expression should allow dynamic values.
+ *
  * @param vocabularyAlias the vocabulary name
  * @param termName the current term
  * @param propertyName the current property


### PR DESCRIPTION
Inside the Communication vocabulary, lots of types are dynamic and should be dealt as `PropertyAnnotationValue<Edm.String>`instead of `Edm.String`. This change is taking care of updating the Communication.contact and its used types to reflect that binding on those annotations is allowed.