### PR TITLE
feat: support the ExpandLevels parameters in a hierarchical query

### DIFF
--- a/.changeset/lazy-carrots-decide.md
+++ b/.changeset/lazy-carrots-decide.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+fix subExpand in topLevels

--- a/packages/fe-mockserver-core/src/request/commonTokens.ts
+++ b/packages/fe-mockserver-core/src/request/commonTokens.ts
@@ -2,11 +2,13 @@ import { createToken } from 'chevrotain';
 
 export const OPEN = createToken({ name: 'OPEN', pattern: /(:?\(|%28)/ });
 export const OPEN_BRACKET = createToken({ name: 'OPEN_BRACKET', pattern: /(:?\[)/ });
+export const OPEN_CURLY_BRACKET = createToken({ name: 'OPEN_CURLY_BRACKET', pattern: /(:?\{)/ });
 export const DOT = createToken({ name: 'DOT', pattern: /\./ });
 export const QUOTE = createToken({ name: 'QUOTE', pattern: /(:?"|%22)/ });
 export const EQ = createToken({ name: 'EQ', pattern: /\=/ });
 export const CLOSE = createToken({ name: 'CLOSE', pattern: /(:?\)|%29)/ });
 export const CLOSE_BRACKET = createToken({ name: 'CLOSE_BRACKET', pattern: /(:?\])/ });
+export const CLOSE_CURLY_BRACKET = createToken({ name: 'CLOSE_CURLY_BRACKET', pattern: /(:?\})/ });
 export const COMMA = createToken({ name: 'COMMA', pattern: /(:?,|%2C)/ });
 export const SLASH = createToken({ name: 'SLASH', pattern: /\// });
 export const ANYALL = createToken({ name: 'COMMA', pattern: /(:?any|all)\(/ });

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -1589,22 +1589,28 @@ describe('Hierarchy Access', () => {
             dataAccess
         );
         expect(odataRequest.applyDefinition).toMatchInlineSnapshot(`
-          [
-            {
-              "name": "com.sap.vocabularies.Hierarchy.v1.TopLevels",
-              "parameters": {
-                "HierarchyNodes": "$root/SalesOrganizations",
-                "HierarchyQualifier": "'SalesOrgHierarchy'",
-                "Levels": "2",
-                "NodeProperty": "'ID'",
-                "ExpandLevels": [
-                  {'NodeID':'US','Levels':1},
-                  {'NodeID':'US East','Levels':2}
-                ]
+            [
+              {
+                "name": "com.sap.vocabularies.Hierarchy.v1.TopLevels",
+                "parameters": {
+                  "ExpandLevels": [
+                    {
+                      "'Levels'": "1",
+                      "'NodeID'": "'US'",
+                    },
+                    {
+                      "'Levels'": "2",
+                      "'NodeID'": "'US East'",
+                    },
+                  ],
+                  "HierarchyNodes": "$root/SalesOrganizations",
+                  "HierarchyQualifier": "'SalesOrgHierarchy'",
+                  "Levels": "2",
+                  "NodeProperty": "'ID'",
+                },
+                "type": "customFunction",
               },
-              "type": "customFunction",
-            },
-          ]
+            ]
         `);
         const data = await dataAccess.getData(odataRequest);
         expect(data).toMatchInlineSnapshot(`
@@ -1613,7 +1619,7 @@ describe('Hierarchy Access', () => {
                 "DistanceFromRoot": 0,
                 "DrillState": "expanded",
                 "ID": "Sales",
-                "LimitedDescendantCount": 7,
+                "LimitedDescendantCount": 6,
                 "Name": "Corporate Sales",
               },
               {

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -1579,6 +1579,89 @@ describe('Hierarchy Access', () => {
             ]
         `);
     });
+
+    test('8.5 - Expand on sub-nodes', async () => {
+        const odataRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: "/SalesOrganizations?$apply=com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/SalesOrganizations,HierarchyQualifier='SalesOrgHierarchy',NodeProperty='ID',Levels=2,ExpandLevels=[{'NodeID':'US','Levels':1},{'NodeID':'US East','Levels':2}])&$count=true&$select=LimitedDescendantCount,DistanceFromRoot,DrillState,ID,Name&$skip=0&$top=50"
+            },
+            dataAccess
+        );
+        expect(odataRequest.applyDefinition).toMatchInlineSnapshot(`
+          [
+            {
+              "name": "com.sap.vocabularies.Hierarchy.v1.TopLevels",
+              "parameters": {
+                "HierarchyNodes": "$root/SalesOrganizations",
+                "HierarchyQualifier": "'SalesOrgHierarchy'",
+                "Levels": "2",
+                "NodeProperty": "'ID'",
+                "ExpandLevels": [
+                  {'NodeID':'US','Levels':1},
+                  {'NodeID':'US East','Levels':2}
+                ]
+              },
+              "type": "customFunction",
+            },
+          ]
+        `);
+        const data = await dataAccess.getData(odataRequest);
+        expect(data).toMatchInlineSnapshot(`
+            [
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "ID": "Sales",
+                "LimitedDescendantCount": 7,
+                "Name": "Corporate Sales",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "collapsed",
+                "ID": "EMEA",
+                "LimitedDescendantCount": 0,
+                "Name": "EMEA",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "expanded",
+                "ID": "US",
+                "LimitedDescendantCount": 4,
+                "Name": "US",
+              },
+              {
+                "DistanceFromRoot": 2,
+                "DrillState": "leaf",
+                "ID": "US West",
+                "LimitedDescendantCount": 0,
+                "Name": "US West",
+              },
+              {
+                "DistanceFromRoot": 2,
+                "DrillState": "expanded",
+                "ID": "US East",
+                "LimitedDescendantCount": 2,
+                "Name": "US East",
+              },
+              {
+                "DistanceFromRoot": 3,
+                "DrillState": "expanded",
+                "ID": "NY",
+                "LimitedDescendantCount": 1,
+                "Name": "New York State",
+              },
+              {
+                "DistanceFromRoot": 4,
+                "DrillState": "leaf",
+                "ID": "NYC",
+                "LimitedDescendantCount": 0,
+                "Name": "New York City",
+              },
+            ]
+        `);
+    });
+
     test('9 - Create new root and a child', async () => {
         const createRequest = new ODataRequest(
             {


### PR DESCRIPTION
The TopLevels function supports a new parameter 'ExpandLevels', that allows to expand sub-nodes individually