### PR TITLE
feat: make the fetchEntries / getAllEntries / onAfterRead method asynchronous

### DIFF
--- a/.changeset/happy-colts-fail.md
+++ b/.changeset/happy-colts-fail.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': minor
+---
+
+Make the fetchEntries / getAllEntries method async

--- a/docs/MockserverAPI.md
+++ b/docs/MockserverAPI.md
@@ -78,6 +78,12 @@ async onAfterAction(actionDefinition, actionData, keys, responseData, odataReque
 }
 ```
 
+### onAfterRead
+
+Provides hooks after an entity is read, this is mostly used to provide additional handling on top of the standard mechanism in order to modify the returned data.
+
+- `onAfterRead(data: object, odataRequest:ODataRequest): Promise<object>;`
+
 ### onBeforeUpdateEntry / onAfterUpdateEntry
 
 Provides hook before and after an entry is updated, this is mostly used to provide additional handling on top of the standard mechanism.

--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -921,6 +921,8 @@ export class DataAccess implements DataAccessInterface {
 
             if (isCount) {
                 data = dataLength;
+            } else {
+                data = await mockEntitySet.getMockData(odataRequest.tenantId).onAfterRead(data, odataRequest);
             }
         }
 
@@ -968,7 +970,9 @@ export class DataAccess implements DataAccessInterface {
             const navPropDetail = entityType.navigationProperties.find((navProp) => navProp.name === lastNavPropName);
             if (navPropDetail) {
                 const navPropEntityType = navPropDetail.targetType;
-                const data: any = (await this.getMockEntitySet(parentEntitySet.name)).performGET(
+                const data: any = await (
+                    await this.getMockEntitySet(parentEntitySet.name)
+                ).performGET(
                     odataRequest.queryPath[odataRequest.queryPath.length - 2].keys,
                     false,
                     odataRequest.tenantId,
@@ -1352,7 +1356,7 @@ export class DataAccess implements DataAccessInterface {
             case 'ancestors':
                 const limitedHierarchyForAncestors = await this.applyTransformation(
                     transformationDef.parameters.inputSetTransformations[0],
-                    mockData.getAllEntries(odataRequest),
+                    await mockData.getAllEntries(odataRequest),
                     odataRequest,
                     mockEntitySet,
                     mockData,
@@ -1382,7 +1386,7 @@ export class DataAccess implements DataAccessInterface {
             case 'descendants':
                 const limitedHierarchyData = await this.applyTransformation(
                     transformationDef.parameters.inputSetTransformations[0],
-                    mockData.getAllEntries(odataRequest),
+                    await mockData.getAllEntries(odataRequest),
                     odataRequest,
                     mockEntitySet,
                     mockData,

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -520,17 +520,17 @@ export class MockDataEntitySet implements EntitySetInterface {
         }
     }
 
-    public performGET(
+    public async performGET(
         keyValues: KeyDefinitions,
         asArray: boolean,
         tenantId: string,
         odataRequest: ODataRequest,
         dontClone = false
-    ): any {
+    ): Promise<any> {
         const currentMockData = this.getMockData(tenantId);
         if (keyValues && Object.keys(keyValues).length) {
             keyValues = this.prepareKeys(keyValues);
-            const data = currentMockData.fetchEntries(keyValues, odataRequest);
+            const data = await currentMockData.fetchEntries(keyValues, odataRequest);
             if (!data || (Array.isArray(data) && data.length === 0 && !asArray)) {
                 if (!currentMockData.hasEntries(odataRequest)) {
                     return currentMockData.getEmptyObject(odataRequest);
@@ -557,7 +557,7 @@ export class MockDataEntitySet implements EntitySetInterface {
         if (!asArray) {
             return cloneDeep(currentMockData.getDefaultElement(odataRequest));
         }
-        return currentMockData.getAllEntries(odataRequest, dontClone);
+        return await currentMockData.getAllEntries(odataRequest, dontClone);
     }
 
     public async performPOST(
@@ -622,7 +622,7 @@ export class MockDataEntitySet implements EntitySetInterface {
         _updateParent: boolean = false
     ): Promise<any> {
         keyValues = this.prepareKeys(keyValues);
-        const data = this.performGET(keyValues, false, tenantId, odataRequest);
+        const data = await this.performGET(keyValues, false, tenantId, odataRequest);
         if (!data) {
             throw new ExecutionError('Not found', 404, undefined, false);
         }
@@ -672,7 +672,7 @@ export class MockDataEntitySet implements EntitySetInterface {
         const currentMockData = this.getMockData(tenantId);
         keyValues = this.prepareKeys(keyValues);
 
-        const entryToRemove = currentMockData.fetchEntries(keyValues, odataRequest);
+        const entryToRemove = await currentMockData.fetchEntries(keyValues, odataRequest);
         let additionalEntriesToRemove: any[] = [];
         for (const aggregationElementName in this.entityTypeDefinition.annotations.Aggregation) {
             if (aggregationElementName.startsWith('RecursiveHierarchy')) {
@@ -680,7 +680,7 @@ export class MockDataEntitySet implements EntitySetInterface {
                     this.entityTypeDefinition.annotations.Aggregation[
                         aggregationElementName as `RecursiveHierarchy#xxx`
                     ]!;
-                const allData = currentMockData.getAllEntries(odataRequest, true);
+                const allData = await currentMockData.getAllEntries(odataRequest, true);
                 additionalEntriesToRemove = await currentMockData.getDescendants(
                     allData,
                     allData,

--- a/packages/fe-mockserver-core/src/data/entitySets/stickyEntitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/stickyEntitySet.ts
@@ -101,7 +101,7 @@ export class StickyMockEntitySet extends MockDataEntitySet {
         odataRequest: ODataRequest
     ): Promise<any> {
         keyValues = this.prepareKeys(keyValues);
-        const data = this.performGET(keyValues, false, tenantId, odataRequest);
+        const data = await this.performGET(keyValues, false, tenantId, odataRequest);
         if (!data) {
             throw new ExecutionError('Not found', 404, undefined, false);
         }
@@ -133,7 +133,7 @@ export class StickyMockEntitySet extends MockDataEntitySet {
         switch (actionDefinition.fullyQualifiedName) {
             // Draft Edit Action
             case `${this.entitySetDefinition?.annotations?.Session?.StickySessionSupported?.EditAction}(${actionDefinition.sourceType})`: {
-                const data = this.performGET(keys, false, odataRequest.tenantId, odataRequest);
+                const data = await this.performGET(keys, false, odataRequest.tenantId, odataRequest);
                 const duplicate = Object.assign({}, data);
 
                 this.createSession(duplicate).addSessionToken(odataRequest);
@@ -192,13 +192,13 @@ export class StickyMockEntitySet extends MockDataEntitySet {
         return responseObject;
     }
 
-    public performGET(
+    public async performGET(
         keyValues: KeyDefinitions,
         asArray: boolean,
         tenantId: string,
         odataRequest: ODataRequest,
         dontClone = false
-    ): any {
+    ): Promise<any> {
         const session = this.getSession(odataRequest);
         if (session && keyValues && Object.keys(keyValues).length) {
             if (

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -281,7 +281,7 @@ export class FileBasedMockData {
         return keyIndex[key] ?? -1;
     }
 
-    fetchEntries(keyValues: KeyDefinitions, _odataRequest: ODataRequest): object[] {
+    async fetchEntries(keyValues: KeyDefinitions, _odataRequest: ODataRequest): Promise<object[]> {
         const keys = this._entityType.keys;
         const indexFromKey = this.fetchIndexFromKey(keys, keyValues, _odataRequest);
         if (indexFromKey !== false) {
@@ -303,7 +303,7 @@ export class FileBasedMockData {
         return this._mockData.length > 0;
     }
 
-    getAllEntries(_odataRequest: ODataRequest, dontClone: boolean = false): any[] {
+    async getAllEntries(_odataRequest: ODataRequest, dontClone: boolean = false): Promise<any[]> {
         if (dontClone) {
             return this._mockData;
         }
@@ -689,6 +689,10 @@ export class FileBasedMockData {
         _odataRequest: ODataRequest
     ): Promise<void> {
         // DO Nothing
+    }
+
+    async onAfterRead(data: object, _odataRequest: ODataRequest): Promise<object> {
+        return data;
     }
     //eslint-disable-next-line
     hasCustomAggregate(_customAggregateName: string, _odataRequest: ODataRequest): boolean {

--- a/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/functionBasedMockData.ts
@@ -66,6 +66,7 @@ export type MockDataContributor<T extends object> = {
         responseData: any,
         odataRequest: ODataRequest
     ): Promise<any>;
+    onAfterRead?(data: T, odataRequest: ODataRequest): Promise<T>;
     onAfterUpdateEntry?(keyValues: KeyDefinitions, updatedData: T, odataRequest: ODataRequest): Promise<void>;
     onBeforeUpdateEntry?(keyValues: KeyDefinitions, updatedData: T, odataRequest: ODataRequest): Promise<void>;
     hasCustomAggregate?(customAggregateName: string, odataRequest: ODataRequest): boolean;
@@ -84,9 +85,9 @@ export type MockDataContributor<T extends object> = {
         updateEntry: (keyValues: KeyDefinitions, newData: T, odataRequest: ODataRequest) => Promise<void>;
         removeEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => Promise<void>;
         hasEntry: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => boolean;
-        fetchEntries: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => T[];
+        fetchEntries: (keyValues: KeyDefinitions, odataRequest: ODataRequest) => Promise<T[]>;
         hasEntries: (odataRequest: ODataRequest) => boolean;
-        getAllEntries: (odataRequest: ODataRequest) => T[];
+        getAllEntries: (odataRequest: ODataRequest) => Promise<T[]>;
         getEmptyObject: (odataRequest: ODataRequest) => T;
         getDefaultElement: (odataRequest: ODataRequest) => T;
         getParentEntityInterface: () => Promise<FileBasedMockData | undefined>;
@@ -146,8 +147,8 @@ export class FunctionBasedMockData extends FileBasedMockData {
                 newObject = Object.assign(newObject, postData);
                 return super.addEntry(newObject, {} as any);
             },
-            updateEntry: (keyValues: KeyDefinitions, patchData: object, odataRequest) => {
-                const data = this.fetchEntries(keyValues, odataRequest)[0];
+            updateEntry: async (keyValues: KeyDefinitions, patchData: object, odataRequest) => {
+                const data = (await this.fetchEntries(keyValues, odataRequest))[0];
                 const updatedData = Object.assign(data, patchData);
                 return super.updateEntry(keyValues, updatedData, patchData, odataRequest);
             },
@@ -200,7 +201,7 @@ export class FunctionBasedMockData extends FileBasedMockData {
         return super.removeEntry(keyValues, odataRequest);
     }
 
-    fetchEntries(keyValues: KeyDefinitions, odataRequest: ODataRequest): object[] {
+    async fetchEntries(keyValues: KeyDefinitions, odataRequest: ODataRequest): Promise<object[]> {
         if (this._mockDataFn?.fetchEntries) {
             return this._mockDataFn.fetchEntries(keyValues, odataRequest);
         } else {
@@ -246,7 +247,7 @@ export class FunctionBasedMockData extends FileBasedMockData {
         }
     }
 
-    getAllEntries(odataRequest: ODataRequest, dontClone: boolean = false): object[] {
+    async getAllEntries(odataRequest: ODataRequest, dontClone: boolean = false): Promise<object[]> {
         if (this._mockDataFn?.getAllEntries) {
             return this._mockDataFn.getAllEntries(odataRequest);
         } else {
@@ -264,6 +265,14 @@ export class FunctionBasedMockData extends FileBasedMockData {
             return this._mockDataFn.onBeforeAction(actionDefinition, actionData, keys, odataRequest);
         } else {
             return super.onBeforeAction(actionDefinition, actionData, keys, odataRequest);
+        }
+    }
+
+    async onAfterRead(data: object, odataRequest: ODataRequest): Promise<object> {
+        if (this._mockDataFn?.onAfterRead) {
+            return this._mockDataFn.onAfterRead(data, odataRequest);
+        } else {
+            return super.onAfterRead(data, odataRequest);
         }
     }
 

--- a/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
+++ b/packages/fe-mockserver-core/test/unit/data/entitySet.test.ts
@@ -46,7 +46,7 @@ describe('EntitySet', () => {
                 },
                 dataAccess
             );
-            const mockData = myEntitySet.getMockData('default').getAllEntries(fakeRequest) as any;
+            const mockData = (await myEntitySet.getMockData('default').getAllEntries(fakeRequest)) as any;
             let filteredData = myEntitySet.checkFilter(mockData[0], v4ComplexLambda, 'default', fakeRequest);
             expect(filteredData).toBe(true);
             filteredData = myEntitySet.checkFilter(mockData[1], v4ComplexLambda, 'default', fakeRequest);
@@ -84,7 +84,7 @@ describe('EntitySet', () => {
                 },
                 dataAccess
             );
-            const mockData = myEntitySet.getMockData('default').getAllEntries(fakeRequest) as any;
+            const mockData = (await myEntitySet.getMockData('default').getAllEntries(fakeRequest)) as any;
             let filteredData = myEntitySet.checkFilter(mockData[0], v4ComplexLambda, 'default', fakeRequest);
             expect(filteredData).toBe(true);
             filteredData = myEntitySet.checkFilter(mockData[1], v4ComplexLambda, 'default', fakeRequest);
@@ -117,7 +117,7 @@ describe('EntitySet', () => {
                 },
                 dataAccess
             );
-            const mockData = myEntitySet.getMockData('default').getAllEntries(fakeRequest) as any;
+            const mockData = (await myEntitySet.getMockData('default').getAllEntries(fakeRequest)) as any;
             let filteredData = myEntitySet.checkFilter(mockData[0], v4InFilter, 'default', fakeRequest);
             expect(filteredData).toBe(true);
             filteredData = myEntitySet.checkFilter(mockData[1], v4InFilter, 'default', fakeRequest);

--- a/packages/fe-mockserver-core/test/unit/data/fileBasedMockData.spec.ts
+++ b/packages/fe-mockserver-core/test/unit/data/fileBasedMockData.spec.ts
@@ -22,7 +22,7 @@ describe('File Based Mock Data', () => {
         metadata = await ODataMetadata.parse(edmx, baseUrl + '/$metadata');
         dataAccess = new DataAccess({ mockdataPath: baseDir } as ServiceConfig, metadata, fileLoader);
     });
-    it('can generate data', () => {
+    it('can generate data', async () => {
         const mockData: any = [];
         mockData.__generateMockData = true;
         const fileBasedData = new FileBasedMockData(
@@ -31,7 +31,7 @@ describe('File Based Mock Data', () => {
             {} as any,
             'default'
         );
-        const allEntries = fileBasedData.getAllEntries({} as any);
+        const allEntries = await fileBasedData.getAllEntries({} as any);
         expect(allEntries[0].Value.length).toBeLessThan(5);
         expect(allEntries[0].complexComputedNotNullProperty.textDescription.length).toBeLessThan(6);
         const fileBasedData2 = new FileBasedMockData(
@@ -40,7 +40,7 @@ describe('File Based Mock Data', () => {
             {} as any,
             'default'
         );
-        const allEntries2 = fileBasedData2.getAllEntries({} as any);
+        const allEntries2 = await fileBasedData2.getAllEntries({} as any);
         expect(allEntries2[0].Value.length).toBeLessThan(5);
         expect(allEntries2[0].StrKey.length).toBeLessThan(4);
         expect(allEntries2[0].MyValue).not.toBe(null);
@@ -56,7 +56,7 @@ describe('File Based Mock Data', () => {
             {} as any,
             'default'
         );
-        const allEntries3 = fileBasedData3.getAllEntries({} as any);
+        const allEntries3 = await fileBasedData3.getAllEntries({} as any);
         expect(allEntries3[0].Value).toBe(null);
         expect(allEntries3[0].StrKey.length).toBeLessThan(4);
         expect(allEntries3[0].MyValue).toBe(null);

--- a/packages/fe-mockserver-core/test/unit/data/functionBasedMockData.test.ts
+++ b/packages/fe-mockserver-core/test/unit/data/functionBasedMockData.test.ts
@@ -31,7 +31,7 @@ describe('Function Based Mock Data', () => {
             },
             dataAccess
         );
-        let mockData = myEntitySet.getMockData('default').getAllEntries(fakeRequest) as any;
+        let mockData = (await myEntitySet.getMockData('default').getAllEntries(fakeRequest)) as any;
         expect(mockData.length).toBe(3);
         expect(mockData[0].complexComputedProperty).toBeDefined();
         expect(mockData[0].complexProperty).toBeDefined();
@@ -39,13 +39,13 @@ describe('Function Based Mock Data', () => {
         expect(mockData[0].complexNotNullProperty).toBeDefined();
         // Fake that in tenant 001 we only return one data
         fakeRequest.tenantId = 'tenant-001';
-        mockData = myEntitySet.getMockData('tenant-001').getAllEntries(fakeRequest) as any;
+        mockData = (await myEntitySet.getMockData('tenant-001').getAllEntries(fakeRequest)) as any;
         expect(mockData.length).toBe(1);
         // Fake that in tenant 002 we throw an error
         fakeRequest.tenantId = 'tenant-002';
         expect(() => {
-            mockData = myEntitySet.getMockData('tenant-002').getAllEntries(fakeRequest) as any;
-        }).toThrow('This tenant is not allowed for you');
+            return myEntitySet.getMockData('tenant-002').getAllEntries(fakeRequest) as any;
+        }).rejects.toThrow('This tenant is not allowed for you');
         await fakeRequest.handleRequest();
         let responseData = fakeRequest.getResponseData();
         expect(responseData).toMatchSnapshot();
@@ -74,7 +74,7 @@ describe('Function Based Mock Data', () => {
             dataAccess
         );
         const mockData = myEntitySet.getMockData('default');
-        let allData = mockData.getAllEntries(fakeRequest) as any;
+        let allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
         await mockData.addEntry(
             {
@@ -84,15 +84,15 @@ describe('Function Based Mock Data', () => {
             },
             fakeRequest
         );
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(4);
         const mockData2 = myEntitySet.getMockData('notdefault');
-        const allData2 = mockData2.getAllEntries(fakeRequest) as any;
+        const allData2 = (await mockData2.getAllEntries(fakeRequest)) as any;
         expect(allData2.length).toBe(3);
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(4);
         await mockData.removeEntry({ ID: 4 }, fakeRequest);
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
     });
     it('can Update Entries', async () => {
@@ -104,9 +104,9 @@ describe('Function Based Mock Data', () => {
             dataAccess
         );
         let mockData = myEntitySet.getMockData('default');
-        let allData = mockData.getAllEntries(fakeRequest) as any;
+        let allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
-        mockData.updateEntry(
+        await mockData.updateEntry(
             { ID: 1 },
             {
                 ID: 1,
@@ -118,16 +118,16 @@ describe('Function Based Mock Data', () => {
             },
             fakeRequest
         );
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
         expect(allData[0].Name).toBe('My Updated Name');
 
         // Fake that in tenant 003 we change the value
         fakeRequest.tenantId = 'tenant-003';
         mockData = myEntitySet.getMockData('tenant-003');
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
-        const updatedData = mockData.updateEntry(
+        await mockData.updateEntry(
             { ID: 1 },
             {
                 ID: 1,
@@ -139,16 +139,16 @@ describe('Function Based Mock Data', () => {
             },
             fakeRequest
         );
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
         expect(allData[0].Name).toBe('My Updated Name');
         expect(allData[0].Value).toBe('My ValueFor Special Tenant');
         // Fake that in tenant 004 we add an extra value
         fakeRequest.tenantId = 'tenant-004';
         mockData = myEntitySet.getMockData('tenant-004');
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
-        mockData.updateEntry(
+        await mockData.updateEntry(
             { ID: 1 },
             {
                 ID: 1,
@@ -160,7 +160,7 @@ describe('Function Based Mock Data', () => {
             },
             fakeRequest
         );
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(4);
         expect(allData[0].Name).toBe('My Updated Name');
         expect(allData[0].Value).toBe('My Value');
@@ -171,9 +171,9 @@ describe('Function Based Mock Data', () => {
         // Fake that in tenant 005 we add a sap message to the output
         fakeRequest.tenantId = 'tenant-005';
         mockData = myEntitySet.getMockData('tenant-005');
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
-        mockData.updateEntry(
+        await mockData.updateEntry(
             { ID: 1 },
             {
                 ID: 1,
@@ -192,9 +192,9 @@ describe('Function Based Mock Data', () => {
         // Fake that in tenant 006 we can also update another entity
         fakeRequest.tenantId = 'tenant-006';
         mockData = myEntitySet.getMockData('tenant-006');
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         const secondMock = myOtherEntitySet.getMockData('tenant-006') as any;
-        let allSecondData = secondMock.getAllEntries(fakeRequest) as any;
+        let allSecondData = (await secondMock.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
         expect(allSecondData.length).toBe(1);
         await mockData.updateEntry(
@@ -210,12 +210,12 @@ describe('Function Based Mock Data', () => {
             fakeRequest
         );
         fakeRequest.getResponseData();
-        allSecondData = secondMock.getAllEntries(fakeRequest) as any;
+        allSecondData = (await secondMock.getAllEntries(fakeRequest)) as any;
         expect(allSecondData.length).toBe(2);
         expect(allSecondData[1]).toStrictEqual({ Name: 'MySecondEntityName' });
     });
 
-    it('can get entries based on filters', () => {
+    it('can get entries based on filters', async () => {
         // Fake that in tenant 007 we can influence filtering
         const fakeRequest = new ODataRequest(
             {
@@ -226,7 +226,7 @@ describe('Function Based Mock Data', () => {
         );
         fakeRequest.tenantId = 'tenant-006';
         const mockData = myEntitySet.getMockData('tenant-006');
-        const allData = mockData.getAllEntries(fakeRequest);
+        const allData = await mockData.getAllEntries(fakeRequest);
         let filterResult = mockData.checkFilterValue('Edm.String', allData[0]?.Name, 'Name', 'eq', fakeRequest);
         expect(filterResult).toBe(false);
         fakeRequest.tenantId = 'tenant-007';
@@ -243,11 +243,11 @@ describe('Function Based Mock Data', () => {
         );
         fakeRequest.tenantId = 'tenant-008';
         const mockData = myEntitySet.getMockData('tenant-008');
-        let allData = mockData.getAllEntries(fakeRequest) as any;
+        let allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(3);
         await fakeRequest.handleRequest();
         const responseData = fakeRequest.getResponseData();
-        allData = mockData.getAllEntries(fakeRequest) as any;
+        allData = (await mockData.getAllEntries(fakeRequest)) as any;
         expect(allData.length).toBe(2);
         expect(responseData).toMatchSnapshot();
     });

--- a/packages/fe-mockserver-core/test/unit/v4/services/formSample/Countries.js
+++ b/packages/fe-mockserver-core/test/unit/v4/services/formSample/Countries.js
@@ -2,15 +2,15 @@ module.exports = {
     getInitialDataSet() {
         return require('./Countries.json');
     },
-    fetchEntries(keyValues) {
-        const results = this.base.fetchEntries(keyValues);
+    async fetchEntries(keyValues) {
+        const results = await this.base.fetchEntries(keyValues);
         results.forEach((result) => {
             result.SuperHeroCount = Math.floor(result.PeopleCount / 10);
         });
         return results;
     },
-    getAllEntries() {
-        const results = this.base.getAllEntries();
+    async getAllEntries() {
+        const results = await this.base.getAllEntries();
         results.forEach((result) => {
             result.SuperHeroCount = Math.floor(result.PeopleCount / 10);
         });

--- a/packages/fe-mockserver-core/test/unit/v4/services/formSample/Countries3.js
+++ b/packages/fe-mockserver-core/test/unit/v4/services/formSample/Countries3.js
@@ -1,13 +1,13 @@
 module.exports = {
-    fetchEntries(keyValues) {
-        const results = this.base.fetchEntries(keyValues);
+    async fetchEntries(keyValues) {
+        const results = await this.base.fetchEntries(keyValues);
         results.forEach((result) => {
             result.SuperHeroCount = Math.floor(result.PeopleCount / 10);
         });
         return results;
     },
-    getAllEntries() {
-        const results = this.base.getAllEntries();
+    async getAllEntries() {
+        const results = await this.base.getAllEntries();
         results.forEach((result) => {
             result.SuperHeroCount = Math.floor(result.PeopleCount / 10);
         });

--- a/packages/fe-mockserver-core/test/unit/v4/services/formSample/Countries4.js
+++ b/packages/fe-mockserver-core/test/unit/v4/services/formSample/Countries4.js
@@ -1,13 +1,13 @@
 module.exports = {
-    fetchEntries(keyValues) {
-        const results = this.base.fetchEntries(keyValues);
+    async fetchEntries(keyValues) {
+        const results = await this.base.fetchEntries(keyValues);
         results.forEach((result) => {
             result.SuperHeroCount = Math.floor(result.PeopleCount / 10);
         });
         return results;
     },
-    getAllEntries() {
-        const results = this.base.getAllEntries();
+    async getAllEntries() {
+        const results = await this.base.getAllEntries();
         results.forEach((result) => {
             result.SuperHeroCount = Math.floor(result.PeopleCount / 10);
         });


### PR DESCRIPTION
This change also adds an `onAfterRead` extension method to modify the result of the request with additional code.

The change to async for `fetchEntries` and `getAllEntries` is technically a breaking change, but both method were not (and are still not) documented publicly.