### PR TITLE
Update functionBasedMockData.ts

### DIFF
--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -357,7 +357,7 @@ export class FunctionBasedMockData extends FileBasedMockData {
         if (this._mockDataFn?.getReferentialConstraints) {
             return this._mockDataFn.getReferentialConstraints(_navigationProperty);
         } else {
-            return undefined;
+            return super.getReferentialConstraints(_navigationProperty);
         }
     }
 


### PR DESCRIPTION
getReferentialConstraint was not working when there was an implementation file associated with a hierarchic entity