### PR TITLE
feat: introduce a basic support for etags

### DIFF
--- a/.changeset/brave-lizards-battle.md
+++ b/.changeset/brave-lizards-battle.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/ui5-middleware-fe-mockserver': patch
+'@sap-ux/fe-mockserver-core': patch
+---
+
+feat: introduce a basic support for entity ETags

--- a/packages/fe-mockserver-core/src/api.ts
+++ b/packages/fe-mockserver-core/src/api.ts
@@ -28,6 +28,7 @@ export interface ConfigService {
     cdsServiceName?: string;
     debug: boolean;
     noETag: boolean;
+    validateETag: boolean;
     contextBasedIsolation: boolean;
     forceNullableValuesToNull: boolean;
     strictKeyMode: boolean;
@@ -50,6 +51,7 @@ export interface BaseServerConfig {
     debug?: boolean;
     watch?: boolean;
     noETag?: boolean;
+    validateETag?: boolean;
     contextBasedIsolation?: boolean;
     generateMockData?: boolean;
     forceNullableValuesToNull?: boolean;
@@ -85,6 +87,7 @@ export type ServiceConfig = {
     watch?: boolean; // should be forced to false in browser
     noETag?: boolean; // should be forced to true in browser
     contextBasedIsolation?: boolean;
+    validateETag?: boolean;
 };
 
 export type ServiceConfigEx = ServiceConfig & {

--- a/packages/fe-mockserver-core/src/data/common.ts
+++ b/packages/fe-mockserver-core/src/data/common.ts
@@ -64,10 +64,12 @@ export interface EntitySetInterface {
     getEntityInterface(entitySetName: string, tenantId: string): Promise<FileBasedMockData | undefined>;
     getMockData(tenantId: string): FileBasedMockData;
     isV4(): boolean;
+    shouldValidateETag(): boolean;
     isDraft(): boolean;
 }
 export interface DataAccessInterface {
     isV4(): boolean;
+    shouldValidateETag(): boolean;
     getNavigationPropertyKeys(
         data: any,
         navPropDetail: NavigationProperty,

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -295,6 +295,10 @@ export class MockDataEntitySet implements EntitySetInterface {
         return this.dataAccess.isV4();
     }
 
+    public shouldValidateETag(): boolean {
+        return this.dataAccess.shouldValidateETag();
+    }
+
     public isDraft(): boolean {
         return !!(
             this.entitySetDefinition?.annotations.Common?.DraftRoot ??

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -179,9 +179,11 @@ export class FileBasedMockData {
                 }
             }
         });
-        const currentDate = _getDateTimeOffset(true);
-        if (topLevel) {
-            mockEntry['@odata.etag'] = `W/\"${currentDate}\"`;
+        if (this._mockDataEntitySet?.shouldValidateETag?.()) {
+            const currentDate = _getDateTimeOffset(true);
+            if (topLevel) {
+                mockEntry['@odata.etag'] = `W/\"${currentDate}\"`;
+            }
         }
     }
     public cleanupHierarchies() {
@@ -240,7 +242,7 @@ export class FileBasedMockData {
         _odataRequest: ODataRequest
     ): Promise<void> {
         if (
-            this._mockDataEntitySet.shouldValidateETag() &&
+            this._mockDataEntitySet.shouldValidateETag?.() &&
             _odataRequest.etagReference !== updatedData['@odata.etag']
         ) {
             throw new ExecutionError(
@@ -252,7 +254,10 @@ export class FileBasedMockData {
         }
         const dataIndex = this.getDataIndex(keyValues, _odataRequest);
         const currentDate = _getDateTimeOffset(true);
-        updatedData['@odata.etag'] = `W/\"${currentDate}\"`;
+        if (this._mockDataEntitySet?.shouldValidateETag?.()) {
+            updatedData['@odata.etag'] = `W/\"${currentDate}\"`;
+        }
+
         this._mockData[dataIndex] = updatedData;
         this.createKeyIndex();
     }
@@ -590,8 +595,10 @@ export class FileBasedMockData {
                 outObj[navigationProperty.name] = [];
             }
         });
-        const currentDate = _getDateTimeOffset(true);
-        outObj['@odata.etag'] = `W/\"${currentDate}\"`;
+        if (this._mockDataEntitySet?.shouldValidateETag?.()) {
+            const currentDate = _getDateTimeOffset(true);
+            outObj['@odata.etag'] = `W/\"${currentDate}\"`;
+        }
         return outObj;
     }
 

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -182,7 +182,7 @@ export class FileBasedMockData {
         if (this._mockDataEntitySet?.shouldValidateETag?.()) {
             const currentDate = _getDateTimeOffset(true);
             if (topLevel) {
-                mockEntry['@odata.etag'] = `W/\"${currentDate}\"`;
+                mockEntry['@odata.etag'] = `W/\\"${currentDate}\\"`;
             }
         }
     }
@@ -255,7 +255,7 @@ export class FileBasedMockData {
         const dataIndex = this.getDataIndex(keyValues, _odataRequest);
         const currentDate = _getDateTimeOffset(true);
         if (this._mockDataEntitySet?.shouldValidateETag?.()) {
-            updatedData['@odata.etag'] = `W/\"${currentDate}\"`;
+            updatedData['@odata.etag'] = `W/\\"${currentDate}\\"`;
         }
 
         this._mockData[dataIndex] = updatedData;
@@ -597,7 +597,7 @@ export class FileBasedMockData {
         });
         if (this._mockDataEntitySet?.shouldValidateETag?.()) {
             const currentDate = _getDateTimeOffset(true);
-            outObj['@odata.etag'] = `W/\"${currentDate}\"`;
+            outObj['@odata.etag'] = `W/\\"${currentDate}\\"`;
         }
         return outObj;
     }

--- a/packages/fe-mockserver-core/src/router/batchRouter.ts
+++ b/packages/fe-mockserver-core/src/router/batchRouter.ts
@@ -28,6 +28,9 @@ async function handlePart(
     if (partDefinition.contentId) {
         batchResponse += `Content-ID: ${partDefinition.contentId}${NL}`;
     }
+    if (partRequest.getETag()) {
+        batchResponse += `ETag: ${partRequest.getETag()}${NL}`;
+    }
     batchResponse += NL;
     const responseData = partRequest.getResponseData();
     batchResponse += `HTTP/1.1 ${partRequest.statusCode} ${http.STATUS_CODES[partRequest.statusCode]}${NL}`;

--- a/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
@@ -662,7 +662,6 @@ exports[`V4 Requestor can update data through a call 1`] = `
 exports[`V4 Requestor can update data through a call 2`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=556)",
-  "@odata.etag": "W/"2024-07-01T10:01:31.747Z"",
   "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
@@ -687,7 +686,6 @@ exports[`V4 Requestor can update data through a call 3`] = `
 exports[`V4 Requestor can update data through a call 4`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=556)/Prop1",
-  "@odata.etag": "W/"2024-07-01T10:01:31.781Z"",
   "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
@@ -705,7 +703,6 @@ exports[`V4 Requestor can update data through a call 4`] = `
 exports[`V4 Requestor get one data 1`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=2)",
-  "@odata.etag": "W/"2024-07-01T10:01:31.612Z"",
   "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
@@ -725,7 +722,6 @@ exports[`V4 Requestor get one data 2`] = `""`;
 exports[`V4 Requestor get one data 3`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=2)",
-  "@odata.etag": "W/"2024-07-01T10:01:31.646Z"",
   "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,

--- a/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
@@ -662,6 +662,7 @@ exports[`V4 Requestor can update data through a call 1`] = `
 exports[`V4 Requestor can update data through a call 2`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=556)",
+  "@odata.etag": "W/"2024-07-01T10:01:31.747Z"",
   "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
@@ -678,13 +679,21 @@ exports[`V4 Requestor can update data through a call 2`] = `
 
 exports[`V4 Requestor can update data through a call 3`] = `
 {
+  "code": 412001,
+  "message": "ETag condition not met",
+}
+`;
+
+exports[`V4 Requestor can update data through a call 4`] = `
+{
   "@odata.context": "$metadata#RootElement(ID=556)/Prop1",
+  "@odata.etag": "W/"2024-07-01T10:01:31.781Z"",
   "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 556,
   "IsActiveEntity": false,
-  "Prop1": "Lali-ho",
+  "Prop1": "Lali-hoho",
   "Prop2": "",
   "Sibling_ID": 0,
   "isBoundAction1Hidden": false,
@@ -696,6 +705,7 @@ exports[`V4 Requestor can update data through a call 3`] = `
 exports[`V4 Requestor get one data 1`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=2)",
+  "@odata.etag": "W/"2024-07-01T10:01:31.612Z"",
   "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
@@ -715,6 +725,7 @@ exports[`V4 Requestor get one data 2`] = `""`;
 exports[`V4 Requestor get one data 3`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=2)",
+  "@odata.etag": "W/"2024-07-01T10:01:31.646Z"",
   "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -17,7 +17,8 @@ describe('V4 Requestor', function () {
                     metadataPath: path.join(__dirname, '__testData', 'service.cds'),
                     mockdataPath: path.join(__dirname, '__testData'),
                     urlPath: '/sap/fe/core/mock/action',
-                    watch: true
+                    watch: true,
+                    validateETag: true
                 },
                 {
                     metadataPath: path.join(__dirname, '__testData', 'service2.cds'),
@@ -125,6 +126,7 @@ describe('V4 Requestor', function () {
               "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
               "value": [
                 {
+                  "@odata.etag": "W/"2024-07-01T10:01:31.347Z"",
                   "HasActiveEntity": true,
                   "HasDraftEntity": false,
                   "ID": 1,
@@ -137,6 +139,7 @@ describe('V4 Requestor', function () {
                   "sibling_ID": 2,
                 },
                 {
+                  "@odata.etag": "W/"2024-07-01T10:01:31.347Z"",
                   "HasActiveEntity": true,
                   "HasDraftEntity": false,
                   "ID": 2,
@@ -149,6 +152,7 @@ describe('V4 Requestor', function () {
                   "sibling_ID": 1,
                 },
                 {
+                  "@odata.etag": "W/"2024-07-01T10:01:31.347Z"",
                   "HasActiveEntity": true,
                   "HasDraftEntity": false,
                   "ID": 3,
@@ -313,10 +317,17 @@ describe('V4 Requestor', function () {
         const res2 = await dataRequestor.updateData<any>('RootElement(ID=556)/Prop1', 'Lali-ho', true, 'PUT').execute();
         delete res2.body.DraftAdministrativeData;
         expect(res2.body).toMatchSnapshot();
+        const res3 = await dataRequestor
+            .updateData<any>('RootElement(ID=556)/Prop1', 'Lali-hoho', true, 'PUT', {
+                'If-Match': dataRes2[4]['@odata.etag']
+            })
+            .execute();
+        delete res3.body.DraftAdministrativeData;
+        expect(res3.body).toMatchSnapshot();
         const dataRes3 = await dataRequestor.getList<any>('RootElement').executeAsBatch();
         expect(dataRes3.length).toBe(5);
         expect(dataRes3[4].ID).toBe(556);
-        expect(dataRes3[4].Prop1).toBe('Lali-ho');
+        expect(dataRes3[4].Prop1).toBe('Lali-hoho');
     });
     describe('Sticky', () => {
         const dataRequestor = new ODataV4Requestor('http://localhost:33331/tenant-0/sap/fe/core/mock/sticky');

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -119,6 +119,9 @@ describe('V4 Requestor', function () {
         const dataRes2 = await dataRequestor
             .callGETAction('/RootElement(ID=1,IsActiveEntity=true)/_Elements')
             .execute();
+        for (const dataRes2Element of (dataRes2.body as any).value) {
+            delete dataRes2Element['@odata.etag'];
+        }
         expect(dataRes2.body).toMatchInlineSnapshot(`
             {
               "@odata.context": "$metadata#RootElement(ID=1,IsActiveEntity=true)/_Elements",
@@ -126,7 +129,6 @@ describe('V4 Requestor', function () {
               "@odata.metadataEtag": "W/"60af-tCc45VlNT7csKPRiK0amTPyY35E"",
               "value": [
                 {
-                  "@odata.etag": "W/"2024-07-01T10:01:31.347Z"",
                   "HasActiveEntity": true,
                   "HasDraftEntity": false,
                   "ID": 1,
@@ -139,7 +141,6 @@ describe('V4 Requestor', function () {
                   "sibling_ID": 2,
                 },
                 {
-                  "@odata.etag": "W/"2024-07-01T10:01:31.347Z"",
                   "HasActiveEntity": true,
                   "HasDraftEntity": false,
                   "ID": 2,
@@ -152,7 +153,6 @@ describe('V4 Requestor', function () {
                   "sibling_ID": 1,
                 },
                 {
-                  "@odata.etag": "W/"2024-07-01T10:01:31.347Z"",
                   "HasActiveEntity": true,
                   "HasDraftEntity": false,
                   "ID": 3,
@@ -247,19 +247,23 @@ describe('V4 Requestor', function () {
         // expect(dataRes).toMatchSnapshot();
         let dataRequestor = new ODataV4Requestor('http://localhost:33331/tenant-002/sap/fe/core/mock/action');
         let dataRes = await dataRequestor.getObject<any>('RootElement', { ID: 2 }).executeAsBatch();
+        delete dataRes['@odata.etag'];
         expect(dataRes).toMatchSnapshot();
 
         dataRequestor = new ODataV4Requestor('http://localhost:33331/tenant-002/sap/fe/core/mock/action');
         dataRes = await dataRequestor.getObject<any>('RootElement', { ID: 233 }).executeAsBatch();
+        delete dataRes['@odata.etag'];
         expect(dataRes).toMatchSnapshot();
 
         dataRequestor = new ODataV4Requestor('http://localhost:33331/tenant-003/sap/fe/core/mock/action');
         dataRes = await dataRequestor.getObject<any>('RootElement', { ID: 2 }).executeAsBatch();
+        delete dataRes['@odata.etag'];
         expect(dataRes).toMatchSnapshot();
         dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');
         const dataResClient = await dataRequestor
             .getObject<any>('RootElement', { ID: 2 })
             .executeAsBatch(false, '?sap-client=003');
+        delete dataResClient['@odata.etag'];
         expect(dataResClient).toEqual(dataRes);
     });
 
@@ -300,9 +304,11 @@ describe('V4 Requestor', function () {
         const dataRequestor = new ODataV4Requestor('http://localhost:33331/tenant-001/sap/fe/core/mock/action');
         let dataRes = await dataRequestor.createData<any>('RootElement', { ID: 556 }).execute();
         delete dataRes.body.DraftAdministrativeData;
+        delete dataRes.body['@odata.etag'];
         expect(dataRes.body).toMatchSnapshot();
         dataRes = await dataRequestor.updateData<any>('RootElement(ID=556)', { Prop1: 'MyNewProp1' }).execute();
         delete dataRes.body.DraftAdministrativeData;
+        delete dataRes.body['@odata.etag'];
         expect(dataRes.body).toMatchSnapshot();
         const dataRes2 = await dataRequestor.getList<any>('RootElement').executeAsBatch();
         expect(dataRes2.length).toBe(5);
@@ -323,6 +329,7 @@ describe('V4 Requestor', function () {
             })
             .execute();
         delete res3.body.DraftAdministrativeData;
+        delete res3.body['@odata.etag'];
         expect(res3.body).toMatchSnapshot();
         const dataRes3 = await dataRequestor.getList<any>('RootElement').executeAsBatch();
         expect(dataRes3.length).toBe(5);

--- a/packages/fe-mockserver-core/test/unit/v4/__snapshots__/unboundAction.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/v4/__snapshots__/unboundAction.test.ts.snap
@@ -23,6 +23,7 @@ exports[`Unbound Action can call the base interface 1`] = `
 exports[`Unbound Action can call the base interface 2`] = `
 [
   {
+    "@odata.etag": "W/"2024-07-01T10:01:46.914Z"",
     "BooleanProperty": false,
     "Currency": "",
     "DescriptionProperty": "",

--- a/packages/fe-mockserver-core/test/unit/v4/__snapshots__/unboundAction.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/v4/__snapshots__/unboundAction.test.ts.snap
@@ -23,7 +23,6 @@ exports[`Unbound Action can call the base interface 1`] = `
 exports[`Unbound Action can call the base interface 2`] = `
 [
   {
-    "@odata.etag": "W/"2024-07-01T10:01:46.914Z"",
     "BooleanProperty": false,
     "Currency": "",
     "DescriptionProperty": "",

--- a/packages/ui5-middleware-fe-mockserver/src/configResolver.ts
+++ b/packages/ui5-middleware-fe-mockserver/src/configResolver.ts
@@ -121,7 +121,7 @@ function processServicesConfig(
         if (inConfig.forceNullableValuesToNull && !inService.hasOwnProperty('forceNullableValuesToNull')) {
             myServiceConfig.forceNullableValuesToNull = inConfig.forceNullableValuesToNull;
         }
-        if (inConfig.validateETag && !inService.hasOwnProperty('forceNullableValuesToNull')) {
+        if (inConfig.validateETag && !inService.hasOwnProperty('validateETag')) {
             myServiceConfig.validateETag = inConfig.validateETag;
         }
 

--- a/packages/ui5-middleware-fe-mockserver/src/configResolver.ts
+++ b/packages/ui5-middleware-fe-mockserver/src/configResolver.ts
@@ -77,6 +77,7 @@ function processServicesConfig(
             watch: inService.watch,
             urlPath: inService.urlPath,
             noETag: inService.noETag,
+            validateETag: inService.validateETag,
             debug: inService.debug,
             strictKeyMode: inService.strictKeyMode,
             generateMockData: inService.generateMockData,
@@ -119,6 +120,9 @@ function processServicesConfig(
         }
         if (inConfig.forceNullableValuesToNull && !inService.hasOwnProperty('forceNullableValuesToNull')) {
             myServiceConfig.forceNullableValuesToNull = inConfig.forceNullableValuesToNull;
+        }
+        if (inConfig.validateETag && !inService.hasOwnProperty('forceNullableValuesToNull')) {
+            myServiceConfig.validateETag = inConfig.validateETag;
         }
 
         return myServiceConfig;


### PR DESCRIPTION
Introduced a new service configuration settings `validateETag` that should force a 412 error when an update doesn't contain the proper If-Match value