### PR TITLE
fix: lambda queries containing method are properly evaluated

### DIFF
--- a/.changeset/early-scissors-listen.md
+++ b/.changeset/early-scissors-listen.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Lambda expression containing methods a properly evaluated

--- a/packages/fe-mockserver-core/src/request/filterParser.ts
+++ b/packages/fe-mockserver-core/src/request/filterParser.ts
@@ -49,6 +49,7 @@ export type FilterMethodCall = {
     type: 'method';
     method: string;
     methodArgs: string[];
+    propertyPaths?: string[];
 };
 export type LambdaExpression = {
     type: 'lambda';

--- a/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
+++ b/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
@@ -56,5 +56,40 @@ describe('EntitySet', () => {
             filteredData = myEntitySet.checkFilter(mockData[3], v4ComplexLambda, 'default', fakeRequest);
             expect(filteredData).toBe(false);
         });
+        it('works on deep lambda expression with methods', async () => {
+            const myEntitySet = new MockDataEntitySet(
+                baseDir,
+                {
+                    name: 'MyEntityData',
+                    entityType: {
+                        entityProperties: []
+                    },
+                    _type: 'EntitySet'
+                } as any,
+                dataAccess,
+                false,
+                true
+            );
+            await myEntitySet.readyPromise;
+            const v4ComplexLambda = parseFilter(
+                "((ArrayData/any(t:t/SubArray/any(a0:contains(a0/Name,'Something') and a0/SubSubArray/any(a1:a1/Value ge '20220600') and a0/SubSubArray/any(a1:a1/Value le '20220603'))))) and (BaseData eq 'FirstCheck')"
+            );
+            const fakeRequest = new ODataRequest(
+                {
+                    method: 'GET',
+                    url: 'MyEntityData'
+                },
+                dataAccess
+            );
+            const mockData = myEntitySet.getMockData('default').getAllEntries(fakeRequest) as any;
+            let filteredData = myEntitySet.checkFilter(mockData[0], v4ComplexLambda, 'default', fakeRequest);
+            expect(filteredData).toBe(true);
+            filteredData = myEntitySet.checkFilter(mockData[1], v4ComplexLambda, 'default', fakeRequest);
+            expect(filteredData).toBe(true);
+            filteredData = myEntitySet.checkFilter(mockData[2], v4ComplexLambda, 'default', fakeRequest);
+            expect(filteredData).toBe(true);
+            filteredData = myEntitySet.checkFilter(mockData[3], v4ComplexLambda, 'default', fakeRequest);
+            expect(filteredData).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
If a lambda query contains a method call, the operation fails with a string replace error