### PR TITLE
Adding tests to support Expand all children of a node 

### DIFF
--- a/.changeset/long-countries-learn.md
+++ b/.changeset/long-countries-learn.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+Adding tests to support Expand all children of a node 

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -1096,7 +1096,10 @@ export class FileBasedMockData {
                 for (const expandLevels of _parameters.ExpandLevels) {
                     toExpand.push({
                         name: expandLevels['"NodeID"'].substring(1, expandLevels['"NodeID"'].length - 1),
-                        depth: parseInt(expandLevels['"Levels"'], 10)
+                        depth:
+                            expandLevels['"Levels"'] && expandLevels['"Levels"'] !== 'null'
+                                ? parseInt(expandLevels['"Levels"'], 10)
+                                : Number.POSITIVE_INFINITY
                     });
                 }
             }

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -2291,4 +2291,151 @@ describe('Hierarchy Access', () => {
             ]
         `);
     });
+
+    test('16 - Expand a node completely (OP)', async () => {
+        const expandRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: `/Organizations(ID='FUNC',IsActiveEntity=true)/_Nodes?$select=DistanceFromRoot,DrillState,HasActiveEntity,ID,IsActiveEntity,LimitedDescendantCount,employeeCount,name,nodeType&$apply=com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/Organizations(ID=%27FUNC%27,IsActiveEntity=true)/_Nodes,HierarchyQualifier=%27NodesHierarchy%27,NodeProperty=%27ID%27,Levels=1,ExpandLevels=%5B%7B"NodeID":"FUNC2","Levels":null%7D%5D)&$count=true&$skip=0&$top=206`
+            },
+            dataAccess
+        );
+        const data = await dataAccess.getData(expandRequest);
+        // Expanding Sales
+        expect(data).toMatchInlineSnapshot(`
+            [
+              {
+                "ID": "FUNC2",
+                "name": "Sales",
+                "employeeCount": 88,
+                "nodeType": "Zone",
+                "IsActiveEntity": false,
+                "HasActiveEntity": true,
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "LimitedDescendantCount": 4
+              },
+              {
+                "ID": "FUNC21",
+                "name": "Consumer goods",
+                "employeeCount": 61,
+                "nodeType": "Intermediary",
+                "IsActiveEntity": true,
+                "HasActiveEntity": true,
+                "DistanceFromRoot": 1,
+                "DrillState": "leaf",
+                "LimitedDescendantCount": 0
+              },
+              {
+                "ID": "FUNC22",
+                "name": "Financial services",
+                "employeeCount": 27,
+                "nodeType": "Intermediary",
+                "IsActiveEntity": true,
+                "HasActiveEntity": true,
+                "DistanceFromRoot": 1,
+                "DrillState": "expanded",
+                "LimitedDescendantCount": 2
+              },
+              {
+                "ID": "FUNC221",
+                "name": "Bank",
+                "employeeCount": 19,
+                "nodeType": "Line",
+                "IsActiveEntity": true,
+                "HasActiveEntity": true,
+                "DistanceFromRoot": 2,
+                "DrillState": "leaf",
+                "LimitedDescendantCount": 0
+              },
+              {
+                "ID": "FUNC222",
+                "name": "Insurance",
+                "employeeCount": 8,
+                "nodeType": "Line",
+                "IsActiveEntity": true,
+                "HasActiveEntity": true,
+                "DistanceFromRoot": 2,
+                "DrillState": "leaf",
+                "LimitedDescendantCount": 0
+              },
+              {
+                "ID": "FUNC1",
+                "name": "Operations",
+                "employeeCount": 274,
+                "nodeType": "Zone",
+                "IsActiveEntity": false,
+                "HasActiveEntity": true,
+                "DistanceFromRoot": 0,
+                "DrillState": "collapsed",
+                "LimitedDescendantCount": 0
+              }
+            ]
+        `);
+    });
+
+    test('17 - Expand a node completely (LR)', async () => {
+        const expandRequest = new ODataRequest(
+            {
+                method: 'GET',
+                url: `/SalesOrganizations?$apply=com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/SalesOrganizations,HierarchyQualifier=%27SalesOrgHierarchy%27,NodeProperty=%27ID%27,Levels=2,ExpandLevels=%5B%7B"NodeID":"US","Levels":null%7D%5D)&$select=DistanceFromRoot,DrillState,ID,LimitedDescendantCount,Name&$count=true&$skip=0&$top=251`
+            },
+            dataAccess
+        );
+        // Expand US
+        const data = await dataAccess.getData(expandRequest);
+        expect(data).toMatchInlineSnapshot(`
+            [
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "ID": "Sales",
+                "LimitedDescendantCount": 2,
+                "Name": "Corporate Sales",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "collapsed",
+                "ID": "EMEA",
+                "LimitedDescendantCount": 0,
+                "Name": "EMEA",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "expanded",
+                "ID": "US",
+                "LimitedDescendantCount": 4,
+                "Name": "US",
+              },
+              {
+                "DistanceFromRoot": 2,
+                "DrillState": "leaf",
+                "ID": "US West",
+                "LimitedDescendantCount": 0,
+                "Name": "US West"
+              },
+              {
+                "DistanceFromRoot": 2,
+                "DrillState": "expanded",
+                "ID": "US East",
+                "LimitedDescendantCount": 2,
+                "Name": "US East"
+              },
+              {
+                "DistanceFromRoot": 3,
+                "DrillState": "expanded",
+                "ID": "NY",
+                "LimitedDescendantCount": 1,
+                "Name": "New York State"
+              },
+              {
+                "DistanceFromRoot": 4,
+                "DrillState": "leaf",
+                "ID": "NYC",
+                "LimitedDescendantCount": 0,
+                "Name": "New York City"
+              },
+            ]
+        `);
+    });
 });

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -2292,88 +2292,6 @@ describe('Hierarchy Access', () => {
         `);
     });
 
-    test('16 - Expand a node completely (OP)', async () => {
-        const expandRequest = new ODataRequest(
-            {
-                method: 'GET',
-                url: `/Organizations(ID='FUNC',IsActiveEntity=true)/_Nodes?$select=DistanceFromRoot,DrillState,HasActiveEntity,ID,IsActiveEntity,LimitedDescendantCount,employeeCount,name,nodeType&$apply=com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/Organizations(ID=%27FUNC%27,IsActiveEntity=true)/_Nodes,HierarchyQualifier=%27NodesHierarchy%27,NodeProperty=%27ID%27,Levels=1,ExpandLevels=%5B%7B"NodeID":"FUNC2","Levels":null%7D%5D)&$count=true&$skip=0&$top=206`
-            },
-            dataAccess
-        );
-        const data = await dataAccess.getData(expandRequest);
-        // Expanding Sales
-        expect(data).toMatchInlineSnapshot(`
-            [
-              {
-                "ID": "FUNC2",
-                "name": "Sales",
-                "employeeCount": 88,
-                "nodeType": "Zone",
-                "IsActiveEntity": false,
-                "HasActiveEntity": true,
-                "DistanceFromRoot": 0,
-                "DrillState": "expanded",
-                "LimitedDescendantCount": 4
-              },
-              {
-                "ID": "FUNC21",
-                "name": "Consumer goods",
-                "employeeCount": 61,
-                "nodeType": "Intermediary",
-                "IsActiveEntity": true,
-                "HasActiveEntity": true,
-                "DistanceFromRoot": 1,
-                "DrillState": "leaf",
-                "LimitedDescendantCount": 0
-              },
-              {
-                "ID": "FUNC22",
-                "name": "Financial services",
-                "employeeCount": 27,
-                "nodeType": "Intermediary",
-                "IsActiveEntity": true,
-                "HasActiveEntity": true,
-                "DistanceFromRoot": 1,
-                "DrillState": "expanded",
-                "LimitedDescendantCount": 2
-              },
-              {
-                "ID": "FUNC221",
-                "name": "Bank",
-                "employeeCount": 19,
-                "nodeType": "Line",
-                "IsActiveEntity": true,
-                "HasActiveEntity": true,
-                "DistanceFromRoot": 2,
-                "DrillState": "leaf",
-                "LimitedDescendantCount": 0
-              },
-              {
-                "ID": "FUNC222",
-                "name": "Insurance",
-                "employeeCount": 8,
-                "nodeType": "Line",
-                "IsActiveEntity": true,
-                "HasActiveEntity": true,
-                "DistanceFromRoot": 2,
-                "DrillState": "leaf",
-                "LimitedDescendantCount": 0
-              },
-              {
-                "ID": "FUNC1",
-                "name": "Operations",
-                "employeeCount": 274,
-                "nodeType": "Zone",
-                "IsActiveEntity": false,
-                "HasActiveEntity": true,
-                "DistanceFromRoot": 0,
-                "DrillState": "collapsed",
-                "LimitedDescendantCount": 0
-              }
-            ]
-        `);
-    });
-
     test('17 - Expand a node completely (LR)', async () => {
         const expandRequest = new ODataRequest(
             {
@@ -2390,7 +2308,7 @@ describe('Hierarchy Access', () => {
                 "DistanceFromRoot": 0,
                 "DrillState": "expanded",
                 "ID": "Sales",
-                "LimitedDescendantCount": 2,
+                "LimitedDescendantCount": 7,
                 "Name": "Corporate Sales",
               },
               {
@@ -2412,28 +2330,35 @@ describe('Hierarchy Access', () => {
                 "DrillState": "leaf",
                 "ID": "US West",
                 "LimitedDescendantCount": 0,
-                "Name": "US West"
+                "Name": "US West",
               },
               {
                 "DistanceFromRoot": 2,
                 "DrillState": "expanded",
                 "ID": "US East",
                 "LimitedDescendantCount": 2,
-                "Name": "US East"
+                "Name": "US East",
               },
               {
                 "DistanceFromRoot": 3,
                 "DrillState": "expanded",
                 "ID": "NY",
                 "LimitedDescendantCount": 1,
-                "Name": "New York State"
+                "Name": "New York State",
               },
               {
                 "DistanceFromRoot": 4,
                 "DrillState": "leaf",
                 "ID": "NYC",
                 "LimitedDescendantCount": 0,
-                "Name": "New York City"
+                "Name": "New York City",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "leaf",
+                "ID": "APJ",
+                "LimitedDescendantCount": 0,
+                "Name": "APJ",
               },
             ]
         `);

--- a/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/Nodes.json
+++ b/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/Nodes.json
@@ -1,0 +1,133 @@
+[
+    {
+        "ID": "GEO1",
+        "name": "America North",
+        "orgID": "GEO",
+        "hrPartner": "John Woodward",
+        "employeeCount": 578,
+        "nodeType": "Zone"
+    },
+    {
+        "ID": "GEO11",
+        "parent": "GEO1",
+        "name": "USA",
+        "orgID": "GEO",
+        "hrPartner": "John Woodward",
+        "employeeCount": 508,
+        "nodeType": "Intermediary"
+    },
+    {
+        "ID": "GEO12",
+        "parent": "GEO1",
+        "name": "Canada",
+        "orgID": "GEO",
+        "hrPartner": "André Laclanche",
+        "employeeCount": 70,
+        "nodeType": "Intermediary"
+    },
+    {
+        "ID": "GEO2",
+        "name": "Europe North",
+        "orgID": "GEO",
+        "hrPartner": "Andrew McAllister",
+        "employeeCount": 498,
+        "nodeType": "Zone"
+    },
+    {
+        "ID": "GEO21",
+        "parent": "GEO2",
+        "name": "United Kingdom",
+        "orgID": "GEO",
+        "hrPartner": "Nelly Flint",
+        "employeeCount": 204,
+        "nodeType": "Intermediary"
+    },
+    {
+        "ID": "GEO22",
+        "parent": "GEO2",
+        "name": "Ireland",
+        "orgID": "GEO",
+        "hrPartner": "Niamh O'Connor",
+        "employeeCount": 294,
+        "nodeType": "Intermediary"
+    },
+    {
+        "ID": "GEO221",
+        "parent": "GEO22",
+        "name": "Dublin",
+        "orgID": "GEO",
+        "hrPartner": "Niamh O'Connor",
+        "employeeCount": 294,
+        "nodeType": "Line"
+    },
+    {
+        "ID": "FUNC1",
+        "name": "Operations",
+        "orgID": "FUNC",
+        "hrPartner": "Julia Black",
+        "employeeCount": 274,
+        "nodeType": "Zone"
+    },
+    {
+        "ID": "FUNC11",
+        "parent": "FUNC1",
+        "name": "Human Resources",
+        "orgID": "FUNC",
+        "hrPartner": "Marie Kramp",
+        "employeeCount": 117,
+        "nodeType": "Intermediary"
+    },
+    {
+        "ID": "FUNC12",
+        "parent": "FUNC1",
+        "name": "Finance",
+        "orgID": "FUNC",
+        "hrPartner": "Marie Kramp",
+        "employeeCount": 157,
+        "nodeType": "Intermediary"
+    },
+    {
+        "ID": "FUNC2",
+        "name": "Sales",
+        "orgID": "FUNC",
+        "hrPartner": "Richard Dowey",
+        "employeeCount": 88,
+        "nodeType": "Zone"
+    },
+    {
+        "ID": "FUNC21",
+        "parent": "FUNC2",
+        "name": "Consumer goods",
+        "orgID": "FUNC",
+        "hrPartner": "Anna Pritchard",
+        "employeeCount": 61,
+        "nodeType": "Intermediary"
+    },
+    {
+        "ID": "FUNC22",
+        "parent": "FUNC2",
+        "name": "Financial services",
+        "orgID": "FUNC",
+        "hrPartner": "Don Paney",
+        "employeeCount": 27,
+        "nodeType": "Intermediary"
+    },
+    {
+        "ID": "FUNC221",
+        "parent": "FUNC22",
+        "name": "Bank",
+        "orgID": "FUNC",
+        "hrPartner": "Don Paney",
+        "employeeCount": 19,
+        "nodeType": "Line"
+    },
+    {
+        "ID": "FUNC222",
+        "parent": "FUNC22",
+        "name": "Insurance",
+        "orgID": "FUNC",
+        "hrPartner": "Don Paney",
+        "employeeCount": 8,
+        "nodeType": "Line"
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/Organizations.json
+++ b/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/Organizations.json
@@ -1,0 +1,10 @@
+[
+    {
+        "ID": "GEO",
+        "description": "Geographical organization"
+    },
+    {
+        "ID": "FUNC",
+        "description": "Functional organization"
+    }
+]

--- a/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/otherDraftService.cds
+++ b/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/otherDraftService.cds
@@ -1,0 +1,287 @@
+namespace sap.fe.core;
+
+type StateMessage : {
+  code            : String(10) not null;
+  message         : String(100);
+  numericSeverity : Integer;
+  transition      : Boolean default true;
+  target          : String(200) not null;
+  longtextUrl     : String(200) not null;
+};
+
+entity Organizations {
+      @Core.Computed: true
+  key ID             :      String;
+      preferredNode  :      String @(Common: {
+        Label    : 'Preferred Node',
+        ValueList: {
+          CollectionPath              : 'Nodes',
+          Parameters                  : [
+            {
+              $Type            : 'Common.ValueListParameterInOut',
+              LocalDataProperty: preferredNode,
+              ValueListProperty: 'ID',
+            },
+            {
+              $Type            : 'Common.ValueListParameterDisplayOnly',
+              ValueListProperty: 'name',
+            },
+          ],
+          PresentationVariantQualifier: 'VH',
+        }
+      });
+      description    :      String;
+      SAP_Messages   : many StateMessage;
+      _Nodes         :      Composition of many Nodes
+                              on _Nodes.Organization = $self;
+      _PreferredNode :      Composition of many smallNodes
+                              on _PreferredNode.Organization = $self;
+};
+
+@Aggregation.RecursiveHierarchy #NodesHierarchy             : {
+  NodeProperty            : ID,
+  ParentNavigationProperty: Superordinate
+}
+@Hierarchy.RecursiveHierarchy #NodesHierarchy               : {
+  ExternalKey           : ID,
+  LimitedDescendantCount: LimitedDescendantCount,
+  DistanceFromRoot      : DistanceFromRoot,
+  DrillState            : DrillState,
+  Matched               : Matched,
+  MatchedDescendantCount: MatchedDescendantCount,
+  LimitedRank           : LimitedRank,
+}
+@Aggregation.RecursiveHierarchy #NodesHierarchyFakeMove     : {
+  NodeProperty            : ID,
+  ParentNavigationProperty: Superordinate
+}
+@Hierarchy.RecursiveHierarchy #NodesHierarchyFakeMove       : {
+  ExternalKey           : ID,
+  LimitedDescendantCount: LimitedDescendantCount,
+  DistanceFromRoot      : DistanceFromRoot,
+  DrillState            : DrillState,
+  Matched               : Matched,
+  MatchedDescendantCount: MatchedDescendantCount,
+  LimitedRank           : LimitedRank,
+}
+@Hierarchy.RecursiveHierarchyActions #NodesHierarchyFakeMove: {
+  $Type                  : 'Hierarchy.RecursiveHierarchyActionsType',
+  ChangeNextSiblingAction: 'dummyAction',
+}
+@Capabilities.FilterRestrictions                            : {NonFilterableProperties: [
+  LimitedDescendantCount,
+  DistanceFromRoot,
+  DrillState,
+  Matched,
+  MatchedDescendantCount
+]}
+@Capabilities.SortRestrictions                              : {NonSortableProperties: [
+  LimitedDescendantCount,
+  DistanceFromRoot,
+  DrillState,
+  Matched,
+  MatchedDescendantCount
+]}
+entity Nodes {
+      @Core.Immutable: true
+      @Common.Label  : 'ID'
+  key ID                     : String;
+      parent                 : String;
+
+      @Common.Label  : 'Org level name'
+      name                   : String;
+
+      @UI.Hidden     : true
+      orgID                  : String;
+
+      @Common.Label  : 'HR Business Partner'
+      hrPartner              : String;
+
+      @Common.Label  : 'Number of employees'
+      employeeCount          : Integer;
+
+      @Core.Immutable: true
+      @Common.Label  : 'Node type'
+      nodeType               : String;
+      Superordinate          : Association to Nodes
+                                 on Superordinate.ID = parent @odata.draft.enclosed;
+      Organization           : Association to Organizations
+                                 on Organization.ID = orgID   @odata.draft.enclosed;
+
+      @Core.Computed : true
+      @UI.Hidden     : true
+      LimitedDescendantCount : Integer64;
+
+      @Core.Computed : true
+      @UI.Hidden     : true
+      DistanceFromRoot       : Integer64;
+
+      @Core.Computed : true
+      @UI.Hidden     : true
+      DrillState             : String;
+
+      @Core.Computed : true
+      @UI.Hidden     : true
+      Matched                : Boolean;
+
+      @Core.Computed : true
+      @UI.Hidden     : true
+      MatchedDescendantCount : Integer64;
+
+      @Core.Computed : true
+      @UI.Hidden     : true
+      LimitedRank            : Integer64;
+};
+
+entity smallNodes {
+      @Core.Immutable: true
+  key ID           : String                       @(Common: {
+        Label    : 'Preferred Node',
+        ValueList: {
+          CollectionPath              : 'Nodes',
+          Parameters                  : [
+            {
+              $Type            : 'Common.ValueListParameterInOut',
+              LocalDataProperty: ID,
+              ValueListProperty: 'ID',
+            },
+            {
+              $Type            : 'Common.ValueListParameterDisplayOnly',
+              ValueListProperty: 'name',
+            },
+          ],
+          PresentationVariantQualifier: 'VH',
+        }
+      });
+      orgID        : String;
+      Organization : Association to Organizations
+                       on Organization.ID = orgID @odata.draft.enclosed;
+};
+
+annotate Organizations with @UI: {
+  PresentationVariant #VH: {
+    $Type         : 'UI.PresentationVariantType',
+    Visualizations: ['@UI.LineItem', ]
+  },
+  SelectionFields        : [preferredNode],
+  LineItem               : [
+    {
+      $Type: 'UI.DataField',
+      Value: ID,
+    },
+    {
+      $Type: 'UI.DataField',
+      Value: description,
+    },
+  ],
+  HeaderInfo             : {
+    $Type         : 'UI.HeaderInfoType',
+    TypeName      : 'Organization',
+    TypeNamePlural: 'Organizations',
+    Title         : {
+      $Type: 'UI.DataField',
+      Value: ID,
+    },
+    Description   : {
+      $Type: 'UI.DataField',
+      Value: description,
+    },
+  },
+  Facets                 : [
+    {
+      $Type : 'UI.ReferenceFacet',
+      Target: '_Nodes/@UI.PresentationVariant',
+      Label : 'Nodes',
+    },
+    {
+      $Type : 'UI.ReferenceFacet',
+      Target: '@UI.FieldGroup#VH',
+      Label : 'Organization',
+    },
+  ],
+  FieldGroup #VH         : {Data: [
+    {
+      Value: preferredNode,
+      Label: 'Preferred Node'
+    },
+    {
+      Value: _PreferredNode.ID,
+      Label: 'Liked Nodes'
+    }
+  ]},
+};
+
+annotate Nodes with @UI: {
+  PresentationVariant    : {
+    $Type         : 'UI.PresentationVariantType',
+    RequestAtLeast: [nodeType],
+    Visualizations: ['@UI.LineItem', ],
+  },
+  PresentationVariant #VH: {
+    $Type                      : 'UI.PresentationVariantType',
+    Visualizations             : ['@UI.LineItem', ],
+    RecursiveHierarchyQualifier: 'NodesHierarchy',
+    InitialExpansionLevel      : 2
+  },
+  LineItem               : [
+    {
+      $Type: 'UI.DataField',
+      Value: name,
+    },
+    {
+      $Type: 'UI.DataField',
+      Value: employeeCount,
+    },
+    {
+      $Type: 'UI.DataField',
+      Value: nodeType,
+    },
+  ],
+  HeaderInfo             : {
+    $Type         : 'UI.HeaderInfoType',
+    TypeName      : 'Organization Level',
+    TypeNamePlural: 'Organization Levels',
+    Title         : {
+      $Type: 'UI.DataField',
+      Value: ID,
+    },
+    Description   : {
+      $Type: 'UI.DataField',
+      Value: ID,
+    },
+  },
+  FieldGroup             : {
+    $Type: 'UI.FieldGroupType',
+    Data : [
+      {
+        $Type: 'UI.DataField',
+        Value: name,
+      },
+      {
+        $Type: 'UI.DataField',
+        Value: hrPartner,
+      },
+      {
+        $Type: 'UI.DataField',
+        Value: employeeCount,
+      },
+    ],
+  },
+  Facets                 : [{
+    $Type : 'UI.ReferenceFacet',
+    Target: '@UI.FieldGroup',
+    Label : 'Informations',
+  }, ],
+};
+
+
+annotate Organizations with @Common: {Messages: SAP_Messages, };
+
+
+service Hierarchy {
+  @odata.draft.enabled
+  entity Organizations as projection on core.Organizations;
+
+  entity Nodes         as projection on core.Nodes;
+  entity smallNodes    as projection on core.smallNodes;
+}


### PR DESCRIPTION
Replaces https://github.com/SAP/open-ux-odata/pull/867

When doing a context.expand(MAX_SAFE_INTEGER), we should expand the node selected and all descendants.
This is done by returning all the children of the node, the type of node, the distance from root and the number of children a node has.
This has been checked on a working backend.