### PR TITLE
fix: don't try to set undefined headers

### DIFF
--- a/packages/fe-mockserver-core/src/router/batchRouter.ts
+++ b/packages/fe-mockserver-core/src/router/batchRouter.ts
@@ -88,7 +88,9 @@ export function batchRouter(dataAccess: DataAccess): NextHandleFunction {
             batchResponse += `--${batchData.boundary}--${NL}`;
             res.statusCode = 200;
             for (const globalHeaderName in globalHeaders) {
-                res.setHeader(globalHeaderName, globalHeaders[globalHeaderName]);
+                if (globalHeaders[globalHeaderName]) {
+                    res.setHeader(globalHeaderName, globalHeaders[globalHeaderName]);
+                }
             }
             res.setHeader('Content-Type', `multipart/mixed; boundary=${batchData.boundary}`);
             res.setHeader('odata-version', dataAccess.getMetadata().getVersion());


### PR DESCRIPTION
@drktfl @tobiasqueck 
This was noticed on the FE testsuite where after a while the ui sends a message to refresh the session, the mockserver just dies :)