### PR TITLE
feat: update to router 2.0.0

### DIFF
--- a/.changeset/swift-ants-think.md
+++ b/.changeset/swift-ants-think.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': minor
+---
+
+Update to router 2.x

--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
         "pnpm": "9",
         "node": ">=18.0.0 < 19.0.0 || >=20.0.0 < 21.0.0"
     },
-    "packageManager": "pnpm@9.7pnpm.0"
+    "packageManager": "pnpm@9.7.0"
 }

--- a/package.json
+++ b/package.json
@@ -47,11 +47,5 @@
         "pnpm": "9",
         "node": ">=18.0.0 < 19.0.0 || >=20.0.0 < 21.0.0"
     },
-    "packageManager": "pnpm@9.7.0",
-    "pnpm": {
-        "overrides": {
-            "body-parser": "1.20.3",
-            "path-to-regexp": "0.1.10"
-        }
-    }
+    "packageManager": "pnpm@9.7pnpm.0"
 }

--- a/packages/fe-mockserver-core/package.json
+++ b/packages/fe-mockserver-core/package.json
@@ -40,7 +40,7 @@
         "lodash.clonedeep": "4.5.0",
         "lodash.merge": "4.6.2",
         "query-string": "7.1.3",
-        "router": "1.3.8"
+        "router": "2.0.0"
     },
     "devDependencies": {
         "@sap-ux/vocabularies-types": "workspace:*",

--- a/packages/fe-mockserver-core/src/middleware.ts
+++ b/packages/fe-mockserver-core/src/middleware.ts
@@ -44,7 +44,10 @@ function prepareCatalogAndAnnotation(app: IRouter, newConfig: MockserverConfigur
     app.use('/sap/opu/odata/IWFND/CATALOGSERVICE;v=2', catalogServiceRouter(newConfig.services as ServiceConfigEx[]));
     // Prepare the annotation files
     for (const mockAnnotation of newConfig.annotations || []) {
-        const escapedPath = escapeRegex(mockAnnotation.urlPath);
+        let escapedPath = escapeRegex(mockAnnotation.urlPath);
+        if (escapedPath.endsWith('*')) {
+            escapedPath += 'rest';
+        }
         app.get(escapedPath, async (_req: IncomingMessage, res: ServerResponse) => {
             try {
                 const data = await fileLoader.loadFile(mockAnnotation.localPath);

--- a/packages/fe-mockserver-core/src/router/catalogServiceRouter.ts
+++ b/packages/fe-mockserver-core/src/router/catalogServiceRouter.ts
@@ -74,7 +74,7 @@ export function catalogServiceRouter(servicesConfig: ServiceConfigEx[], version 
         res.end();
     });
 
-    router.get('/ServiceCollection\\(*', (_req: IncomingMessage, res: ServerResponse) => {
+    router.get('/ServiceCollection\\(*rest', (_req: IncomingMessage, res: ServerResponse) => {
         res.setHeader('content-type', 'application/json');
         res.write(
             JSON.stringify({

--- a/packages/fe-mockserver-core/src/router/serviceRouter.ts
+++ b/packages/fe-mockserver-core/src/router/serviceRouter.ts
@@ -61,7 +61,7 @@ export async function serviceRouter(service: ServiceConfigEx, dataAccess: DataAc
     });
 
     // Deal with the $metadata support
-    router.get('/\\$metadata', (_req: IncomingMessage, res: ServerResponse) => {
+    router.get('/$metadata', (_req: IncomingMessage, res: ServerResponse) => {
         res.setHeader('Content-Type', 'application/xml');
         if (service.ETag) {
             res.setHeader('ETag', service.ETag);
@@ -70,7 +70,7 @@ export async function serviceRouter(service: ServiceConfigEx, dataAccess: DataAc
         res.write(dataAccess.getMetadata().getEdmx());
         res.end();
     });
-    router.post('/\\$metadata/reload', (_req: IncomingMessage, res: ServerResponse) => {
+    router.post('/$metadata/reload', (_req: IncomingMessage, res: ServerResponse) => {
         dataAccess.reloadData();
         res.setHeader('Content-Type', 'application/json');
         res.write(JSON.stringify({ message: 'Reload success' }));
@@ -157,7 +157,7 @@ export async function serviceRouter(service: ServiceConfigEx, dataAccess: DataAc
 
     router.use('/\\$batch', batchRouter(dataAccess));
 
-    router.route('/*').all(async (req: IncomingMessageWithTenant, res: ServerResponse, next: NextFunction) => {
+    router.route('/*all').all(async (req: IncomingMessageWithTenant, res: ServerResponse, next: NextFunction) => {
         try {
             const oDataRequest = new ODataRequest(
                 {
@@ -193,7 +193,7 @@ export async function serviceRouter(service: ServiceConfigEx, dataAccess: DataAc
         }
     });
 
-    router.use('*', (err: any, _req: IncomingMessage, res: ServerResponse, next: NextFunction) => {
+    router.use('*all', (err: any, _req: IncomingMessage, res: ServerResponse, next: NextFunction) => {
         log.error(err);
         if (res.headersSent) {
             return next(err);

--- a/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
+++ b/packages/fe-mockserver-core/test/unit/__testData/Requestor.ts
@@ -156,7 +156,11 @@ export class ODataV4ListRequest<T> extends ODataRequest<T> {
      * @param relative
      */
     protected buildUrl(relative: boolean): string {
-        const baseUrl = `${!relative ? this.odataRootUri + '/' : ''}${this.targetPath}`;
+        let targetPath = this.targetPath;
+        if (relative && targetPath.startsWith('/')) {
+            targetPath = targetPath.substring(1);
+        }
+        const baseUrl = `${!relative ? this.odataRootUri : ''}${targetPath}`;
         const urlParts = [];
         if (this.selectDefinition) {
             urlParts.push('$select=' + this.selectDefinition.join(','));
@@ -319,9 +323,9 @@ export class ODataV4ObjectRequest<T> extends ODataRequest<T> {
         });
         let url;
         if (keys.length) {
-            url = `${!relative ? this.odataRootUri + '/' : ''}${this.targetPath}(${keys.join(',')})`;
+            url = `${!relative ? this.odataRootUri : ''}${this.targetPath}(${keys.join(',')})`;
         } else {
-            url = `${!relative ? this.odataRootUri + '/' : ''}${this.targetPath}`;
+            url = `${!relative ? this.odataRootUri : ''}${this.targetPath}`;
         }
 
         return url;

--- a/packages/fe-mockserver-core/test/unit/middleware.test.ts
+++ b/packages/fe-mockserver-core/test/unit/middleware.test.ts
@@ -88,9 +88,9 @@ describe('V4 Requestor', function () {
 
     it('can get some data', async () => {
         const dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');
-        const dataRes = await dataRequestor.getList<any>('RootElement').execute();
+        const dataRes = await dataRequestor.getList<any>('/RootElement').execute();
         expect(dataRes.body.length).toBe(4);
-        const dataRes2 = await dataRequestor.getList<any>('RootElement').executeAsBatch();
+        const dataRes2 = await dataRequestor.getList<any>('/RootElement').executeAsBatch();
         expect(dataRes2.length).toBe(4);
     });
     it('can execute an action without return type', async () => {
@@ -303,29 +303,31 @@ describe('V4 Requestor', function () {
     });
     it('can update data through a call', async () => {
         const dataRequestor = new ODataV4Requestor('http://localhost:33331/tenant-001/sap/fe/core/mock/action');
-        let dataRes = await dataRequestor.createData<any>('RootElement', { ID: 556 }).execute();
+        let dataRes = await dataRequestor.createData<any>('/RootElement', { ID: 556 }).execute();
         delete dataRes.body.DraftAdministrativeData;
         delete dataRes.body['@odata.etag'];
         expect(dataRes.body).toMatchSnapshot();
-        dataRes = await dataRequestor.updateData<any>('RootElement(ID=556)', { Prop1: 'MyNewProp1' }).execute();
+        dataRes = await dataRequestor.updateData<any>('/RootElement(ID=556)', { Prop1: 'MyNewProp1' }).execute();
         delete dataRes.body.DraftAdministrativeData;
         delete dataRes.body['@odata.etag'];
         expect(dataRes.body).toMatchSnapshot();
-        const dataRes2 = await dataRequestor.getList<any>('RootElement').executeAsBatch();
+        const dataRes2 = await dataRequestor.getList<any>('/RootElement').executeAsBatch();
         expect(dataRes2.length).toBe(5);
         expect(dataRes2[4].ID).toBe(556);
         expect(dataRes2[4].Prop1).toBe('MyNewProp1');
 
         // update something that does not exist
-        const res = await dataRequestor.updateData<any>('RootElement(ID=557)', { Prop1: 'MyNewProp1' }).execute();
+        const res = await dataRequestor.updateData<any>('/RootElement(ID=557)', { Prop1: 'MyNewProp1' }).execute();
         expect(res.status).toBe(404);
 
         // Deep update
-        const res2 = await dataRequestor.updateData<any>('RootElement(ID=556)/Prop1', 'Lali-ho', true, 'PUT').execute();
+        const res2 = await dataRequestor
+            .updateData<any>('/RootElement(ID=556)/Prop1', 'Lali-ho', true, 'PUT')
+            .execute();
         delete res2.body.DraftAdministrativeData;
         expect(res2.body).toMatchSnapshot();
         const res3 = await dataRequestor
-            .updateData<any>('RootElement(ID=556)/Prop1', 'Lali-hoho', true, 'PUT', {
+            .updateData<any>('/RootElement(ID=556)/Prop1', 'Lali-hoho', true, 'PUT', {
                 'If-Match': dataRes2[4]['@odata.etag']
             })
             .execute();
@@ -333,22 +335,22 @@ describe('V4 Requestor', function () {
         const newEtag = res3.body['@odata.etag'];
         delete res3.body['@odata.etag'];
         expect(res3.body).toMatchSnapshot();
-        const dataRes3 = await dataRequestor.getList<any>('RootElement').executeAsBatch();
+        const dataRes3 = await dataRequestor.getList<any>('/RootElement').executeAsBatch();
         expect(dataRes3.length).toBe(5);
         expect(dataRes3[4].ID).toBe(556);
         expect(dataRes3[4].Prop1).toBe('Lali-hoho');
         const res4 = await dataRequestor
-            .updateData<any>('RootElement(ID=556)/Prop1', 'Lali', true, 'PUT', {
+            .updateData<any>('/RootElement(ID=556)/Prop1', 'Lali', true, 'PUT', {
                 'If-Match': dataRes2[4]['@odata.etag']
             })
             .execute();
         expect(res4.body).toMatchSnapshot();
-        const dataRes4 = await dataRequestor.getList<any>('RootElement').executeAsBatch();
+        const dataRes4 = await dataRequestor.getList<any>('/RootElement').executeAsBatch();
         expect(dataRes4.length).toBe(5);
         expect(dataRes4[4].ID).toBe(556);
         expect(dataRes4[4].Prop1).toBe('Lali-hoho');
         const res5 = await dataRequestor
-            .updateData<any>('RootElement(ID=556)/Prop1', 'Lali', true, 'PUT', {
+            .updateData<any>('/RootElement(ID=556)/Prop1', 'Lali', true, 'PUT', {
                 'If-Match': newEtag
             })
             .execute();
@@ -382,7 +384,7 @@ describe('V4 Requestor', function () {
             );
 
             const updated = await dataRequestor
-                .updateData<any>(`Root(ID=${id})`, { data: 'Updated Data' }, false, 'PATCH', {
+                .updateData<any>(`/Root(ID=${id})`, { data: 'Updated Data' }, false, 'PATCH', {
                     'sap-contextid': contextId
                 })
                 .execute();
@@ -434,7 +436,7 @@ Content-Type:application/json;charset=UTF-8;IEEE754Compatible=true
         const dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');
 
         // /RootElement?$expand=_Elements($select=ID)) --> too many closing parentheses!
-        const dataReq = dataRequestor.getList<any>('RootElement');
+        const dataReq = dataRequestor.getList<any>('/RootElement');
         dataReq.expand({ _Elements: { select: ['ID)'] } });
 
         const response = await dataReq.execute();
@@ -442,7 +444,7 @@ Content-Type:application/json;charset=UTF-8;IEEE754Compatible=true
     });
     it('can get some data after changing the watch mode', async () => {
         let dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');
-        let dataRes = await dataRequestor.getList<any>('RootElement').execute();
+        let dataRes = await dataRequestor.getList<any>('/RootElement').execute();
         expect(dataRes.body.length).toBe(4);
         expect(dataRes.body[0].Prop1).toBe('First Prop');
         const myJSON = JSON.parse(
@@ -456,7 +458,7 @@ Content-Type:application/json;charset=UTF-8;IEEE754Compatible=true
         });
         setTimeout(async function () {
             dataRequestor = new ODataV4Requestor('http://localhost:33331/sap/fe/core/mock/action');
-            dataRes = await dataRequestor.getList<any>('RootElement').execute();
+            dataRes = await dataRequestor.getList<any>('/RootElement').execute();
             expect(dataRes.body.length).toBe(4);
             expect(dataRes.body[0].Prop1).toBe('SomethingElse');
             resolveFn();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  body-parser: 1.20.3
-  path-to-regexp: 0.1.10
-
 importers:
 
   .:
@@ -135,8 +131,8 @@ importers:
         specifier: 7.1.3
         version: 7.1.3
       router:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
       '@sap-ux/fe-mockserver-plugin-cds':
         specifier: workspace:*
@@ -202,8 +198,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui5-middleware-fe-mockserver
       '@ui5/cli':
-        specifier: 3.11.1
-        version: 3.11.1
+        specifier: 3.11.4
+        version: 3.11.4
 
   samples/error-handling:
     devDependencies:
@@ -211,8 +207,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui5-middleware-fe-mockserver
       '@ui5/cli':
-        specifier: 3.11.1
-        version: 3.11.1
+        specifier: 3.11.4
+        version: 3.11.4
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
@@ -223,8 +219,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui5-middleware-fe-mockserver
       '@ui5/cli':
-        specifier: 3.11.1
-        version: 3.11.1
+        specifier: 3.11.4
+        version: 3.11.4
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
@@ -920,8 +916,8 @@ packages:
     resolution: {integrity: sha512-RpiWIarR876+CILtbzCM0hAjMA0oYkS6N/UIocnwPIOKCfZKrDJnpBoAnzgyq/fOF+jm9XXhSnJrkXnyvPPysw==}
     engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
 
-  '@ui5/cli@3.11.1':
-    resolution: {integrity: sha512-LBrKt6MIWlL0p8BgKHDQA3vQmCuLYencioLW3siArFKGBW3Mq5bVzSv0GwWCn/haxEQr5GduRIu0D3UOuKkoXQ==}
+  '@ui5/cli@3.11.4':
+    resolution: {integrity: sha512-SRHCZEDHJViZUdChWdzAb3y2OasnfvHyMFgiB8HF86Md0NKQBFTVl7TkrGocZB6xEdba/8HsELRW1t7QUYTxnA==}
     engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
     hasBin: true
 
@@ -942,8 +938,8 @@ packages:
     resolution: {integrity: sha512-IkpDXWWiTE7eZibcQoWi09zbXAn+FJJN3boXNpZBVUxzqiqZRVatRLWdKD4TvyLZ7FvAikkufGkl+z/h2r20cQ==}
     engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
 
-  '@ui5/server@3.2.1':
-    resolution: {integrity: sha512-WFiL2/5sl5sO9w1+SeRLWSoEUjIlgGRimS3StuKAaeJXHQx83UUfP4tLwmhUsYlu6BOL8DHF5jOjIkR/g1FACg==}
+  '@ui5/server@3.3.0':
+    resolution: {integrity: sha512-AsqYgr3rTXwsnoaSX3tm78QeiKoKSOMDKR/s60lyTmANIuheECDK9JBLv6NIzp6chCp8Cbbdp/mMScnVlLy7QA==}
     engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
 
   '@ungap/structured-clone@1.2.0':
@@ -1068,10 +1064,10 @@ packages:
     engines: {node: '>= 0.4'}
 
   array-flatten@1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/array-flatten/-/array-flatten-1.1.1.tgz}
 
   array-flatten@3.0.0:
-    resolution: {integrity: sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==}
+    resolution: {integrity: sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/array-flatten/-/array-flatten-3.0.0.tgz}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -1141,6 +1137,10 @@ packages:
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
+  body-parser@1.20.2:
+    resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -1396,7 +1396,7 @@ packages:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/cookie/-/cookie-0.6.0.tgz}
     engines: {node: '>= 0.6'}
 
   core-util-is@1.0.3:
@@ -2334,6 +2334,9 @@ packages:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/is-promise/-/is-promise-4.0.0.tgz}
+
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -2915,11 +2918,6 @@ packages:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
     engines: {node: '>=0.12.0'}
 
-  nopt@7.2.0:
-    resolution: {integrity: sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    hasBin: true
-
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -3142,8 +3140,12 @@ packages:
     resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  path-to-regexp@0.1.7:
+    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3284,7 +3286,7 @@ packages:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qs@6.11.0:
-    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/qs/-/qs-6.11.0.tgz}
     engines: {node: '>=0.6'}
 
   qs@6.13.0:
@@ -3444,9 +3446,9 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
-  router@1.3.8:
-    resolution: {integrity: sha512-461UFH44NtSfIlS83PUg2N7OZo86BC/kB3dY77gJdsODsBhhw7+2uE0tzTINxrY9CahCUVk1VhpWCA5i1yoIEg==}
-    engines: {node: '>= 0.8'}
+  router@2.0.0:
+    resolution: {integrity: sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==}
+    engines: {node: '>= 0.10'}
 
   run-applescript@5.0.0:
     resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
@@ -3728,10 +3730,6 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-
-  tar@6.1.15:
-    resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
-    engines: {node: '>=10'}
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
@@ -5175,13 +5173,13 @@ snapshots:
       workerpool: 6.5.1
       xml2js: 0.6.2
 
-  '@ui5/cli@3.11.1':
+  '@ui5/cli@3.11.4':
     dependencies:
       '@ui5/builder': 3.5.1
       '@ui5/fs': 3.0.5
       '@ui5/logger': 3.0.0
       '@ui5/project': 3.9.2
-      '@ui5/server': 3.2.1
+      '@ui5/server': 3.3.0
       chalk: 5.3.0
       data-with-position: 0.5.0
       import-local: 3.2.0
@@ -5246,7 +5244,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@ui5/server@3.2.1':
+  '@ui5/server@3.3.0':
     dependencies:
       '@ui5/builder': 3.5.1
       '@ui5/fs': 3.0.5
@@ -5264,7 +5262,7 @@ snapshots:
       parseurl: 1.3.3
       portscanner: 2.2.0
       replacestream: 4.0.3
-      router: 1.3.8
+      router: 2.0.0
       spdy: 4.0.2
       yesno: 0.4.0
     transitivePeerDependencies:
@@ -5475,6 +5473,23 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@1.20.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
@@ -5569,7 +5584,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 4.0.0
       ssri: 10.0.4
-      tar: 6.1.15
+      tar: 6.2.1
       unique-filename: 3.0.0
 
   cacheable-lookup@7.0.0: {}
@@ -6273,7 +6288,7 @@ snapshots:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.2
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.6.0
@@ -6290,7 +6305,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.7
       proxy-addr: 2.0.7
       qs: 6.11.0
       range-parser: 1.2.1
@@ -6812,6 +6827,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@1.1.0: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.1.4:
     dependencies:
@@ -7549,7 +7566,7 @@ snapshots:
       glob: 10.3.10
       graceful-fs: 4.2.11
       make-fetch-happen: 13.0.1
-      nopt: 7.2.0
+      nopt: 7.2.1
       proc-log: 4.2.0
       semver: 7.6.3
       tar: 6.2.1
@@ -7562,10 +7579,6 @@ snapshots:
   node-releases@2.0.18: {}
 
   node-stream-zip@1.15.0: {}
-
-  nopt@7.2.0:
-    dependencies:
-      abbrev: 2.0.0
 
   nopt@7.2.1:
     dependencies:
@@ -7767,7 +7780,7 @@ snapshots:
       promise-retry: 2.0.1
       sigstore: 2.2.2
       ssri: 10.0.4
-      tar: 6.1.15
+      tar: 6.2.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -7819,7 +7832,9 @@ snapshots:
       lru-cache: 10.0.1
       minipass: 7.0.4
 
-  path-to-regexp@0.1.10: {}
+  path-to-regexp@0.1.7: {}
+
+  path-to-regexp@8.2.0: {}
 
   path-type@4.0.0: {}
 
@@ -8102,17 +8117,15 @@ snapshots:
     dependencies:
       glob: 10.3.10
 
-  router@1.3.8:
+  router@2.0.0:
     dependencies:
       array-flatten: 3.0.0
-      debug: 2.6.9
+      is-promise: 4.0.0
       methods: 1.1.2
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 8.2.0
       setprototypeof: 1.2.0
       utils-merge: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   run-applescript@5.0.0:
     dependencies:
@@ -8434,15 +8447,6 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  tar@6.1.15:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
 
   tar@6.2.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1064,10 +1064,10 @@ packages:
     engines: {node: '>= 0.4'}
 
   array-flatten@1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/array-flatten/-/array-flatten-1.1.1.tgz}
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-flatten@3.0.0:
-    resolution: {integrity: sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/array-flatten/-/array-flatten-3.0.0.tgz}
+    resolution: {integrity: sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -1396,7 +1396,7 @@ packages:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/cookie/-/cookie-0.6.0.tgz}
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
   core-util-is@1.0.3:
@@ -2335,7 +2335,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/is-promise/-/is-promise-4.0.0.tgz}
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -3286,7 +3286,7 @@ packages:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qs@6.11.0:
-    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==, tarball: https://int.repositories.cloud.sap/artifactory/api/npm/build-releases-npm/qs/-/qs-6.11.0.tgz}
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
     engines: {node: '>=0.6'}
 
   qs@6.13.0:

--- a/samples/basic-usage/package.json
+++ b/samples/basic-usage/package.json
@@ -15,7 +15,7 @@
     },
     "devDependencies": {
         "@sap-ux/ui5-middleware-fe-mockserver": "workspace:*",
-        "@ui5/cli": "3.11.1"
+        "@ui5/cli": "3.11.4"
     },
     "ui5": {
         "dependencies": [

--- a/samples/error-handling/package.json
+++ b/samples/error-handling/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@sap-ux/ui5-middleware-fe-mockserver": "workspace:*",
-        "@ui5/cli": "3.11.1",
+        "@ui5/cli": "3.11.4",
         "rimraf": "3.0.2"
     },
     "ui5": {

--- a/samples/function-import/package.json
+++ b/samples/function-import/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@sap-ux/ui5-middleware-fe-mockserver": "workspace:*",
-        "@ui5/cli": "3.11.1",
+        "@ui5/cli": "3.11.4",
         "rimraf": "3.0.2"
     },
     "ui5": {


### PR DESCRIPTION
For security reason we can't use the old one anymore. This shouldn't change anything but the matching regexp are a bit more strict than they were before (especially around double / in front)