### PR TITLE
feat: Support the new version of the com.sap.vocabularies.Hierarchy

### DIFF
--- a/.changeset/calm-ties-taste.md
+++ b/.changeset/calm-ties-taste.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+feat: Support the new version of the com.sap.vocabularies.Hierarchy

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -1134,25 +1134,40 @@ export class FileBasedMockData {
             sourceReference = this.getSourceReference(aggregationAnnotation!);
             return {
                 distanceFromRootProperty:
-                    getPathOrPropertyPath(hierarchyAnnotation.DistanceFromRootProperty) ?? '$$distanceFromRootProperty',
+                    getPathOrPropertyPath(
+                        hierarchyAnnotation.DistanceFromRoot ?? hierarchyAnnotation.DistanceFromRootProperty
+                    ) ?? '$$distanceFromRootProperty',
                 drillStateProperty:
-                    getPathOrPropertyPath(hierarchyAnnotation.DrillStateProperty) ?? '$$drillStateProperty',
+                    getPathOrPropertyPath(hierarchyAnnotation.DrillState ?? hierarchyAnnotation.DrillStateProperty) ??
+                    '$$drillStateProperty',
                 limitedDescendantCountProperty:
-                    getPathOrPropertyPath(hierarchyAnnotation.LimitedDescendantCountProperty) ??
-                    '$$limitedDescendantCountProperty',
+                    getPathOrPropertyPath(
+                        hierarchyAnnotation.LimitedDescendantCount ?? hierarchyAnnotation.LimitedDescendantCountProperty
+                    ) ?? '$$limitedDescendantCountProperty',
                 matchedDescendantCountProperty:
-                    getPathOrPropertyPath(hierarchyAnnotation.MatchedDescendantCountProperty) ??
-                    '$$matchedDescendantCountProperty',
-                matchedProperty: getPathOrPropertyPath(hierarchyAnnotation.MatchedProperty) ?? '$$matchedProperty',
+                    getPathOrPropertyPath(
+                        hierarchyAnnotation.MatchedDescendantCount ?? hierarchyAnnotation.MatchedDescendantCountProperty
+                    ) ?? '$$matchedDescendantCountProperty',
+                matchedProperty:
+                    getPathOrPropertyPath(hierarchyAnnotation.Matched ?? hierarchyAnnotation.MatchedProperty) ??
+                    '$$matchedProperty',
                 sourceReference
             } as HierarchyDefinition;
         }
         return {
-            distanceFromRootProperty: getPathOrPropertyPath(hierarchyAnnotation.DistanceFromRootProperty),
-            drillStateProperty: getPathOrPropertyPath(hierarchyAnnotation.DrillStateProperty),
-            limitedDescendantCountProperty: getPathOrPropertyPath(hierarchyAnnotation.LimitedDescendantCountProperty),
-            matchedDescendantCountProperty: getPathOrPropertyPath(hierarchyAnnotation.MatchedDescendantCountProperty),
-            matchedProperty: getPathOrPropertyPath(hierarchyAnnotation.MatchedProperty)
+            distanceFromRootProperty: getPathOrPropertyPath(
+                hierarchyAnnotation.DistanceFromRoot ?? hierarchyAnnotation.DistanceFromRootProperty
+            ),
+            drillStateProperty: getPathOrPropertyPath(
+                hierarchyAnnotation.DrillState ?? hierarchyAnnotation.DrillStateProperty
+            ),
+            limitedDescendantCountProperty: getPathOrPropertyPath(
+                hierarchyAnnotation.LimitedDescendantCount ?? hierarchyAnnotation.LimitedDescendantCountProperty
+            ),
+            matchedDescendantCountProperty: getPathOrPropertyPath(
+                hierarchyAnnotation.MatchedDescendantCount ?? hierarchyAnnotation.MatchedDescendantCountProperty
+            ),
+            matchedProperty: getPathOrPropertyPath(hierarchyAnnotation.Matched ?? hierarchyAnnotation.MatchedProperty)
         };
     }
 

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -43,7 +43,6 @@ describe('Hierarchy Access', () => {
               },
             ]
         `);
-        debugger;
         const data = await dataAccess.getData(odataRequest);
         expect(data).toMatchInlineSnapshot(`
             [

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -43,6 +43,7 @@ describe('Hierarchy Access', () => {
               },
             ]
         `);
+        debugger;
         const data = await dataAccess.getData(odataRequest);
         expect(data).toMatchInlineSnapshot(`
             [

--- a/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/draftService.cds
+++ b/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/draftService.cds
@@ -1,16 +1,15 @@
 service v4treedraft {
   @Aggregation.RecursiveHierarchy#SalesOrgHierarchy: {
     NodeProperty: ID,
-    ParentNavigationProperty: Superordinate,
-    DistanceFromRootProperty: DistanceFromRoot
+    ParentNavigationProperty: Superordinate
   }
   @Hierarchy.RecursiveHierarchy#SalesOrgHierarchy: {
-    ExternalKeyProperty: ID,
-    LimitedDescendantCountProperty: LimitedDescendantCount,
-    DistanceFromRootProperty: DistanceFromRoot,
-    DrillStateProperty: DrillState,
-    MatchedProperty: Matched,
-    MatchedDescendantCountProperty: MatchedDescendantCount
+    ExternalKey: ID,
+    LimitedDescendantCount: LimitedDescendantCount,
+    DistanceFromRoot: DistanceFromRoot,
+    DrillState: DrillState,
+    Matched: Matched,
+    MatchedDescendantCount: MatchedDescendantCount
   }
   @Capabilities.FilterRestrictions: {
     NonFilterableProperties: [LimitedDescendantCount,DistanceFromRoot,DrillState,Matched,MatchedDescendantCount]

--- a/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/service.cds
+++ b/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/service.cds
@@ -1,16 +1,15 @@
 service v4tree {
   @Aggregation.RecursiveHierarchy#SalesOrgHierarchy: {
     NodeProperty: ID,
-    ParentNavigationProperty: Superordinate,
-    DistanceFromRootProperty: DistanceFromRoot
+    ParentNavigationProperty: Superordinate
   }
   @Hierarchy.RecursiveHierarchy#SalesOrgHierarchy: {
-    ExternalKeyProperty: ID,
-    LimitedDescendantCountProperty: LimitedDescendantCount,
-    DistanceFromRootProperty: DistanceFromRoot,
-    DrillStateProperty: DrillState,
-    MatchedProperty: Matched,
-    MatchedDescendantCountProperty: MatchedDescendantCount
+    ExternalKey: ID,
+    LimitedDescendantCount: LimitedDescendantCount,
+    DistanceFromRoot: DistanceFromRoot,
+    DrillState: DrillState,
+    Matched: Matched,
+    MatchedDescendantCount: MatchedDescendantCount
   }
   @Capabilities.FilterRestrictions: {
     NonFilterableProperties: [LimitedDescendantCount,DistanceFromRoot,DrillState,Matched,MatchedDescendantCount]


### PR DESCRIPTION
The property names in RecursiveHierarchyType have changed. We support both versions.