### PR TITLE
fix: not operator in lambda is properly evaluated

### DIFF
--- a/.changeset/wild-jobs-shop.md
+++ b/.changeset/wild-jobs-shop.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Fix an issue with not lambda parsing

--- a/packages/fe-mockserver-core/src/request/filterParser.ts
+++ b/packages/fe-mockserver-core/src/request/filterParser.ts
@@ -282,13 +282,13 @@ export class FilterParser extends EmbeddedActionsParser {
                     ALT: () => {
                         // boolParenExpr
                         $.CONSUME(NOT_OPERATOR);
-                        $.CONSUME(WS);
-                        const hasOpen = $.OPTION(() => {
+                        $.OPTION(() => $.CONSUME(WS));
+                        const hasOpen = $.OPTION2(() => {
                             $.CONSUME(OPEN);
                             return true;
                         });
                         const expression = $.SUBRULE($.boolCommonExpr);
-                        $.OPTION2(() => $.CONSUME(CLOSE));
+                        $.OPTION3(() => $.CONSUME(CLOSE));
                         return {
                             isGroup: !!hasOpen,
                             isReversed: true,
@@ -327,7 +327,7 @@ export class FilterParser extends EmbeddedActionsParser {
                                 ALT: () => $.SUBRULE($.methodCallExpr)
                             }
                         ]);
-                        $.OPTION3(() => {
+                        $.OPTION4(() => {
                             $.CONSUME2(WS);
                             operator = $.CONSUME(LOGICAL_OPERATOR);
                             $.CONSUME3(WS);
@@ -348,7 +348,7 @@ export class FilterParser extends EmbeddedActionsParser {
                     }
                 }
             ]);
-            $.OPTION4(() => {
+            $.OPTION5(() => {
                 operator = $.CONSUME(ANDOR);
                 const subsubExpr = $.SUBRULE3($.boolCommonExpr);
                 let expressions: FilterExpression[];

--- a/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/filterParser.test.ts
@@ -368,6 +368,41 @@ describe('Filter Parser', () => {
             }
         `);
     });
+    test('reverse lambda', () => {
+        const complexLambda = parseFilter(`not(_extension/any(ent:contains(ent/name, 'HCP_SUBACCOUNT_ID')))`);
+        expect(complexLambda).toMatchInlineSnapshot(`
+            {
+              "expressions": [
+                {
+                  "identifier": {
+                    "expression": {
+                      "expressions": [
+                        {
+                          "identifier": {
+                            "method": "contains",
+                            "methodArgs": [
+                              "ent/name",
+                              "'HCP_SUBACCOUNT_ID'",
+                            ],
+                            "type": "method",
+                          },
+                        },
+                      ],
+                    },
+                    "key": "ent",
+                    "operator": "ANY",
+                    "target": "_extension",
+                    "type": "lambda",
+                  },
+                },
+              ],
+              "isGroup": true,
+              "isReversed": true,
+              "operator": undefined,
+            }
+        `);
+    });
+
     test('complex lambda', () => {
         const complexLambda = parseFilter(`formats/any(f:f/FORMAT_ID eq 1) and not items/any()`);
         expect(complexLambda).toMatchInlineSnapshot(`


### PR DESCRIPTION
The parser did not allow request such as not(_Elements/any(L1:contains(L1/SubProp1(xxx))