### PR TITLE
fix: discard a draft in a hierarchy

### DIFF
--- a/.changeset/funny-bears-promise.md
+++ b/.changeset/funny-bears-promise.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Fix recursive delete

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -1070,22 +1070,24 @@ export class FileBasedMockData {
                     const currentNode = parentNodeChildren.find((node: any) =>
                         compareRowData(node, item, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
                     );
-                    if (_parameters.keepStart) {
-                        if (hierarchyDefinition.matchedProperty) {
-                            // TODO compare with lastFilterTransformationResult
-                            setData(currentNode, hierarchyDefinition.matchedProperty, true);
+                    if (currentNode) {
+                        if (_parameters.keepStart) {
+                            if (hierarchyDefinition.matchedProperty) {
+                                // TODO compare with lastFilterTransformationResult
+                                setData(currentNode, hierarchyDefinition.matchedProperty, true);
+                            }
+                            subTrees.push(currentNode);
                         }
-                        subTrees.push(currentNode);
+                        currentNode.$children?.forEach((child: any) => {
+                            this.flattenTree(
+                                child,
+                                subTrees,
+                                nodeProperty,
+                                hierarchyDefinition,
+                                _parameters.maximumDistance
+                            );
+                        });
                     }
-                    currentNode.$children?.forEach((child: any) => {
-                        this.flattenTree(
-                            child,
-                            subTrees,
-                            nodeProperty,
-                            hierarchyDefinition,
-                            _parameters.maximumDistance
-                        );
-                    });
                 }
             });
             const outData: object[] = [];

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyDraftAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyDraftAccess.test.ts
@@ -111,5 +111,46 @@ describe('Hierarchy with draft', () => {
               },
             ]
         `);
+
+        // Delete the draft instance
+        const draftDeleteRequest = new ODataRequest(
+            {
+                method: 'DELETE',
+                url: "/SalesOrganizations(ID='EMEA',IsActiveEntity=false)"
+            },
+            dataAccess
+        );
+        await dataAccess.deleteData(draftDeleteRequest);
+
+        // Reload the hierarchy
+        const dataAfterDelete = await dataAccess.getData(odataRequest);
+        expect(dataAfterDelete).toMatchInlineSnapshot(`
+            [
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "ID": "Sales",
+                "IsActiveEntity": true,
+                "LimitedDescendantCount": 2,
+                "Name": "Corporate Sales",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "collapsed",
+                "ID": "EMEA",
+                "IsActiveEntity": true,
+                "LimitedDescendantCount": 0,
+                "Name": "EMEA",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "collapsed",
+                "ID": "US",
+                "IsActiveEntity": true,
+                "LimitedDescendantCount": 0,
+                "Name": "US",
+              },
+            ]
+        `);
     });
 });


### PR DESCRIPTION
Discarding a draft in a hierarchical service throws an exception