### PR TITLE
fix: display hierarchy of active instances

### DIFF
--- a/.changeset/orange-cougars-roll.md
+++ b/.changeset/orange-cougars-roll.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Fix draft hierarchy queries

--- a/packages/fe-mockserver-core/src/data/common.ts
+++ b/packages/fe-mockserver-core/src/data/common.ts
@@ -64,6 +64,7 @@ export interface EntitySetInterface {
     getEntityInterface(entitySetName: string, tenantId: string): Promise<FileBasedMockData | undefined>;
     getMockData(tenantId: string): FileBasedMockData;
     isV4(): boolean;
+    isDraft(): boolean;
 }
 export interface DataAccessInterface {
     isV4(): boolean;

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -294,6 +294,13 @@ export class MockDataEntitySet implements EntitySetInterface {
         return this.dataAccess.isV4();
     }
 
+    public isDraft(): boolean {
+        return !!(
+            this.entitySetDefinition?.annotations.Common?.DraftRoot ||
+            this.entitySetDefinition?.annotations.Common?.DraftNode
+        );
+    }
+
     public getProperty(identifier: string) {
         let resolvedPath;
         if (this.entitySetDefinition) {

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -296,7 +296,7 @@ export class MockDataEntitySet implements EntitySetInterface {
 
     public isDraft(): boolean {
         return !!(
-            this.entitySetDefinition?.annotations.Common?.DraftRoot ||
+            this.entitySetDefinition?.annotations.Common?.DraftRoot ??
             this.entitySetDefinition?.annotations.Common?.DraftNode
         );
     }

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -712,10 +712,7 @@ export class FileBasedMockData {
         const itemPerParents: Record<string, any[]> = {};
 
         inputSet.forEach((item: any) => {
-            if (
-                !this._mockDataEntitySet.isDraft() ||
-                (item.IsActiveEntity !== false && item.HasActiveEntity === true)
-            ) {
+            if (!this._mockDataEntitySet.isDraft() || item.IsActiveEntity !== false) {
                 const parentItemValue = getData(item, hierarchyDefinition.sourceReference) ?? '';
                 if (!itemPerParents[parentItemValue]) {
                     itemPerParents[parentItemValue] = [];

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -94,6 +94,29 @@ function deleteData(currentNode: any, deepProperty: string) {
     }
     delete subNode[deepPropertyPath[deepPropertyPath.length - 1]];
 }
+
+function compareRowData(
+    row1: any,
+    row2: any,
+    hierarchyNodeProperty: string,
+    hierarchySourceProperty: string,
+    isDraft: boolean
+): boolean {
+    if (isDraft) {
+        if (hierarchyNodeProperty === hierarchySourceProperty) {
+            return (
+                getData(row1, hierarchyNodeProperty) === getData(row2, hierarchySourceProperty) &&
+                getData(row1, 'IsActiveEntity') === getData(row2, 'IsActiveEntity')
+            );
+        } else {
+            return (
+                getData(row1, hierarchyNodeProperty) === getData(row2, hierarchySourceProperty) &&
+                getData(row1, 'IsActiveEntity') === true
+            );
+        }
+    }
+    return getData(row1, hierarchyNodeProperty) === getData(row2, hierarchySourceProperty);
+}
 export class FileBasedMockData {
     protected _mockData: object[];
     protected _hierarchyTree: Record<string, Record<string, any>> = {};
@@ -689,11 +712,16 @@ export class FileBasedMockData {
         const itemPerParents: Record<string, any[]> = {};
 
         inputSet.forEach((item: any) => {
-            const parentItemValue = getData(item, hierarchyDefinition.sourceReference) ?? '';
-            if (!itemPerParents[parentItemValue]) {
-                itemPerParents[parentItemValue] = [];
+            if (
+                !this._mockDataEntitySet.isDraft() ||
+                (item.IsActiveEntity !== false && item.HasActiveEntity === true)
+            ) {
+                const parentItemValue = getData(item, hierarchyDefinition.sourceReference) ?? '';
+                if (!itemPerParents[parentItemValue]) {
+                    itemPerParents[parentItemValue] = [];
+                }
+                itemPerParents[parentItemValue].push(item);
             }
-            itemPerParents[parentItemValue].push(item);
         });
         this._hierarchyTree[hierarchyQualifier] = itemPerParents;
 
@@ -793,7 +821,8 @@ export class FileBasedMockData {
         hierarchyDefinition: HierarchyDefinition,
         depth: number,
         matchedChildrenCount: number,
-        matchedProperties: any[]
+        matchedProperties: any[],
+        isDraft: boolean
     ) {
         let descendantCount = 0;
         if (currentNode && (depth < 0 || depth > 0)) {
@@ -817,11 +846,9 @@ export class FileBasedMockData {
                     setData(
                         currentNode,
                         hierarchyDefinition.matchedProperty,
-                        !!matchedProperties.find((prop) => {
-                            const mainItem = getData(prop, nodeProperty);
-                            const adjustedItem = getData(currentNode, nodeProperty);
-                            return mainItem === adjustedItem;
-                        })
+                        !!matchedProperties.find((prop) =>
+                            compareRowData(prop, currentNode, nodeProperty, nodeProperty, isDraft)
+                        )
                     );
                     if (getData(currentNode, hierarchyDefinition.matchedProperty)) {
                         matchedChildrenCount++;
@@ -851,7 +878,8 @@ export class FileBasedMockData {
                     hierarchyDefinition,
                     depth - 1,
                     matchedChildrenCount,
-                    matchedProperties
+                    matchedProperties,
+                    isDraft
                 );
             }
 
@@ -874,20 +902,22 @@ export class FileBasedMockData {
         if (aggregationAnnotation) {
             const nodeProperty = getNodeProperty(aggregationAnnotation)!;
             let adjustedData = data.map((adjustedRowData: any) => {
-                const item = this._mockData.find((dataItem: any) => {
-                    const mainItem = getData(dataItem, nodeProperty);
-                    const adjustedItem = getData(adjustedRowData, nodeProperty);
-                    return mainItem === adjustedItem;
-                });
+                const item = this._mockData.find((dataItem: any) =>
+                    compareRowData(
+                        dataItem,
+                        adjustedRowData,
+                        nodeProperty,
+                        nodeProperty,
+                        this._mockDataEntitySet.isDraft()
+                    )
+                );
                 return { ...item, ...adjustedRowData, ...{ $inResultSet: true } };
             });
             const restOfData = this._mockData
                 .filter((item: any) => {
-                    return !data.find((dataItem: any) => {
-                        const mainItem = getData(dataItem, nodeProperty);
-                        const adjustedItem = getData(item, nodeProperty);
-                        return mainItem === adjustedItem;
-                    });
+                    return !data.find((dataItem: any) =>
+                        compareRowData(dataItem, item, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
+                    );
                 })
                 .map((item: any) => {
                     return { ...item, ...{ $inResultSet: false } };
@@ -898,11 +928,9 @@ export class FileBasedMockData {
             const sourceReference = this.getSourceReference(aggregationAnnotation);
             // TODO Considering the input set the top level node is not necessarely the root node
             const allRootNodes = adjustedData.filter((node) => {
-                const parent = adjustedData.find((parent) => {
-                    const nodeValue = getData(parent, nodeProperty);
-                    const sourceReferenceValue = getData(node, sourceReference);
-                    return nodeValue === sourceReferenceValue;
-                });
+                const parent = adjustedData.find((parent) =>
+                    compareRowData(parent, node, nodeProperty, sourceReference, this._mockDataEntitySet.isDraft())
+                );
                 return !parent || !parent.$inResultSet;
             });
             allRootNodes.sort((a) => {
@@ -969,11 +997,9 @@ export class FileBasedMockData {
 
             let outData: object[] = [];
             outItems.forEach((item: any) => {
-                const subTreeData = data.find((dataItem: any) => {
-                    const mainItem = getData(dataItem, nodeProperty);
-                    const adjustedItem = getData(item, nodeProperty);
-                    return mainItem === adjustedItem;
-                });
+                const subTreeData = data.find((dataItem: any) =>
+                    compareRowData(dataItem, item, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
+                );
                 const nodePropertyValue = getData(item, nodeProperty);
                 if (subTreeData) {
                     if (
@@ -1024,11 +1050,9 @@ export class FileBasedMockData {
         if (aggregationAnnotation) {
             const nodeProperty = getNodeProperty(aggregationAnnotation)!;
             const adjustedData = this._mockData.map((item: any) => {
-                const adjustedRowData = hierarchyFilter.find((dataItem: any) => {
-                    const mainItem = getData(dataItem, nodeProperty);
-                    const adjustedItem = getData(item, nodeProperty);
-                    return mainItem === adjustedItem;
-                });
+                const adjustedRowData = hierarchyFilter.find((dataItem: any) =>
+                    compareRowData(dataItem, item, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
+                );
                 if (adjustedRowData) {
                     return { ...item, ...adjustedRowData, ...{ $inResultSet: true } };
                 } else {
@@ -1046,11 +1070,9 @@ export class FileBasedMockData {
             hierarchyFilter.forEach((item: any) => {
                 const parentNodeChildren = hierarchyNodes[getData(item, sourceReference) ?? ''];
                 if (parentNodeChildren) {
-                    const currentNode = parentNodeChildren.find((node: any) => {
-                        const mainItem = getData(node, nodeProperty);
-                        const adjustedItem = getData(item, nodeProperty);
-                        return mainItem === adjustedItem;
-                    });
+                    const currentNode = parentNodeChildren.find((node: any) =>
+                        compareRowData(node, item, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
+                    );
                     if (_parameters.keepStart) {
                         if (hierarchyDefinition.matchedProperty) {
                             // TODO compare with lastFilterTransformationResult
@@ -1071,11 +1093,9 @@ export class FileBasedMockData {
             });
             const outData: object[] = [];
             inputSet.forEach((item: any) => {
-                const subTreeData: any = subTrees.find((dataItem: any) => {
-                    const mainItem = getData(dataItem, nodeProperty);
-                    const adjustedItem = getData(item, nodeProperty);
-                    return mainItem === adjustedItem;
-                });
+                const subTreeData: any = subTrees.find((dataItem: any) =>
+                    compareRowData(dataItem, item, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
+                );
                 if (subTreeData) {
                     if (
                         hierarchyDefinition.matchedDescendantCountProperty &&
@@ -1133,6 +1153,7 @@ export class FileBasedMockData {
             matchedProperty: getPathOrPropertyPath(hierarchyAnnotation.MatchedProperty)
         };
     }
+
     async getAncestors(
         inputSet: object[],
         lastFilterTransformationResult: object[],
@@ -1149,11 +1170,9 @@ export class FileBasedMockData {
             const nodeProperty = getNodeProperty(aggregationAnnotation)!;
             const sourceReference = this.getSourceReference(aggregationAnnotation);
             const adjustedData = this._mockData.map((item: any) => {
-                const adjustedRowData = limitedHierarchy.find((dataItem: any) => {
-                    const mainItem = getData(dataItem, nodeProperty);
-                    const adjustedItem = getData(item, nodeProperty);
-                    return mainItem === adjustedItem;
-                });
+                const adjustedRowData = limitedHierarchy.find((dataItem: any) =>
+                    compareRowData(item, dataItem, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
+                );
                 if (adjustedRowData) {
                     return { ...item, ...adjustedRowData, ...{ $inResultSet: true } };
                 } else {
@@ -1168,11 +1187,9 @@ export class FileBasedMockData {
             const ancestors: any[] = [];
             limitedHierarchy.forEach((item: any) => {
                 const parentNodeChildren = hierarchyNodes[getData(item, sourceReference) ?? ''];
-                const currentNode = parentNodeChildren.find((node: any) => {
-                    const mainItem = getData(node, nodeProperty);
-                    const adjustedItem = getData(item, nodeProperty);
-                    return mainItem === adjustedItem;
-                });
+                const currentNode = parentNodeChildren.find((node: any) =>
+                    compareRowData(node, item, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
+                );
                 if (_parameters.keepStart) {
                     this.getAncestorsOfNode(
                         currentNode,
@@ -1181,7 +1198,8 @@ export class FileBasedMockData {
                         hierarchyDefinition,
                         _parameters.maximumDistance - 1,
                         0,
-                        lastFilterTransformationResult
+                        lastFilterTransformationResult,
+                        this._mockDataEntitySet.isDraft()
                     );
                 } else if (currentNode && currentNode.$parent) {
                     this.getAncestorsOfNode(
@@ -1191,17 +1209,16 @@ export class FileBasedMockData {
                         hierarchyDefinition,
                         _parameters.maximumDistance - 1,
                         1,
-                        lastFilterTransformationResult
+                        lastFilterTransformationResult,
+                        this._mockDataEntitySet.isDraft()
                     );
                 }
             });
             const outData: object[] = [];
             inputSet.forEach((item: any) => {
-                const subTreeData = ancestors.find((dataItem: any) => {
-                    const mainItem = getData(dataItem, nodeProperty);
-                    const adjustedItem = getData(item, nodeProperty);
-                    return mainItem === adjustedItem;
-                });
+                const subTreeData = ancestors.find((dataItem: any) =>
+                    compareRowData(dataItem, item, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
+                );
                 if (subTreeData) {
                     outData.push({ ...item, ...subTreeData });
                 }

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyDraftAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyDraftAccess.test.ts
@@ -1,0 +1,115 @@
+import CDSMetadataProvider from '@sap-ux/fe-mockserver-plugin-cds';
+import { join } from 'path';
+import type { ServiceConfig } from '../../../src';
+import { DataAccess } from '../../../src/data/dataAccess';
+import { ODataMetadata } from '../../../src/data/metadata';
+import FileSystemLoader from '../../../src/plugins/fileSystemLoader';
+import ODataRequest from '../../../src/request/odataRequest';
+
+jest.setTimeout(3600000);
+describe('Hierarchy with draft', () => {
+    let dataAccess!: DataAccess;
+    let metadata!: ODataMetadata;
+    const baseUrl = '/Hierarchy';
+    const fileLoader = new FileSystemLoader();
+    const metadataProvider = new CDSMetadataProvider(fileLoader);
+
+    beforeAll(async () => {
+        const baseDir = join(__dirname, 'services', 'hierarchy');
+
+        const edmx = await metadataProvider.loadMetadata(join(baseDir, 'draftService.cds'));
+
+        metadata = await ODataMetadata.parse(edmx, baseUrl + '/$metadata');
+        dataAccess = new DataAccess({ mockdataPath: baseDir } as ServiceConfig, metadata, fileLoader);
+    });
+
+    test('Request active instances only', async () => {
+        // Create a draft for EMEA
+        const draftCreateRequest = new ODataRequest(
+            {
+                method: 'POST',
+                url: "/SalesOrganizations(ID='EMEA',IsActiveEntity=true)/v4treedraft.draftEdit?$select=HasActiveEntity,HasDraftEntity,ID,IsActiveEntity&$expand=DraftAdministrativeData($select=DraftIsCreatedByMe,DraftUUID,InProcessByUser)'"
+            },
+            dataAccess
+        );
+        await dataAccess.performAction(draftCreateRequest);
+
+        // Request the hierarchy for all active instances
+        const odataRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: "/SalesOrganizations?$apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(IsActiveEntity eq true),keep start)/com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/SalesOrganizations,HierarchyQualifier='SalesOrgHierarchy',NodeProperty='ID',Levels=2)&$count=true&$select=LimitedDescendantCount,DistanceFromRoot,DrillState,ID,Name&$skip=0&$top=10"
+            },
+            dataAccess
+        );
+
+        expect(odataRequest.applyDefinition).toMatchInlineSnapshot(`
+            [
+              {
+                "parameters": {
+                  "hierarchyRoot": "$root/SalesOrganizations",
+                  "inputSetTransformations": [
+                    {
+                      "filterExpr": {
+                        "expressions": [
+                          {
+                            "identifier": "IsActiveEntity",
+                            "literal": "true",
+                            "operator": "eq",
+                          },
+                        ],
+                      },
+                      "type": "filter",
+                    },
+                  ],
+                  "keepStart": true,
+                  "maximumDistance": -1,
+                  "propertyPath": "ID",
+                  "qualifier": "SalesOrgHierarchy",
+                },
+                "type": "ancestors",
+              },
+              {
+                "name": "com.sap.vocabularies.Hierarchy.v1.TopLevels",
+                "parameters": {
+                  "HierarchyNodes": "$root/SalesOrganizations",
+                  "HierarchyQualifier": "'SalesOrgHierarchy'",
+                  "Levels": "2",
+                  "NodeProperty": "'ID'",
+                },
+                "type": "customFunction",
+              },
+            ]
+        `);
+        const data = await dataAccess.getData(odataRequest);
+
+        expect(data).toMatchInlineSnapshot(`
+            [
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "ID": "Sales",
+                "IsActiveEntity": true,
+                "LimitedDescendantCount": 2,
+                "Name": "Corporate Sales",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "collapsed",
+                "ID": "EMEA",
+                "IsActiveEntity": true,
+                "LimitedDescendantCount": 0,
+                "Name": "EMEA",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "collapsed",
+                "ID": "US",
+                "IsActiveEntity": true,
+                "LimitedDescendantCount": 0,
+                "Name": "US",
+              },
+            ]
+        `);
+    });
+});

--- a/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/draftService.cds
+++ b/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/draftService.cds
@@ -1,0 +1,77 @@
+service v4treedraft {
+  @Aggregation.RecursiveHierarchy#SalesOrgHierarchy: {
+    NodeProperty: ID,
+    ParentNavigationProperty: Superordinate,
+    DistanceFromRootProperty: DistanceFromRoot
+  }
+  @Hierarchy.RecursiveHierarchy#SalesOrgHierarchy: {
+    ExternalKeyProperty: ID,
+    LimitedDescendantCountProperty: LimitedDescendantCount,
+    DistanceFromRootProperty: DistanceFromRoot,
+    DrillStateProperty: DrillState,
+    MatchedProperty: Matched,
+    MatchedDescendantCountProperty: MatchedDescendantCount
+  }
+  @Capabilities.FilterRestrictions: {
+    NonFilterableProperties: [LimitedDescendantCount,DistanceFromRoot,DrillState,Matched,MatchedDescendantCount]
+  }
+  @Capabilities.SortRestrictions: {
+    NonSortableProperties: [LimitedDescendantCount,DistanceFromRoot,DrillState,Matched,MatchedDescendantCount]
+  }
+  @odata.draft.enabled
+  entity SalesOrganizations {
+    key ID : String;
+    Parent : String;
+    Name : String;
+    Superordinate : Association to SalesOrganizations on Superordinate.ID = Parent;
+    _Products : Association to many Products on _Products.SalesOrg = $self;
+    @Core.Computed: true
+    LimitedDescendantCount : Integer64;
+    @Core.Computed: true
+    DistanceFromRoot : Integer64;
+    @Core.Computed: true
+    DrillState : String;
+    @Core.Computed: true
+    Matched : Boolean;
+    @Core.Computed: true
+    MatchedDescendantCount : Integer64;
+  };
+
+  @Aggregation.RecursiveHierarchy#ProductsHierarchy: {
+    NodeProperty: ID,
+    ParentNavigationProperty: Superordinate,
+    DistanceFromRootProperty: DistanceFromRoot
+  }
+  @Hierarchy.RecursiveHierarchy#ProductsHierarchy: {
+    ExternalKeyProperty: ID,
+    LimitedDescendantCountProperty: LimitedDescendantCount,
+    DistanceFromRootProperty: DistanceFromRoot,
+    DrillStateProperty: DrillState,
+    MatchedProperty: Matched,
+    MatchedDescendantCountProperty: MatchedDescendantCount
+  }
+  @Capabilities.FilterRestrictions: {
+    NonFilterableProperties: [LimitedDescendantCount,DistanceFromRoot,DrillState,Matched,MatchedDescendantCount]
+  }
+  @Capabilities.SortRestrictions: {
+    NonSortableProperties: [LimitedDescendantCount,DistanceFromRoot,DrillState,Matched,MatchedDescendantCount]
+  }
+  entity Products {
+    key ID: String;
+    Parent: String;
+    Name: String;
+    SalesOrgID : String;
+    Superordinate : Association to Products on Superordinate.ID = Parent;
+    SalesOrg : Association to SalesOrganizations on SalesOrg.ID = SalesOrgID;
+    @Core.Computed: true
+    LimitedDescendantCount : Integer64;
+    @Core.Computed: true
+    DistanceFromRoot : Integer64;
+    @Core.Computed: true
+    DrillState : String;
+    @Core.Computed: true
+    Matched : Boolean;
+    @Core.Computed: true
+    MatchedDescendantCount : Integer64;
+  }
+}


### PR DESCRIPTION
When displaying a hierarchy for a draft-enabled entity, we only show active instances in the ListReport. Therefore, we add the filter 'IsActiveEntity = true' in the hierarchical query, to ignore draft instances