### PR TITLE
fix: hierarchy issue with integer nodes

### DIFF
--- a/.changeset/four-experts-approve.md
+++ b/.changeset/four-experts-approve.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+Fix issue with the hierarchy due to integer based handling

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -169,7 +169,11 @@ export class FileBasedMockData {
                 mockEntry.hasOwnProperty(prop.name) &&
                 ['Edm.Int16', 'Edm.Int32', 'Edm.Int64'].includes(prop.type)
             ) {
-                mockEntry[prop.name] = parseInt(mockEntry[prop.name], 10);
+                if (mockEntry[prop.name] === '') {
+                    mockEntry[prop.name] = ''; // hierarchy root node  case
+                } else {
+                    mockEntry[prop.name] = parseInt(mockEntry[prop.name], 10);
+                }
             }
         });
     }


### PR DESCRIPTION
the parseInt messed up the hierarchy calculations