### PR TITLE
'Levels' parameter can be omitted in the TopLevels custom function

### DIFF
--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -781,7 +781,7 @@ export class FileBasedMockData {
                 return 1;
             });
 
-            const depth: number = parseInt(_parameters.Levels, 10);
+            const depth: number = _parameters.Levels ? parseInt(_parameters.Levels, 10) : 999;
 
             const toExpand = _parameters.Expand?.map((expand) => expand.substring(1, expand.length - 1)) ?? [];
             const toShow = _parameters.Show?.map((collapse) => collapse.substring(1, collapse.length - 1)) ?? [];

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -792,7 +792,8 @@ export class FileBasedMockData {
                 return 1;
             });
 
-            const depth: number = _parameters.Levels ? parseInt(_parameters.Levels, 10) : 999;
+            // If no 'Levels' value is specified, then all levels are returned
+            const depth: number = _parameters.Levels ? parseInt(_parameters.Levels, 10) : Number.POSITIVE_INFINITY;
 
             const toExpand = _parameters.Expand?.map((expand) => expand.substring(1, expand.length - 1)) ?? [];
             const toShow = _parameters.Show?.map((collapse) => collapse.substring(1, collapse.length - 1)) ?? [];

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -1500,7 +1500,7 @@ describe('Hierarchy Access', () => {
         const odataRequest = new ODataRequest(
             {
                 method: 'GET',
-                url: `/SalesOrganizations?$apply=com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/SalesOrganizations,HierarchyQualifier='SalesOrgHierarchy',NodeProperty='ID',Levels=999)&$select=DistanceFromRoot,DrillState,ID,LimitedDescendantCount,Name&$count=true&$skip=0&$top=47`
+                url: `/SalesOrganizations?$apply=com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/SalesOrganizations,HierarchyQualifier='SalesOrgHierarchy',NodeProperty='ID')&$select=DistanceFromRoot,DrillState,ID,LimitedDescendantCount,Name&$count=true&$skip=0&$top=47`
             },
             dataAccess
         );
@@ -1511,7 +1511,6 @@ describe('Hierarchy Access', () => {
                 "parameters": {
                   "HierarchyNodes": "$root/SalesOrganizations",
                   "HierarchyQualifier": "'SalesOrgHierarchy'",
-                  "Levels": "999",
                   "NodeProperty": "'ID'",
                 },
                 "type": "customFunction",


### PR DESCRIPTION
When no Levels is specified, it means we should expand all nodes