### PR TITLE
fix: slight change to the vocabulary type for partner navigation

### DIFF
--- a/.changeset/brave-pens-drum.md
+++ b/.changeset/brave-pens-drum.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/vocabularies-types': patch
+---
+
+Slight change for the partner navigation on type or the raw v4 navigation

--- a/packages/vocabularies-types/src/Edm.ts
+++ b/packages/vocabularies-types/src/Edm.ts
@@ -359,7 +359,7 @@ export type ReferentialConstraint = {
 export type BaseNavigationProperty = {
     _type: 'NavigationProperty';
     name: SimpleIdentifier;
-    partner: string;
+    partner?: string;
     fullyQualifiedName: FullyQualifiedName;
     targetTypeName: FullyQualifiedName;
     targetType: EntityType;


### PR DESCRIPTION
Currently partner is required, while it's not guaranteed to exist