### PR TITLE
feat: support the "unofficial" search for v2

### DIFF
--- a/.changeset/lucky-planets-own.md
+++ b/.changeset/lucky-planets-own.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+feat: support the "unofficial" search for v2

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -112,6 +112,10 @@ export default class ODataRequest {
     private parseParameters(searchParams: URLSearchParams) {
         this.allParams = searchParams;
         this.searchQuery = parseSearch(searchParams.get('$search'));
+        if (this.dataAccess.getMetadata().getVersion() === '2.0' && this.searchQuery.length === 0) {
+            // In v2, there is no official $search support but sometimes `search` without dollar is used
+            this.searchQuery = parseSearch(searchParams.get('search'));
+        }
         this.orderBy = this.parseOrderBy(searchParams.get('$orderby'));
         this.startIndex = parseInt(searchParams.get('$skip') || '', 10);
         this.skipLocation = searchParams.get('sap-skiplocation');

--- a/packages/fe-mockserver-core/test/unit/v2/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v2/dataAccess.test.ts
@@ -95,6 +95,17 @@ describe('Data Access', () => {
         expect(productData[1].Name).toEqual('Acme Trap v2');
         expect(productData[2].Name).toEqual('Acme Boomerang');
         expect(productData[3].Name).toEqual('Acme Extra Comfy Safe');
+
+        odataRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: '/SEPMRA_C_PD_Product?search=Trap&$skip=0&$top=20&$orderby=to_ProductTextInOriginalLang/Name%20asc&$filter=IsActiveEntity%20eq%20false%20or%20SiblingEntity/IsActiveEntity%20eq%20null&$select=ProductCategory%2cProductPictureURL%2cProductForEdit%2cto_ProductTextInOriginalLang%2fName%2cProduct%2cDraftUUID%2cIsActiveEntity%2cHasDraftEntity%2cHasActiveEntity%2cCopy_ac%2cDraftAdministrativeData&$expand=to_ProductTextInOriginalLang%2cDraftAdministrativeData&$inlinecount=allpages'
+            },
+            dataAccess
+        );
+        productData = await dataAccess.getData(odataRequest);
+        expect(productData.length).toEqual(1);
+        expect(odataRequest.dataCount).toEqual(1);
     });
     test('v2metadata - it can GET data for an entity with keys that needs encoding', async () => {
         const odataRequest = new ODataRequest(


### PR DESCRIPTION
Internal issue

V2 doesn't support an official $search in the URI, but it seems the standard implementation from the ABAP gateway support a search parameter