### PR TITLE
fix: resolve unbound actions

### DIFF
--- a/.changeset/heavy-countries-build.md
+++ b/.changeset/heavy-countries-build.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-converter': patch
+---
+
+fix: The annotation converter now resolves unbound actions both with a trailing `()` and without

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -122,7 +122,8 @@ function resolveTarget<T>(
             startElement =
                 converter.getConvertedEntityType(pathSegments[0]) ??
                 converter.getConvertedComplexType(pathSegments[0]) ??
-                converter.getConvertedAction(pathSegments[0]);
+                converter.getConvertedAction(pathSegments[0]) ??
+                converter.getConvertedAction(`${pathSegments[0]}()`); // unbound action
             pathSegments.shift(); // Let's remove the first path element
         } else {
             startElement = converter.getConvertedEntityContainer();

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -417,6 +417,18 @@ describe('Annotation Converter', () => {
             expect(target.target.name).toEqual('isVerified');
         });
 
+        it('can resolve a path starting at an unbound action', () => {
+            const target: ResolutionTarget<any> = convertedTypes.resolvePath(
+                '/com.c_salesordermanage_sd.UnboundAction/0'
+            );
+
+            expect(target.target).not.toBeNull();
+            expect(target.target).not.toBeUndefined();
+            expect(target.objectPath.length).toEqual(1); // Action
+            expect(target.target._type).toEqual('Action');
+            expect(target.target.name).toEqual('UnboundAction');
+        });
+
         it('can resolve /$Type starting at an entity type', () => {
             const entityType = convertedTypes.entityTypes[0];
             expect(entityType).not.toBeNull();


### PR DESCRIPTION
`resolveTarget()` might be called with an (unbound) action FQN missing the trailing `()` that should be there to denote the unbound overload. This is kind of an edge case, though - there can be only one unbound action with a given name in the schema.