### PR TITLE
fix: update batchResponse in case of 412 warnings for changeset

### DIFF
--- a/.changeset/flat-mangos-learn.md
+++ b/.changeset/flat-mangos-learn.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+update to the batchResponse in case of 412 warnings for changeset

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -497,8 +497,11 @@ Content-Type:application/json;charset=UTF-8;IEEE754Compatible=true
 --batch_id-1719917686303-234--
 Group ID: $auto`
         });
+        const expectedResponse =
+            '--batch_id-1719917686303-234\r\nContent-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n\r\nHTTP/1.1 412 Precondition Failed\r\nsap-tenantid: tenant-default\r\nPreference-Applied: handling=strict\r\ncontent-type: application/json;odata.metadata=minimal;IEEE754Compatible=true\r\nodata-version: 4.0\r\n\r\n\r\n{"error":{"code":412,"message":"Unable to execute the action due to a warning.","details":[{"code":"null","message":"Unable to execute the action due to a warning.","@Core.ContentID":"0.0"},{"code":"null","message":"Unable to execute the action due to a warning.","@Core.ContentID":"1.0"}]}}\r\n--batch_id-1719917686303-234--\r\n';
         const responseStr = await response.text();
         const responseJson: any = getJsonFromMultipartContent(responseStr);
+        expect(responseStr).toEqual(expectedResponse);
         expect(responseJson[0].error.code).toEqual(412);
         expect(responseJson[0].error.details.length).toBe(2);
     });
@@ -558,9 +561,8 @@ Group ID: $auto`
         });
         const responseStr = await response.text();
         const responseJson: any = getJsonFromMultipartContent(responseStr);
-        expect(responseJson[0].error.code).toEqual(500);
-        expect(responseJson[1].error.code).toEqual(412);
-        expect(responseJson[1].error.details.length).toBe(2);
+        expect(responseJson[0].error.code).toEqual(412);
+        expect(responseJson[0].error.details.length).toBe(2);
     });
     beforeAll(() => {
         const myJSON = JSON.parse(


### PR DESCRIPTION
In case of 412 warnings for changeset request with strict handling, only a single error response needs to be returned with error details per context as part of the error details array. (override any other response if any)
To comply with models requirements to retrigger the selected contexts on confirmation by user
- remove changeset boundary 
- remove content-id in the inner HTTP response, include @Core.ContentId property in the error details only