### PR TITLE
fix: We add ContentID to error details on changeset failure

### DIFF
--- a/.changeset/nine-pianos-grow.md
+++ b/.changeset/nine-pianos-grow.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+fix: We add ContentID to error details on changeset failure

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -12,6 +12,21 @@ import type { FilterExpression } from './filterParser';
 import { parseFilter } from './filterParser';
 import { parseSearch } from './searchParser';
 
+export type ErrorResponse = {
+    code: string;
+    message: string;
+    severity?: string;
+    details: ErrorDetails[];
+    '@Core.ContentID'?: string;
+} & Record<string, unknown>;
+
+export type ErrorDetails = {
+    code: string;
+    message: string;
+    severity?: string;
+    '@Core.ContentID'?: string;
+} & Record<string, unknown>;
+
 export type ExpandDefinition = {
     expand: Record<string, ExpandDefinition>;
     properties: SelectDefinition;
@@ -642,9 +657,13 @@ export default class ODataRequest {
      * @param errorObj Object containing error
      * @param errorObj.error Error object
      */
-    private addContentIdToErrorMessage(errorObj: { error?: { '@Core.ContentID'?: string } }) {
+    private addContentIdToErrorMessage(errorObj: { error?: ErrorResponse }) {
         if (this.contentId && errorObj?.error) {
             errorObj.error['@Core.ContentID'] = this.contentId;
+            const details = errorObj.error?.details ?? [];
+            details.forEach((errorDetail) => {
+                errorDetail['@Core.ContentID'] = this.contentId;
+            });
         }
     }
 

--- a/packages/fe-mockserver-core/src/router/batchRouter.ts
+++ b/packages/fe-mockserver-core/src/router/batchRouter.ts
@@ -3,23 +3,11 @@ import type { ServerResponse } from 'http';
 import * as http from 'http';
 import type { ExecutionError } from '../data/common';
 import type { DataAccess } from '../data/dataAccess';
+import type { ErrorDetails, ErrorResponse } from '../request/odataRequest';
 import ODataRequest from '../request/odataRequest';
 import type { Batch, BatchPart } from './batchParser';
 import { BatchContent, getBoundary, parseBatch } from './batchParser';
 import type { IncomingMessageWithTenant } from './serviceRouter';
-
-type ErrorResponse = {
-    code: string;
-    message: string;
-    severity?: string;
-    details: ErrorDetails[];
-} & Record<string, unknown>;
-
-type ErrorDetails = {
-    code: string;
-    message: string;
-    severity?: string;
-} & Record<string, unknown>;
 
 type ErrorInfo = {
     header: string;

--- a/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
+++ b/packages/fe-mockserver-core/test/unit/__testData/RootElement.js
@@ -67,12 +67,22 @@ module.exports = {
                 break;
             case 'boundActionChangeSet':
                 if (keys['ID'] == '3') {
-                    this.throwError('unbound transition error', 500, {
+                    this.throwError('Bound transition error', 500, {
                         error: {
                             code: 500,
-                            message: 'unbound transition error',
+                            message: 'Bound transition error',
                             transition: true,
-                            '@Common.numericSeverity': 4
+                            '@Common.numericSeverity': 4,
+                            target: 'self',
+                            details: [
+                                {
+                                    code: '500',
+                                    message: `Unable to execute the action due to a error. ID: ${keys['ID']}`,
+                                    '@Common.numericSeverity': 4,
+                                    transition: true,
+                                    target: 'self/Prop1'
+                                }
+                            ]
                         }
                     });
                 } else {

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -516,7 +516,7 @@ Group ID: $auto`
             content-type: application/json;odata.metadata=minimal;IEEE754Compatible=true
             odata-version: 4.0
 
-            {"error":{"code":500,"message":"unbound transition error","transition":true,"@Common.numericSeverity":4,"@Core.ContentID":"1.0"}}
+            {"error":{"code":500,"message":"Bound transition error","transition":true,"@Common.numericSeverity":4,"target":"self","details":[{"code":"500","message":"Unable to execute the action due to a error. ID: 3","@Common.numericSeverity":4,"transition":true,"target":"self/Prop1","@Core.ContentID":"1.0"}],"@Core.ContentID":"1.0"}}
             --batch_id-1719917686303-234--
             "
         `);


### PR DESCRIPTION
We previously added content Id to root error object on changeset failure.
We now add content Ids to error details as well.