### PR TITLE
fix: add some index to speed up the resolution of expands

### DIFF
--- a/.changeset/twenty-numbers-yawn.md
+++ b/.changeset/twenty-numbers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Add index to speed up the mockserver

--- a/packages/fe-mockserver-core/src/api.ts
+++ b/packages/fe-mockserver-core/src/api.ts
@@ -29,6 +29,7 @@ export interface ConfigService {
     debug: boolean;
     noETag: boolean;
     contextBasedIsolation: boolean;
+    forceNullableValuesToNull: boolean;
     strictKeyMode: boolean;
     watch: boolean;
 }

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -135,6 +135,7 @@ function prepareLiteral(literal: string, propertyType: string) {
  *
  */
 export class MockDataEntitySet implements EntitySetInterface {
+    private _resolvedProperties: Record<string, Property> = {};
     public static async read(
         mockDataRootFolder: string,
         entity: string,
@@ -302,16 +303,20 @@ export class MockDataEntitySet implements EntitySetInterface {
     }
 
     public getProperty(identifier: string) {
-        let resolvedPath;
-        if (this.entitySetDefinition) {
-            resolvedPath = this.dataAccess
-                .getMetadata()
-                .resolvePath('/' + this.entitySetDefinition.name + '/' + identifier);
-        } else {
-            resolvedPath = this.entityTypeDefinition.resolvePath(identifier, true);
+        if (!this._resolvedProperties[identifier]) {
+            let resolvedPath;
+            if (this.entitySetDefinition) {
+                resolvedPath = this.dataAccess
+                    .getMetadata()
+                    .resolvePath('/' + this.entitySetDefinition.name + '/' + identifier);
+            } else {
+                resolvedPath = this.entityTypeDefinition.resolvePath(identifier, true);
+            }
+
+            this._resolvedProperties[identifier] = resolvedPath;
         }
 
-        return resolvedPath.target;
+        return this._resolvedProperties[identifier];
     }
 
     public checkFilter(

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -313,7 +313,7 @@ export class MockDataEntitySet implements EntitySetInterface {
                 resolvedPath = this.entityTypeDefinition.resolvePath(identifier, true);
             }
 
-            this._resolvedProperties[identifier] = resolvedPath;
+            this._resolvedProperties[identifier] = resolvedPath.target;
         }
 
         return this._resolvedProperties[identifier];

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -234,18 +234,21 @@ export class FileBasedMockData {
 
     fetchEntries(keyValues: KeyDefinitions, _odataRequest: ODataRequest): object[] {
         const keys = this._entityType.keys;
-        if (Object.keys(keyValues).length === keys.length) {
+        const fetchedKeys = Object.keys(keyValues);
+        const areAllKeysMatched = keys.every((key) => {
+            fetchedKeys.includes(key.name);
+        });
+        if (areAllKeysMatched) {
             if (!this._keyIndex) {
                 this.createKeyIndex();
-            } else {
-                const key = keys
-                    .map((keyProp) => {
-                        return keyValues[keyProp.name];
-                    })
-                    .join('-');
-                const value = this._mockData[this._keyIndex[key]];
-                return value ? [value] : [];
             }
+            const key = keys
+                .map((keyProp) => {
+                    return keyValues[keyProp.name];
+                })
+                .join('-');
+            const value = this._mockData[this._keyIndex[key]];
+            return value ? [value] : [];
         }
 
         return this._mockData.filter((mockData) => {
@@ -282,18 +285,25 @@ export class FileBasedMockData {
     }
     protected getDataIndex(keyValues: KeyDefinitions, _odataRequest: ODataRequest): number {
         const keys = this._entityType.keys;
-        if (!this._keyIndex) {
-            this.createKeyIndex();
+        const fetchedKeys = Object.keys(keyValues);
+        const areAllKeysMatched = keys.every((key) => {
+            fetchedKeys.includes(key.name);
+        });
+        if (areAllKeysMatched) {
+            if (!this._keyIndex) {
+                this.createKeyIndex();
+            }
+            const key = keys
+                .map((keyProp) => {
+                    return keyValues[keyProp.name];
+                })
+                .join('-');
+            return this._keyIndex[key] ?? -1;
+        } else {
+            return this._mockData.findIndex((mockData) => {
+                return Object.keys(keyValues).every(this.checkKeyValues(mockData, keyValues, keys, _odataRequest));
+            });
         }
-        const key = keys
-            .map((keyProp) => {
-                return keyValues[keyProp.name];
-            })
-            .join('-');
-        return this._keyIndex[key] ?? -1;
-        // return this._mockData.findIndex((mockData) => {
-        //     return Object.keys(keyValues).every(this.checkKeyValues(mockData, keyValues, keys, _odataRequest));
-        // });
     }
 
     private checkKeyValues(mockData: object, keyValues: KeyDefinitions, keys: Property[], _odataRequest: ODataRequest) {

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -120,6 +120,7 @@ function compareRowData(
 }
 export class FileBasedMockData {
     protected _mockData: object[];
+    protected _keyIndex: Record<string, number>;
     protected _hierarchyTree: Record<string, Record<string, any>> = {};
     protected _entityType: EntityType;
     protected _mockDataEntitySet: EntitySetInterface;
@@ -164,6 +165,11 @@ export class FileBasedMockData {
             } else if (mockEntry.hasOwnProperty(prop.name) && isComplexTypeDefinition(prop.targetType)) {
                 // If the property is defined from a complex type we should validate the property of the complex type
                 this.validateProperties(mockEntry[prop.name], prop.targetType.properties);
+            } else if (
+                mockEntry.hasOwnProperty(prop.name) &&
+                ['Edm.Int16', 'Edm.Int32', 'Edm.Int64'].includes(prop.type)
+            ) {
+                mockEntry[prop.name] = parseInt(mockEntry[prop.name], 10);
             }
         });
     }
@@ -213,6 +219,7 @@ export class FileBasedMockData {
 
     async addEntry(mockEntry: any, _odataRequest: ODataRequest): Promise<void> {
         this._mockData.push(mockEntry);
+        this.createKeyIndex();
     }
 
     async updateEntry(
@@ -227,6 +234,20 @@ export class FileBasedMockData {
 
     fetchEntries(keyValues: KeyDefinitions, _odataRequest: ODataRequest): object[] {
         const keys = this._entityType.keys;
+        if (Object.keys(keyValues).length === keys.length) {
+            if (!this._keyIndex) {
+                this.createKeyIndex();
+            } else {
+                const key = keys
+                    .map((keyProp) => {
+                        return keyValues[keyProp.name];
+                    })
+                    .join('-');
+                const value = this._mockData[this._keyIndex[key]];
+                return value ? [value] : [];
+            }
+        }
+
         return this._mockData.filter((mockData) => {
             return Object.keys(keyValues).every(this.checkKeyValues(mockData, keyValues, keys, _odataRequest));
         });
@@ -247,11 +268,32 @@ export class FileBasedMockData {
         return cloneDeep(this._mockData);
     }
 
+    protected createKeyIndex() {
+        const keys = this._entityType.keys;
+        this._keyIndex = {};
+        this._mockData.forEach((mockData: any, index: number) => {
+            const key = keys
+                .map((keyProp) => {
+                    return mockData[keyProp.name];
+                })
+                .join('-');
+            this._keyIndex[key] = index;
+        });
+    }
     protected getDataIndex(keyValues: KeyDefinitions, _odataRequest: ODataRequest): number {
         const keys = this._entityType.keys;
-        return this._mockData.findIndex((mockData) => {
-            return Object.keys(keyValues).every(this.checkKeyValues(mockData, keyValues, keys, _odataRequest));
-        });
+        if (!this._keyIndex) {
+            this.createKeyIndex();
+        }
+        const key = keys
+            .map((keyProp) => {
+                return keyValues[keyProp.name];
+            })
+            .join('-');
+        return this._keyIndex[key] ?? -1;
+        // return this._mockData.findIndex((mockData) => {
+        //     return Object.keys(keyValues).every(this.checkKeyValues(mockData, keyValues, keys, _odataRequest));
+        // });
     }
 
     private checkKeyValues(mockData: object, keyValues: KeyDefinitions, keys: Property[], _odataRequest: ODataRequest) {
@@ -271,6 +313,7 @@ export class FileBasedMockData {
         if (dataIndex !== -1) {
             this._mockData.splice(dataIndex, 1);
         }
+        this.createKeyIndex();
     }
 
     protected getDefaultValueFromType(

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -236,7 +236,7 @@ export class FileBasedMockData {
         const keys = this._entityType.keys;
         const fetchedKeys = Object.keys(keyValues);
         const areAllKeysMatched = keys.every((key) => {
-            fetchedKeys.includes(key.name);
+            return fetchedKeys.includes(key.name);
         });
         if (areAllKeysMatched) {
             if (!this._keyIndex) {
@@ -244,6 +244,10 @@ export class FileBasedMockData {
             }
             const key = keys
                 .map((keyProp) => {
+                    const keyValue = keyValues[keyProp.name];
+                    if (keyValue && typeof keyValue === 'string' && keyValue.startsWith("guid'")) {
+                        return keyValue.substring(5, keyValue.length - 1);
+                    }
                     return keyValues[keyProp.name];
                 })
                 .join('-');
@@ -287,7 +291,7 @@ export class FileBasedMockData {
         const keys = this._entityType.keys;
         const fetchedKeys = Object.keys(keyValues);
         const areAllKeysMatched = keys.every((key) => {
-            fetchedKeys.includes(key.name);
+            return fetchedKeys.includes(key.name);
         });
         if (areAllKeysMatched) {
             if (!this._keyIndex) {
@@ -295,6 +299,10 @@ export class FileBasedMockData {
             }
             const key = keys
                 .map((keyProp) => {
+                    const keyValue = keyValues[keyProp.name];
+                    if (keyValue && typeof keyValue === 'string' && keyValue.startsWith("guid'")) {
+                        return keyValue.substring(5, keyValue.length - 1);
+                    }
                     return keyValues[keyProp.name];
                 })
                 .join('-');

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -297,25 +297,6 @@ export class FileBasedMockData {
         const entryFromKeys = this.fetchIndexFromKey(keys, keyValues, _odataRequest);
         if (entryFromKeys) {
             return entryFromKeys;
-        }
-        const fetchedKeys = Object.keys(keyValues);
-        const areAllKeysMatched = keys.every((key) => {
-            return fetchedKeys.includes(key.name);
-        });
-        if (areAllKeysMatched) {
-            if (!this._keyIndex) {
-                this.createKeyIndex();
-            }
-            const key = keys
-                .map((keyProp) => {
-                    const keyValue = keyValues[keyProp.name];
-                    if (keyValue && typeof keyValue === 'string' && keyValue.startsWith("guid'")) {
-                        return keyValue.substring(5, keyValue.length - 1);
-                    }
-                    return keyValues[keyProp.name];
-                })
-                .join('-');
-            return this._keyIndex[key] ?? -1;
         } else {
             return this._mockData.findIndex((mockData) => {
                 return Object.keys(keyValues).every(this.checkKeyValues(mockData, keyValues, keys, _odataRequest));

--- a/packages/ui5-middleware-fe-mockserver/src/configResolver.ts
+++ b/packages/ui5-middleware-fe-mockserver/src/configResolver.ts
@@ -80,7 +80,8 @@ function processServicesConfig(
             debug: inService.debug,
             strictKeyMode: inService.strictKeyMode,
             generateMockData: inService.generateMockData,
-            contextBasedIsolation: inService.contextBasedIsolation
+            contextBasedIsolation: inService.contextBasedIsolation,
+            forceNullableValuesToNull: inService.forceNullableValuesToNull
         } as any;
         const metadataPath = inService.metadataPath || inService.metadataXmlPath || inService.metadataCdsPath;
         if (metadataPath) {


### PR DESCRIPTION
Some expand / join calls were too slow for my taste.
I've introduced a simple stupid index based approach to speed things up