### PR TITLE
fix: 'discard' must not return a `sap-contextid` header

### DIFF
--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -1082,8 +1082,10 @@ export class DataAccess implements DataAccessInterface {
             UUID = entitySet.resetSessionTimeout(tenantId);
             timeoutTime = entitySet.sessionTimeoutTime;
         });
-        odataRequest.addResponseHeader('sap-contextid', UUID, true);
-        odataRequest.addResponseHeader('sap-http-session-timeout', timeoutTime.toString(), true);
+        if (UUID) {
+            odataRequest.addResponseHeader('sap-contextid', UUID, true);
+            odataRequest.addResponseHeader('sap-http-session-timeout', timeoutTime.toString(), true);
+        }
     }
 
     private _applyOrderBy(data: object[], orderByDefinition: OrderByProp[]): object[] {

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -391,9 +391,6 @@ export default class ODataRequest {
 
     public async handleRequest() {
         const contextId = this.requestContent.headers?.['sap-contextid'];
-        if (contextId) {
-            this.dataAccess.resetStickySessionTimeout(this, this.tenantId);
-        }
         try {
             switch (this.requestContent.method) {
                 case 'PATCH':
@@ -469,6 +466,9 @@ export default class ODataRequest {
                 this.addResponseHeader('content-type', 'text/plain');
                 this.setResponseData(errorInformation.message);
             }
+        }
+        if (contextId) {
+            this.dataAccess.resetStickySessionTimeout(this, this.tenantId);
         }
     }
 

--- a/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
+++ b/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
@@ -450,8 +450,16 @@ export class ODataV4Requestor extends ODataRequestor {
             noJSON
         );
     }
-    public callAction<T>(actionPath: string, actionParameters: any, noJSON: boolean = false): ODataV4ObjectRequest<T> {
-        return new ODataV4ObjectRequest<T>(this.odataRootUri, actionPath, {}, 'POST').setBody(actionParameters, noJSON);
+    public callAction<T>(
+        actionPath: string,
+        actionParameters: any,
+        noJSON: boolean = false,
+        headers?: Record<string, string>
+    ): ODataV4ObjectRequest<T> {
+        return new ODataV4ObjectRequest<T>(this.odataRootUri, actionPath, {}, 'POST', headers).setBody(
+            actionParameters,
+            noJSON
+        );
     }
 
     public callGETAction<T>(actionPath: string): ODataV4ObjectRequest<T> {

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -319,7 +319,11 @@ describe('V4 Requestor', function () {
             const id = created.body.ID;
             const contextId = created.headers['sap-contextid'];
 
-            const discarded = await dataRequestor.callAction('/Discard', {}).execute();
+            const discarded = await dataRequestor
+                .callAction('/Discard', {}, false, {
+                    'sap-contextid': contextId
+                })
+                .execute();
             expect(discarded).toMatchSnapshot(
                 {
                     headers: expect.not.objectContaining({ 'sap-contextid': expect.any(String) })


### PR DESCRIPTION
If it does, the client will preserve it in follow-up requests, resulting in errors