### PR TITLE
fix: we now allow null in literal definition

### DIFF
--- a/.changeset/blue-eggs-try.md
+++ b/.changeset/blue-eggs-try.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Fix an issue with null in property names

--- a/packages/fe-mockserver-core/src/request/commonTokens.ts
+++ b/packages/fe-mockserver-core/src/request/commonTokens.ts
@@ -31,6 +31,7 @@ export const TYPEDEF = createToken({ name: 'Typedef', pattern: /Edm\.[a-zA-Z]+/ 
 // null, boolean, guid, dateTimeInOffset / dateValue / timeOfDay / decimalValue / doubleValue / singleValue / string / duration / enum / binary
 export const LITERAL = createToken({
     name: 'Literal',
+    longer_alt: SIMPLEIDENTIFIER,
     pattern:
         /(:?null|true|false|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|guid(:?'|%27)[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(:?'|%27)|(?:datetime|datetimeoffset)'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})*(?:Z)*'|\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:.\d{3,7})*(?:Z|\+\d{2}:\d{2}))*|-?(:?0|[1-9]\d*)(\.\d+)?(:?[eE][+-]?\d+)?|'[^\\"\n\r\']*')/
 });

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -2054,4 +2054,51 @@ describe('Hierarchy Access', () => {
             ]
         `);
     });
+
+    test('more apply queries', () => {
+        const odataRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: '/RiskSettingsService/LevelCorrelation?entitySet=LevelCorrelation&$apply=filter(IsActiveEntity%20eq%20true)/groupby((impactLevelUpperValue,impactLevel_ID,probabilityLevelUpperValue,probabilityLevel_ID),aggregate(nullProperty%20with%20min%20as%20nullMeasure))'
+            },
+            dataAccess
+        );
+        expect(odataRequest.applyDefinition).toMatchInlineSnapshot(`
+            [
+              {
+                "filterExpr": {
+                  "expressions": [
+                    {
+                      "identifier": "IsActiveEntity",
+                      "literal": "true",
+                      "operator": "eq",
+                    },
+                  ],
+                },
+                "type": "filter",
+              },
+              {
+                "groupBy": [
+                  "impactLevelUpperValue",
+                  "impactLevel_ID",
+                  "probabilityLevelUpperValue",
+                  "probabilityLevel_ID",
+                ],
+                "subTransformations": [
+                  {
+                    "aggregateDef": [
+                      {
+                        "name": "nullMeasure",
+                        "operator": "min",
+                        "sourceProperty": "nullProperty",
+                      },
+                    ],
+                    "type": "aggregates",
+                  },
+                ],
+                "type": "groupBy",
+              },
+            ]
+        `);
+    });
 });

--- a/packages/vocabularies-types/utils/config.json
+++ b/packages/vocabularies-types/utils/config.json
@@ -1,5 +1,5 @@
 {
-    "Auth": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Authorization.V1.json",
+    "Authorization": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Authorization.V1.json",
     "Core": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json",
     "Capabilities": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.json",
     "Aggregation": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       '@sap-ux/ui5-middleware-fe-mockserver':
         specifier: workspace:*
         version: link:../../packages/ui5-middleware-fe-mockserver
+      '@sap/open.fe':
+        specifier: 1.120.0
+        version: 1.120.0
       '@ui5/cli':
         specifier: 3.7.3
         version: 3.7.3
@@ -1312,6 +1315,10 @@ packages:
     hasBin: true
     dependencies:
       antlr4: 4.9.3
+    dev: true
+
+  /@sap/open.fe@1.120.0:
+    resolution: {integrity: sha512-U/EtyBqU+VPwbmvwXbnLxx33aaqPl9VphyhJZMEXO7A+osEDW5N7ZVjkcBPIkg63I7FF6PSJMHx7ZkVddJw9MA==}
     dev: true
 
   /@sigstore/bundle@2.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,9 +194,6 @@ importers:
       '@sap-ux/ui5-middleware-fe-mockserver':
         specifier: workspace:*
         version: link:../../packages/ui5-middleware-fe-mockserver
-      '@sap/open.fe':
-        specifier: 1.120.0
-        version: 1.120.0
       '@ui5/cli':
         specifier: 3.7.3
         version: 3.7.3
@@ -1315,10 +1312,6 @@ packages:
     hasBin: true
     dependencies:
       antlr4: 4.9.3
-    dev: true
-
-  /@sap/open.fe@1.120.0:
-    resolution: {integrity: sha512-U/EtyBqU+VPwbmvwXbnLxx33aaqPl9VphyhJZMEXO7A+osEDW5N7ZVjkcBPIkg63I7FF6PSJMHx7ZkVddJw9MA==}
     dev: true
 
   /@sigstore/bundle@2.1.0:


### PR DESCRIPTION
In case simple identifier included a null in their name, they were considered as literals instead which broke some parsing logic