### PR TITLE
fix: filterParser should allow property name starting with logical operator

### DIFF
--- a/packages/fe-mockserver-core/src/request/commonTokens.ts
+++ b/packages/fe-mockserver-core/src/request/commonTokens.ts
@@ -35,7 +35,11 @@ export const LITERAL = createToken({
         /(:?null|true|false|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|guid(:?'|%27)[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(:?'|%27)|datetime'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})*'|\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:.\d{3,7})*(?:Z|\+\d{2}:\d{2}))*|-?(:?0|[1-9]\d*)(\.\d+)?(:?[eE][+-]?\d+)?|'[^\\"\n\r\']*')/
 });
 //ee1a9172-f3c3-47ce-b0f7-dd28c740210c
-export const LOGICAL_OPERATOR = createToken({ name: 'Logical', pattern: /(:?eq|ne|lt|le|gt|ge)/ });
+export const LOGICAL_OPERATOR = createToken({
+    name: 'Logical',
+    longer_alt: SIMPLEIDENTIFIER,
+    pattern: /(:?eq|ne|lt|le|gt|ge)/
+});
 export const ANDOR = createToken({ name: 'AndOr', pattern: /(\s|%20)(:?and|or)(\s|%20)/ });
 export const ASCDESC = createToken({ name: 'AscDesc', longer_alt: SIMPLEIDENTIFIER, pattern: /(:?asc|desc)/ });
 export const WS = createToken({ name: 'Whitespace', pattern: /(\s|%20)+/ });

--- a/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
@@ -157,6 +157,17 @@ describe('Filter Parser', () => {
         expect(dualParenthesisGroup3?.expressions[1].identifier).toBe('PeopleCount');
     });
 
+    test('can deal with propertyName sharing operator definition', () => {
+        const geltTest = parseFilter('genAi gt 3 or ltStuff eq true');
+        expect(geltTest?.operator).toBe('OR');
+        expect(geltTest?.expressions.length).toBe(2);
+        expect(geltTest?.expressions[1].identifier).toBe('ltStuff');
+        expect(geltTest?.expressions[1].literal).toBe('true');
+        expect(geltTest?.expressions[0].identifier).toBe('genAi');
+        expect(geltTest?.expressions[0].operator).toBe('gt');
+        expect(geltTest?.expressions[0].literal).toBe('3');
+    });
+
     test('can deal with function calls', () => {
         // const toLowerCall = parseFilter("tolower(Country_Code) eq 'de'");
         // expect(toLowerCall.expressions[0].identifier.method).toBe('tolower');


### PR DESCRIPTION
Internal issue #228