### PR TITLE
fix: provide right response when there are failures in multi select changeset mode

### DIFF
--- a/.changeset/quick-moons-care.md
+++ b/.changeset/quick-moons-care.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+fix: provide right response when there are failures in multi select changeset mode

--- a/packages/fe-mockserver-core/src/router/batchRouter.ts
+++ b/packages/fe-mockserver-core/src/router/batchRouter.ts
@@ -8,8 +8,6 @@ import type { Batch, BatchPart } from './batchParser';
 import { BatchContent, getBoundary, parseBatch } from './batchParser';
 import type { IncomingMessageWithTenant } from './serviceRouter';
 
-type Error412 = Record<string, ErrorResponse>;
-
 type ErrorResponse = {
     code: string;
     message: string;
@@ -23,6 +21,12 @@ type ErrorDetails = {
     severity?: string;
 } & Record<string, unknown>;
 
+type ErrorInfo = {
+    header: string;
+    error: ErrorResponse;
+    contentId?: string;
+};
+
 /**
  * Returns the result whether isRequest part of changeset or not.
  * @param part
@@ -32,59 +36,35 @@ export function isPartChangeSet(part: BatchPart | Batch): part is Batch {
     return (part as Batch).isChangeSet;
 }
 
-let aggregate412BatchResponseInstance: {
-    add412Response: (header: string, resContent: Error412, contentId: string | undefined) => void;
-    getUnifiedResponse: () => string | undefined;
-    getLength: () => number;
-};
 const NL = '\r\n';
 
 /**
- * Handles the part request.
+ * Get the part request.
  * @param partDefinition
  * @param dataAccess
- * @param boundary
  * @param tenantId
- * @param globalHeaders
- * @param isChangeSetPart
- * @returns {string | null}
+ * @returns {ODataRequest}
  */
-async function handlePart(
+async function getPartRequest(
     partDefinition: BatchPart,
     dataAccess: DataAccess,
-    boundary: string,
-    tenantId: string,
-    globalHeaders: Record<string, string>,
-    isChangeSetPart?: boolean
-): Promise<string | null> {
+    tenantId: string
+): Promise<ODataRequest> {
     const partRequest = new ODataRequest({ ...partDefinition, tenantId: tenantId }, dataAccess);
     await partRequest.handleRequest();
-    const isResponse412ChangeSet = partRequest?.statusCode === 412 && !!isChangeSetPart;
-    const { batchPartRes, header, resContent, contentId } = createBatchResponseObject(
-        partRequest,
-        partDefinition,
-        boundary,
-        globalHeaders,
-        isResponse412ChangeSet
-    );
-    // All 412 batch responses should be transformed and returned as single response
-    if (isResponse412ChangeSet) {
-        aggregate412BatchResponseInstance.add412Response(header, resContent, contentId);
-        return null;
-    }
-    return batchPartRes;
+    return partRequest;
 }
 
 /**
- * Creates a batch response object.
+ * Get the header of the part response.
  * @param partRequest
  * @param partDefinition
  * @param boundary
  * @param globalHeaders
  * @param isResponse412ChangeSet
- * @returns a batch response object
+ * @returns {string} Response string corresponding to the part request.
  */
-function createBatchResponseObject(
+function getPartResponseHeader(
     partRequest: ODataRequest,
     partDefinition: BatchPart,
     boundary: string,
@@ -114,22 +94,50 @@ function createBatchResponseObject(
         globalHeaders[headerName] = partRequest.globalResponseHeaders[headerName];
     }
     batchResponse += NL; // End of part header
-    const header = batchResponse;
+    return batchResponse;
+}
+
+/**
+ * Get the part response.
+ * @param partRequest
+ * @param partDefinition
+ * @param boundary
+ * @param globalHeaders
+ * @param isResponse412ChangeSet
+ * @returns {string} Response string corresponding to the part request.
+ */
+function getPartResponse(
+    partRequest: ODataRequest,
+    partDefinition: BatchPart,
+    boundary: string,
+    globalHeaders: Record<string, string>,
+    isResponse412ChangeSet: boolean
+) {
+    let batchResponse = getPartResponseHeader(
+        partRequest,
+        partDefinition,
+        boundary,
+        globalHeaders,
+        isResponse412ChangeSet
+    );
+
+    const responseData = partRequest.getResponseData();
     if (responseData) {
         batchResponse += responseData;
         //batchResponse += NL; // End of body content
     }
     batchResponse += NL;
-    const resContent = isResponse412ChangeSet ? JSON.parse(responseData as string) : null;
-    return { batchPartRes: batchResponse, header, resContent, contentId };
+
+    return batchResponse;
 }
 
 /**
- * Creates instance of 412 responses aggregated from batch changeset request.
- * @returns void
+ * Get the single error containing all 412 responses.
+ * @param errors412
+ * @returns {string} Response string containing single error holding all 412 responses.
  */
-function aggregate412BatchResponse() {
-    const batch412Response = {
+function getCombined412ErrorResponse(errors412: ErrorInfo[]) {
+    const errorInfo = {
         header: '',
         error: {
             code: '',
@@ -137,38 +145,137 @@ function aggregate412BatchResponse() {
             severity: '',
             details: [] as ErrorDetails[]
         } as ErrorResponse
-    };
-    let firstPart = true;
-    let length = 0;
-    return {
-        add412Response: function (header: string, resContent: Error412, contentId: string | undefined) {
-            if (firstPart) {
-                batch412Response.header = header;
-                batch412Response.error = {
-                    code: resContent.error.code,
-                    message: resContent.error.message,
-                    severity: resContent.error['@Common.Severity'] as string | undefined,
-                    details: []
-                };
-                firstPart = false;
-            }
-            batch412Response.error.details.push(resContent.error.details[0]);
-            batch412Response.error.details[batch412Response.error.details.length - 1]['@Core.ContentID'] = contentId;
-            length++;
-        },
-        getUnifiedResponse: function (): string {
-            let batchResponse = '';
-            batchResponse += batch412Response.header;
-            batchResponse += NL;
-            const { error } = batch412Response;
-            batchResponse += JSON.stringify({ error: error });
-            batchResponse += NL;
-            return batchResponse;
-        },
-        getLength: function () {
-            return length;
+    } as ErrorInfo;
+
+    // Create single error combining all the 412 responses.
+    const overall412ErrorInfo = errors412.reduce((accumErrorInfo: ErrorInfo, { header, error, contentId }, idx) => {
+        if (idx === 0) {
+            // Add header of only the first 412 error.
+            accumErrorInfo.header += header;
+            // Setting the first 412 error at the top.
+            accumErrorInfo.error = {
+                code: error.code,
+                message: error.message,
+                severity: error['@Common.Severity'] as string | undefined,
+                details: []
+            };
         }
-    };
+
+        // Accumulate all remaining errors in error details.
+        const details = [...error.details].map((errDetail) => {
+            errDetail['@Core.ContentID'] = contentId;
+            return errDetail;
+        });
+        accumErrorInfo.error.details = accumErrorInfo.error.details.concat(details);
+
+        return accumErrorInfo;
+    }, errorInfo);
+
+    // Convert the single error into response string.
+    let response = '';
+    response += overall412ErrorInfo.header;
+    response += NL;
+    const { error } = overall412ErrorInfo;
+    response += JSON.stringify({ error: error });
+    response += NL;
+
+    return response;
+}
+
+/**
+ * Get 412 error information from the request's response.
+ * @param errors412
+ * @returns 412 Error information containing header, error object and content-Id.
+ */
+function get412ErrorInfo(
+    partResponseIs412: boolean,
+    partRequest: ODataRequest,
+    changeSetPart: BatchPart,
+    boundary: string,
+    globalHeaders: Record<string, string>
+) {
+    if (partResponseIs412) {
+        const error412Object = partRequest.getResponseData();
+        if (typeof error412Object === 'string') {
+            return {
+                header: getPartResponseHeader(partRequest, changeSetPart, boundary, globalHeaders, true),
+                error: JSON.parse(error412Object).error as ErrorResponse,
+                contentId: changeSetPart.contentId
+            };
+        }
+    }
+}
+
+/**
+ * Get the change set response.
+ * @param changeSet
+ * @param dataAccess
+ * @param tenantId
+ * @param globalHeaders
+ * @returns Response string corresponding to the change set request.
+ */
+async function getChangeSetResponse(
+    changeSet: Batch,
+    dataAccess: DataAccess,
+    tenantId: string,
+    globalHeaders: Record<string, string>
+) {
+    const errors412 = [];
+    let changeSetFailed = false;
+
+    let batchResponse = `Content-Type: multipart/mixed; boundary=${changeSet.boundary}${NL}`;
+    batchResponse += NL;
+
+    for (const changeSetPart of changeSet.parts) {
+        const partRequest = await getPartRequest(changeSetPart as BatchPart, dataAccess, tenantId);
+        const statusCode = (partRequest?.statusCode ?? '').toString();
+
+        const partResponseIs412 = statusCode === '412';
+        const overallErrorStateIs412 = errors412.length > 0 || partResponseIs412;
+        if (overallErrorStateIs412) {
+            // 412 encountered.
+            const errorInfo412 = get412ErrorInfo(
+                partResponseIs412,
+                partRequest,
+                changeSetPart as BatchPart,
+                changeSet.boundary,
+                globalHeaders
+            );
+            if (errorInfo412) {
+                errors412.push(errorInfo412);
+            }
+            // NOTE: If earlier part had a 412 response, so we only accumulate 412 responses from remaining parts.
+        } else {
+            const batchPartRes = getPartResponse(
+                partRequest,
+                changeSetPart as BatchPart,
+                changeSet.boundary,
+                globalHeaders,
+                false
+            );
+            if (statusCode.startsWith('4') || statusCode.startsWith('5')) {
+                // Other error responses of 4XX and 5XX (ChangeSet failed).
+                // We presently override the response and exit in these scenarios.
+                // NOTE: This might change on implementation of continue-on-error.
+                batchResponse = batchPartRes;
+                changeSetFailed = true;
+                break;
+            } else if (batchPartRes !== null) {
+                // No error
+                batchResponse += batchPartRes;
+            }
+        }
+    }
+
+    if (errors412.length > 0) {
+        // Reset response with combine of 412 errors.
+        batchResponse = getCombined412ErrorResponse(errors412);
+    } else if (!changeSetFailed) {
+        // No error, we close the changeset boundary
+        batchResponse += `--${changeSet.boundary}--${NL}`;
+    }
+
+    return batchResponse;
 }
 
 /**
@@ -185,45 +292,15 @@ export function batchRouter(dataAccess: DataAccess): NextHandleFunction {
             const batchData = parseBatch(new BatchContent(body), boundary);
             const globalHeaders: Record<string, string> = {};
             let batchResponse = '';
-            //initialize the instance of aggregator of batch 412 responses
-            aggregate412BatchResponseInstance = aggregate412BatchResponse();
+
             for (const part of batchData.parts) {
                 if (isPartChangeSet(part)) {
                     batchResponse += `--${batchData.boundary}${NL}`;
-                    batchResponse += `Content-Type: multipart/mixed; boundary=${part.boundary}${NL}`;
-                    batchResponse += NL;
-                    for (const changeSetPart of part.parts) {
-                        const batchPartRes = await handlePart(
-                            changeSetPart as BatchPart,
-                            dataAccess,
-                            part.boundary,
-                            req.tenantId!,
-                            globalHeaders,
-                            true
-                        );
-                        if (batchPartRes !== null) {
-                            batchResponse += batchPartRes;
-                        }
-                    }
-                    // append the 412 batch response
-                    if (aggregate412BatchResponseInstance.getLength() > 0) {
-                        batchResponse += aggregate412BatchResponseInstance.getUnifiedResponse();
-                    }
-                    batchResponse += `--${part.boundary}--${NL}`;
+                    batchResponse += await getChangeSetResponse(part, dataAccess, req.tenantId!, globalHeaders);
                 } else {
-                    batchResponse += await handlePart(
-                        part,
-                        dataAccess,
-                        batchData.boundary,
-                        req.tenantId!,
-                        globalHeaders
-                    );
+                    const partRequest = await getPartRequest(part, dataAccess, req.tenantId!);
+                    batchResponse += getPartResponse(partRequest, part, boundary, globalHeaders, false);
                 }
-            }
-            //If there are 412 responses, override and return a single 412 error response
-            if (aggregate412BatchResponseInstance.getLength()) {
-                batchResponse = `--${batchData.boundary}${NL}`;
-                batchResponse += aggregate412BatchResponseInstance.getUnifiedResponse();
             }
             batchResponse += `--${batchData.boundary}--${NL}`;
             res.statusCode = 200;

--- a/packages/fe-mockserver-core/src/router/batchRouter.ts
+++ b/packages/fe-mockserver-core/src/router/batchRouter.ts
@@ -69,7 +69,7 @@ async function getPartRequest(
  * Get the header of the part response.
  * @param partRequest
  * @param partDefinition
- * @param boundary
+ * @param globalHeaders
  * @param isChangeSet
  * @param isResponse412
  * @returns {string} Response string corresponding to the part request.
@@ -138,9 +138,8 @@ function getPartResponseContent(partRequest: ODataRequest, partDefinition: Batch
  * Get the part response.
  * @param partRequest
  * @param partDefinition
- * @param boundary
  * @param globalHeaders
- * @param isResponse412ChangeSet
+ * @param isChangeSet
  * @returns {string} Response string corresponding to the part request.
  */
 function getPartResponse(

--- a/packages/fe-mockserver-core/src/router/batchRouter.ts
+++ b/packages/fe-mockserver-core/src/router/batchRouter.ts
@@ -106,35 +106,6 @@ function getPartResponseHeader(
 }
 
 /**
- * Get the content of the part response.
- * @param partRequest
- * @param partDefinition
- * @param isChangeSet
- * @returns {string} Response string corresponding to the part request.
- */
-function getPartResponseContent(partRequest: ODataRequest, partDefinition: BatchPart, isChangeSet: boolean = false) {
-    let responseData = partRequest.getResponseData() ?? '';
-
-    if (responseData) {
-        if (isChangeSet && hasErrorStatusCode(partRequest)) {
-            // We update content-id in the error response in case of change set failure.
-            const contentId = partDefinition.contentId;
-            try {
-                const responseObj = JSON.parse(responseData);
-                (responseObj.error as ErrorResponse)['@Core.ContentID'] = contentId;
-                responseData = JSON.stringify(responseObj);
-            } catch (e: any) {
-                console.log("Couldn't update change set error response with content-id", e);
-            }
-        }
-        //batchResponse += NL; // End of body content
-    }
-    responseData += NL;
-
-    return responseData;
-}
-
-/**
  * Get the part response.
  * @param partRequest
  * @param partDefinition
@@ -150,7 +121,12 @@ function getPartResponse(
 ) {
     let batchResponse = getPartResponseHeader(partRequest, partDefinition, globalHeaders, isChangeSet);
 
-    batchResponse += getPartResponseContent(partRequest, partDefinition, isChangeSet);
+    const responseData = partRequest.getResponseData();
+    if (responseData) {
+        batchResponse += responseData;
+        //batchResponse += NL; // End of body content
+    }
+    batchResponse += NL;
 
     return batchResponse;
 }

--- a/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
+++ b/packages/fe-mockserver-core/test/unit/__snapshots__/middleware.test.ts.snap
@@ -39,7 +39,7 @@ exports[`V4 Requestor Sticky create, discard, try to update the discarded item: 
 exports[`V4 Requestor can create data through a call 1`] = `
 {
   "@odata.context": "../$metadata#RootElement/$entity",
-  "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+  "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 555,
@@ -56,7 +56,7 @@ exports[`V4 Requestor can create data through a call 1`] = `
 exports[`V4 Requestor can create data through a call 2`] = `
 {
   "@odata.context": "../$metadata#RootElement/$entity",
-  "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+  "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 666,
@@ -186,6 +186,10 @@ exports[`V4 Requestor can get the metadata 1`] = `
         <Parameter Name="self" Type="sap.fe.core.ActionVisibility.RootElement"/>
         <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
       </Action>
+      <Action Name="boundActionChangeSet" IsBound="true" EntitySetPath="self">
+        <Parameter Name="self" Type="sap.fe.core.ActionVisibility.RootElement"/>
+        <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
+      </Action>
       <Action Name="boundAction1" IsBound="true" EntitySetPath="self">
         <Parameter Name="self" Type="sap.fe.core.ActionVisibility.RootElement"/>
         <ReturnType Type="sap.fe.core.ActionVisibility.RootElement"/>
@@ -283,6 +287,11 @@ exports[`V4 Requestor can get the metadata 1`] = `
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Message - 412 (Bound)"/>
               <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.bound412Action"/>
+              <PropertyValue Property="InvocationGrouping" EnumMember="UI.OperationGroupingType/ChangeSet"/>
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Bound Action ChangeSet"/>
+              <PropertyValue Property="Action" String="sap.fe.core.ActionVisibility.boundActionChangeSet"/>
               <PropertyValue Property="InvocationGrouping" EnumMember="UI.OperationGroupingType/ChangeSet"/>
             </Record>
           </Collection>
@@ -613,7 +622,7 @@ exports[`V4 Requestor can get the root 1`] = `
 exports[`V4 Requestor can get the root 2`] = `
 {
   "@odata.context": "$metadata",
-  "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+  "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
   "value": [
     {
       "kind": "EntitySet",
@@ -659,7 +668,7 @@ exports[`V4 Requestor can reload the data 1`] = `
 exports[`V4 Requestor can update data through a call 1`] = `
 {
   "@odata.context": "../$metadata#RootElement/$entity",
-  "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+  "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 556,
@@ -676,7 +685,7 @@ exports[`V4 Requestor can update data through a call 1`] = `
 exports[`V4 Requestor can update data through a call 2`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=556)",
-  "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+  "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 556,
@@ -700,7 +709,7 @@ exports[`V4 Requestor can update data through a call 3`] = `
 exports[`V4 Requestor can update data through a call 4`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=556)/Prop1",
-  "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+  "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 556,
@@ -724,7 +733,7 @@ exports[`V4 Requestor can update data through a call 5`] = `
 exports[`V4 Requestor can update data through a call 6`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=556)/Prop1",
-  "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+  "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 556,
@@ -741,7 +750,7 @@ exports[`V4 Requestor can update data through a call 6`] = `
 exports[`V4 Requestor get one data 1`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=2)",
-  "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+  "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 2,
@@ -760,7 +769,7 @@ exports[`V4 Requestor get one data 2`] = `""`;
 exports[`V4 Requestor get one data 3`] = `
 {
   "@odata.context": "$metadata#RootElement(ID=2)",
-  "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+  "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
   "HasActiveEntity": false,
   "HasDraftEntity": false,
   "ID": 2,

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
@@ -29,7 +29,7 @@ module.exports = {
                                 '@Common.numericSeverity': 4
                             }
                         });
-                    } else if (keys['ID'] == '3' || keys['ID'] == '4') {
+                    } else if (keys['ID'] == '3' || keys['ID'] == '4' || keys['ID'] == '6') {
                         this.throwError('unbound transition error', 500, {
                             error: {
                                 code: 500,
@@ -55,7 +55,6 @@ module.exports = {
                     );
                 }
                 break;
-
             case 'bound503Action':
                 this.throwError(
                     'Server not available',
@@ -65,6 +64,25 @@ module.exports = {
                     { 'Retry-After': 'some date' },
                     actionData.globalError
                 );
+                break;
+            case 'boundActionChangeSet':
+                if (keys['ID'] == '3') {
+                    this.throwError('unbound transition error', 500, {
+                        error: {
+                            code: 500,
+                            message: 'unbound transition error',
+                            transition: true,
+                            '@Common.numericSeverity': 4
+                        }
+                    });
+                } else {
+                    this.throwError(
+                        'Bound action executed',
+                        200,
+                        [{ code: '200', message: 'Bound action executed', numericSeverity: 1 }],
+                        true
+                    );
+                }
                 break;
 
             default:

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
@@ -29,7 +29,7 @@ module.exports = {
                                 '@Common.numericSeverity': 4
                             }
                         });
-                    } else if (keys['ID'] == '3' || keys['ID'] == '4' || keys['ID'] == '6') {
+                    } else if (keys['ID'] == '3' || keys['ID'] == '4') {
                         this.throwError('unbound transition error', 500, {
                             error: {
                                 code: 500,

--- a/packages/fe-mockserver-core/test/unit/__testData/service.cds
+++ b/packages/fe-mockserver-core/test/unit/__testData/service.cds
@@ -90,6 +90,13 @@ annotate RootElement with @UI: {
       Action            : 'sap.fe.core.ActionVisibility.bound412Action',
       InvocationGrouping: #ChangeSet
     },
+    {
+      $Type             : 'UI.DataFieldForAction',
+      Label             : 'Bound Action ChangeSet',
+      Action            : 'sap.fe.core.ActionVisibility.boundActionChangeSet',
+      InvocationGrouping: #ChangeSet
+    },
+
   ],
   HeaderInfo                    : {
     $Type         : 'UI.HeaderInfoType',
@@ -235,6 +242,8 @@ service ActionVisibility {
     actions {
       @cds.odata.bindingparameter.name: 'self'
       action   bound412Action()            returns RootElement;
+      @cds.odata.bindingparameter.name: 'self'
+      action   boundActionChangeSet()      returns RootElement;
       @cds.odata.bindingparameter.name: 'self'
       action   boundAction1()              returns RootElement;
       action   boundAction2()              returns RootElement;

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -127,7 +127,7 @@ describe('V4 Requestor', function () {
             {
               "@odata.context": "$metadata#RootElement(ID=1,IsActiveEntity=true)/_Elements",
               "@odata.count": 3,
-              "@odata.metadataEtag": "W/"63f6-6P/9UFLMfn2HIrza0TGMUWtfMPQ"",
+              "@odata.metadataEtag": "W/"665d-1Bvuw4Fa+YxIyJH8kB/cmsTZ1V0"",
               "value": [
                 {
                   "HasActiveEntity": true,
@@ -507,7 +507,6 @@ Group ID: $auto`
         const responseStr = await response.text();
         expect(responseStr).toMatchInlineSnapshot(`
             "--batch_id-1719917686303-234
-            --changeset_id-1719917686303-235
             Content-Type: application/http
             Content-Transfer-Encoding: binary
             Content-ID: 1.0
@@ -515,9 +514,8 @@ Group ID: $auto`
             HTTP/1.1 500 Internal Server Error
             sap-tenantid: tenant-default
             content-type: application/json;odata.metadata=minimal;IEEE754Compatible=true
-            odata-version: 4.0
 
-            {"error":{"code":500,"message":"unbound transition error","transition":true,"@Common.numericSeverity":4}}
+            {"error":{"code":500,"message":"unbound transition error","transition":true,"@Common.numericSeverity":4,"@Core.ContentID":"1.0"}}
             --batch_id-1719917686303-234--
             "
         `);


### PR DESCRIPTION

1. When a change set request fails due to an error in processing one of it's parts, we exit the scenario and don't execute the remaining parts of the change set.
2. We correct the behaviour to return a single error on change set failure.
3. The function handlePart is refactored into:
- ChangeSet case:
`getChangeSetResponse`
`    getPartRequest`
`    get412ErrorInfo*`
`    getPartResponse`
`    getCombined412ErrorResponse`
- Isolated case:
`getPartRequest`
`getPartResponse`