### PR TITLE
fix: Correct hierarchy with expanded sub-nodes after draft creation

### DIFF
--- a/.changeset/plenty-experts-try.md
+++ b/.changeset/plenty-experts-try.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+fix: Correct hierarchy with expanded sub-nodes after draft creation

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -915,6 +915,9 @@ export class FileBasedMockData {
             });
             const restOfData = this._mockData
                 .filter((item: any) => {
+                    if (this._mockDataEntitySet.isDraft() && item.IsActiveEntity === false) {
+                        return false;
+                    }
                     return !data.find((dataItem: any) =>
                         compareRowData(dataItem, item, nodeProperty, nodeProperty, this._mockDataEntitySet.isDraft())
                     );


### PR DESCRIPTION
After creating a draft for an existing node, getting the hierarchy with expanded subnodes was returning the nodes in a wrong order.