### PR TITLE
fix: we now properly support annotations on parameter overload

### DIFF
--- a/.changeset/quiet-suits-cough.md
+++ b/.changeset/quiet-suits-cough.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-converter': patch
+---
+
+Action parameter on action with collection now properly consider the unspecific anntoations on top of the overloaded ones

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -1477,7 +1477,7 @@ function convertActionParameter(
         // annotations on action parameters are resolved following the rules for actions
         const unspecificOverloadTarget =
             rawActionParameter.fullyQualifiedName.substring(0, rawActionParameter.fullyQualifiedName.indexOf('(')) +
-            rawActionParameter.fullyQualifiedName.substring(rawActionParameter.fullyQualifiedName.indexOf(')') + 1);
+            rawActionParameter.fullyQualifiedName.substring(rawActionParameter.fullyQualifiedName.lastIndexOf(')') + 1);
         const specificOverloadTarget = rawActionParameter.fullyQualifiedName;
 
         const effectiveAnnotations = converter.getAnnotations(specificOverloadTarget);

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -37,6 +37,38 @@ import { convert, defaultReferences, revertTermToGenericType } from '../src';
 import { loadFixture } from './fixturesHelper';
 
 describe('Annotation Converter', () => {
+    it('can convert EDMX with action annotations', async () => {
+        const parsedEDMX = parse(await loadFixture('v4/actions/metadata.xml'));
+        const parsedAnnotation = parse(await loadFixture('v4/actions/annotations.xml'), 'annotations');
+        const result = merge(parsedEDMX, parsedAnnotation);
+        const convertedTypes = convert(result);
+        expect(
+            convertedTypes.actions.by_fullyQualifiedName(
+                'com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber(Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType))'
+            )
+        ).not.toBeUndefined();
+        expect(
+            convertedTypes.actions.by_fullyQualifiedName(
+                'com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber(Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType))'
+            )?.annotations
+        ).not.toBeUndefined();
+        expect(
+            convertedTypes.actions
+                .by_fullyQualifiedName(
+                    'com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber(Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType))'
+                )
+                ?.parameters.by_name('_SerialList')
+        ).not.toBeUndefined();
+        expect(
+            convertedTypes.actions
+                .by_fullyQualifiedName(
+                    'com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber(Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType))'
+                )
+                ?.parameters.by_name('_SerialList')
+                ?.annotations.UI?.Hidden?.valueOf()
+        ).not.toBeUndefined();
+    });
+
     it('can convert EDMX with multiple schemas', async () => {
         const parsedEDMX = parse(await loadFixture('northwind.metadata.xml'));
         const convertedTypes = convert(parsedEDMX);

--- a/packages/annotation-converter/test/fixtures/v4/actions/annotations.xml
+++ b/packages/annotation-converter/test/fixtures/v4/actions/annotations.xml
@@ -1,0 +1,774 @@
+        <!--
+
+            Copyright (C) 2009- SAP SE or an SAP affiliate company. All rights reserved.
+
+         -->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+        <edmx:Include Namespace="com.sap.vocabularies.Common.v1" Alias="Common"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+        <edmx:Include Namespace="com.sap.vocabularies.UI.v1" Alias="UI"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata4/sap/eam_sb_materialserialnumber/srvd/sap/eam_materialserialnumber/0001/$metadata">
+        <edmx:Include Namespace="com.sap.gateway.srvd.eam_materialserialnumber.v0001" Alias="SAP__self"/>
+        <edmx:Include Namespace="com.sap.vocabularies.UI.v1" Alias="SAP__UI"/>
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="local">
+            <Annotations Target="SAP__self.I_MaterialSerialNumberVHType/UniqueItemIdentifier">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifier">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifierStrucType">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifierRespPlant">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/ConcatenatedActiveUserStsName">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/EquipMaterialLastSerialNumber">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/ReadOnly"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/SetSrlzdMaterialItemToInactive">
+                <Annotation Term="com.sap.vocabularies.Common.v1.SideEffects" Qualifier="LastChangeDateTimeChanged">
+                    <Record>
+                        <!--  <PropertyValue Property="SourceProperties">
+                                                    <Collection>
+                                                        <PropertyPath>LastChangeDateTime</PropertyPath>
+                                                    </Collection>
+                                                </PropertyValue>  -->
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_EquipMatlSrlNmbrChgHistoryTP</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <!--  <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/Material">
+                            <Annotation Term="Common.SemanticObject" Qualifier="TechnicalObjectLinks">
+                                <String>MaintenanceObject</String>
+                            </Annotation >
+                        </Annotations>  -->
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/Material">
+                <Annotation Term="Common.SemanticObject" Qualifier="MaterialLinks">
+                    <String>Material</String>
+                </Annotation>
+                <Annotation Term="Common.SemanticObjectUnavailableActions" Qualifier="MaterialLinks">
+                    <Collection>
+                        <String>displayInAssetViewer</String>
+                        <String>displayBreakdownAnalysis</String>
+                        <String>displayDamageAnalysis</String>
+                        <String>postprocessDataTransfer</String>
+                        <String>transferDataFromEquipment</String>
+                        <String>transferDataFromFunctionalLoc</String>
+                        <String>analyzeInventoryTurnover</String>
+                        <String>analyzeInventoryKPIsTimeseries</String>
+                        <String>analyzeStockinDateRange</String>
+                        <String>displayDeadStock</String>
+                        <String>displayMaterialDocuments</String>
+                        <String>displayOverdueGRBlockedStock</String>
+                        <String>displayOverdueStockInTransit</String>
+                        <String>displaySerialNumberInfo</String>
+                        <String>displaySerStockInfo</String>
+                        <String>displaySlowOrNonMoving</String>
+                        <String>displayStockForPostingDate</String>
+                        <String>displayStockInTransitInWebGUI</String>
+                        <String>displayStockMultipleMaterials</String>
+                        <String>displayStockOverview</String>
+                        <String>displayStockOverviewInWebGUI</String>
+                        <String>displayWarehouseStockInWebGUI</String>
+                        <String>manageBySubcontractingSupplier</String>
+                        <String>postGoodsIssueInWebGUI</String>
+                        <String>postGoodsMovementInWebGUI</String>
+                        <String>postGoodsReceiptInWebGUI</String>
+                        <String>postTransferPostingInWebGUI</String>
+                        <String>transferStock</String>
+                        <String>transferStockCrossPlant</String>
+                        <String>change</String>
+                        <String>create</String>
+                        <String>displayEquipment</String>
+                        <String>display</String>
+                        <String>displayFactSheet</String>
+                        <String>createMatlSerialNumber</String>
+                        <String>createMultipleMatlSerialNumber</String>
+                        <String>displayComplianceInfo</String>
+                        <String>activatePlannedChanges</String>
+                        <String>maintainCyCIndicator</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="Common.SemanticObjectMapping">
+                    <Collection>
+                        <Record Type="Common.SemanticObjectMappingType">
+                            <PropertyValue Property="LocalProperty" PropertyPath="TechnicalObject"/>
+                            <PropertyValue Property="SemanticObjectProperty" String="Equipment"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/EquipmentName">
+                <Annotation Term="UI.Hidden">
+                    <If>
+                        <Eq>
+                            <Path>HasEquipmentData</Path>
+                            <Bool>false</Bool>
+                        </Eq>
+                        <Bool>true</Bool>
+                        <Bool>false</Bool>
+                    </If>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/TechnicalObject">
+                <Annotation Term="Common.SemanticObjectUnavailableActions">
+                    <Collection>
+                        <String>displayInAssetViewer</String>
+                        <String>changeMatlSerialNumber</String>
+                        <String>createMatlSerialNumber</String>
+                        <String>createMultipleMatlSerialNumber</String>
+                        <String>displayMatlSerialNumberList</String>
+                        <String>displayMatlSerialNumber</String>
+                        <String>displayBreakdownAnalysis</String>
+                        <String>displayDamageAnalysis</String>
+                        <String>postprocessDataTransfer</String>
+                        <String>transferDataFromEquipment</String>
+                        <String>transferDataFromFunctionalLoc</String>
+                        <String>displayFactSheet</String>
+                        <String>createMatlSerialNumber</String>
+                        <String>createMultipleMatlSerialNumber</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="Common.SemanticObjectMapping">
+                    <Collection>
+                        <Record Type="Common.SemanticObjectMappingType">
+                            <PropertyValue Property="LocalProperty" PropertyPath="TechObjIsEquipOrFuncnlLoc"/>
+                            <PropertyValue Property="SemanticObjectProperty" String="TechObjIsEquipOrFuncnlLoc"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType">
+                <Annotation Term="SAP__UI.SelectionFields">
+                    <Collection>
+                        <PropertyPath>Material</PropertyPath>
+                        <PropertyPath>SerialNumber</PropertyPath>
+                        <PropertyPath>Equipment</PropertyPath>
+                        <PropertyPath>ConcatenatedActiveSystStsName</PropertyPath>
+                        <PropertyPath>InventoryStockType</PropertyPath>
+                        <PropertyPath>EquipmentCategory</PropertyPath>
+                        <PropertyPath>Plant</PropertyPath>
+                        <PropertyPath>MaterialSerialNumberStockBatch</PropertyPath>
+                        <PropertyPath>StorageLocation</PropertyPath>
+                        <PropertyPath>Customer</PropertyPath>
+                        <PropertyPath>HasEquipmentData</PropertyPath>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataFieldForIntentBasedNavigation">
+                            <PropertyValue Property="Label" String="{@i18n>serialNumberHistory}"/>
+                            <PropertyValue Property="SemanticObject" String="Material"/>
+                            <PropertyValue Property="Action" String="displaySerHistoryInfo"/>
+                            <PropertyValue Property="RequiresContext" Bool="false"/>
+                            <PropertyValue Property="NavigationAvailable" Bool="true"/>
+                            <Annotation Term="UI.Hidden">
+                                <If>
+                                    <Or>
+                                        <And>
+                                            <Eq>
+                                                <Path>HasActiveEntity</Path>
+                                                <Bool>false</Bool>
+                                            </Eq>
+                                            <Eq>
+                                                <Path>IsActiveEntity</Path>
+                                                <Bool>true</Bool>
+                                            </Eq>
+                                        </And>
+                                        <And>
+                                            <Eq>
+                                                <Path>HasActiveEntity</Path>
+                                                <Bool>true</Bool>
+                                            </Eq>
+                                            <Eq>
+                                                <Path>IsActiveEntity</Path>
+                                                <Bool>false</Bool>
+                                            </Eq>
+                                        </And>
+                                    </Or>
+                                    <Bool>false</Bool>
+                                    <Bool>true</Bool>
+                                </If>
+                            </Annotation>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>activateEquipmentView}"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ActvtSrlzdMatlItmEquipmentData(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>changeEquipmentCategory}"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeEquipmentCategory(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>changePlant}"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeMaintenancePlant(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <Annotation Term="UI.Hidden">
+                                <If>
+                                    <Eq>
+                                        <Path>IsCloudSystem</Path>
+                                        <Bool>true</Bool>
+                                    </Eq>
+                                    <Bool>true</Bool>
+                                    <Bool>false</Bool>
+                                </If>
+                            </Annotation>
+                            <PropertyValue Property="Label" String="{@i18n>changeUII}"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeUniqueItemIdentifier(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>setMaterialItemInactive}"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>resetMaterialItemInactive}"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.RsetSrlzdMatlItemFromInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>setMaterialItemDeletion}"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>resetMaterialItemDeletion}"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ResetSrlzdMatlItmFrmDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.ConnectedFields" Qualifier="SalesOrder">
+                    <Record>
+                        <PropertyValue Property="Data">
+                            <Record>
+                                <PropertyValue Property="SalesOrder">
+                                    <Record Type="UI.DataField">
+                                        <PropertyValue Property="Value" Path="SalesOrder"/>
+                                    </Record>
+                                </PropertyValue>
+                                <PropertyValue Property="SalesOrderItem">
+                                    <Record Type="UI.DataField">
+                                        <PropertyValue Property="Value" Path="SalesOrderItem"/>
+                                    </Record>
+                                </PropertyValue>
+                            </Record>
+                        </PropertyValue>
+                        <PropertyValue Property="Label" String="{@i18n>salesOrder} / {@i18n>salesOrderItem}"/>
+                        <PropertyValue Property="Template" String="{SalesOrder} / {SalesOrderItem}"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.HeaderFacets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="ID" String="General"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#HeaderFacetMain"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="HeaderFacetMain">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="EquipmentCategory"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="SerialNumber"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="UniqueItemIdentifierRespPlant"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="UniqueItemIdentifier"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="UniqueItemIdentifierStrucType"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="ConcatenatedActiveSystStsName"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.CollectionFacet">
+                            <PropertyValue Property="Label" String="{@i18n>serialNumberData}"/>
+                            <PropertyValue Property="ID" String="SerialNumberData"/>
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="Label" String="{@i18n>general}"/>
+                                        <PropertyValue Property="ID" String="General"/>
+                                        <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#General"/>
+                                    </Record>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="Label" String="{@i18n>stockInformation}"/>
+                                        <PropertyValue Property="ID" String="StockInformation"/>
+                                        <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#StockInformation"/>
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                        <Record Type="SAP__UI.CollectionFacet">
+                            <PropertyValue Property="Label" String="{@i18n>history}"/>
+                            <PropertyValue Property="ID" String="History"/>
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <Record Type="SAP__UI.ReferenceFacet">
+                                        <PropertyValue Property="Label" String="{@i18n>history}"/>
+                                        <PropertyValue Property="ID" String="History1"/>
+                                        <PropertyValue Property="Target" AnnotationPath="_EquipMatlSrlNmbrChgHistory/@SAP__UI.LineItem#History"/>
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="General">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="TechnicalObject"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="EquipMaterialLastSerialNumber"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="EquipmentName"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="StockInformation">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="InventoryStockType"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Plant"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="CompanyCode"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="StorageLocation"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="MatlSrlNmbrLastGdsMvtDte"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="MaterialSerialNumberStockBatch"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="InventorySpecialStockType"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="MatlSrlNmbrMasterBatch"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Customer"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Supplier"/>
+                                </Record>
+                                <Record Type="UI.DataFieldForAnnotation">
+                                    <PropertyValue Property="Target" AnnotationPath="@UI.ConnectedFields#SalesOrder"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="WBSElement"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="StockOwner"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <!--  <Annotations Target="SAP__self.CreateMassMaterialSerialNumber">
+                            <Annotation Term="Common.DefaultValuesFunction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.GetRefSerializedMaterialItem" />
+                        </Annotations>  -->
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/Material">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH"/>
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="Material"/>
+                                    <PropertyValue Property="ValueListProperty" String="Material"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="UniqueItemIdentifier"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_StorageLocationStdVH/StorageLocation">
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="C_EquipMaterialSerialNumberTPType"/>
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterIn">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="StorageLocation"/>
+                                    <PropertyValue Property="ValueListProperty" String="StorageLocation"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="Plant"/>
+                                    <PropertyValue Property="ValueListProperty" String="Plant"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="StorageLocation"/>
+                                    <PropertyValue Property="ValueListProperty" String="StorageLocation"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="Plant"/>
+                                    <PropertyValue Property="ValueListProperty" String="Plant"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="StorageLocation"/>
+                                    <PropertyValue Property="ValueListProperty" String="StorageLocation"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/SrlzdMatlItmReferenceMaterial">
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH"/>
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SrlzdMatlItmReferenceMaterial"/>
+                                    <PropertyValue Property="ValueListProperty" String="Material"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/EquipmentCategory">
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_EquipmentCategoryStdVH"/>
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="EquipmentCategory"/>
+                                    <PropertyValue Property="ValueListProperty" String="EquipmentCategory"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/SerialNumber">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH"/>
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SerialNumber"/>
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterIn">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="Material"/>
+                                    <PropertyValue Property="ValueListProperty" String="Material"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/SrlzdMatlItmRefSerialNumber">
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH"/>
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SrlzdMatlItmRefSerialNumber"/>
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterIn">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SrlzdMatlItmReferenceMaterial"/>
+                                    <PropertyValue Property="ValueListProperty" String="Material"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChgSrlzdMatlItemSerialNumber/SerialNumber">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH"/>
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SerialNumber"/>
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Material"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/UniqueItemIdentifierRespPlant">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/UniqueItemIdentifierRespPlant">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/Material">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/EquipmentCategory">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/EquipMaterialLastSerialNumber">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/ReadOnly"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaintenancePlant/MaintenancePlant">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/_SerialList">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ActvtSrlzdMatlItmEquipmentData">
+                <Annotation Term="com.sap.vocabularies.Common.v1.IsActionCritical" Bool="true"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType">
+                <Annotation Term="SAP__UI.LineItem" Qualifier="History">
+                    <Collection>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="ChangeDocDatabaseTableField"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="ChangeDocItemChangeType"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="ChangeDocNewFieldValue"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="ChangeDocPreviousFieldValue"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="CreatedByUser"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="CreationDateTime"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="TechObjChgDocNewFldValueText"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="TechObjChgDocOldFldValueText"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaterialName"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaintObjectChangeTypeCodeText"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaintObjectChangeTypeCode"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="UserDescription"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.PresentationVariant">
+                    <Record>
+                        <PropertyValue Property="MaxItems" Int="2"/>
+                        <PropertyValue Property="SortOrder">
+                            <Collection>
+                                <Record Type="Common.SortOrderType">
+                                    <PropertyValue Property="Property" PropertyPath="CreationDateTime"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="Visualizations">
+                            <Collection>
+                                <AnnotationPath>@UI.LineItem</AnnotationPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaterial(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChgSrlzdMatlItemSerialNumber(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeEquipmentCategory(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaintenancePlant(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ActvtSrlzdMatlItmEquipmentData(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.SetSrlzdMaterialItemToInactive(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.RsetSrlzdMatlItemFromInactive(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.SetSrlzdMaterialItemToDeletion(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ResetSrlzdMatlItmFrmDeletion(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/annotation-converter/test/fixtures/v4/actions/metadata.xml
+++ b/packages/annotation-converter/test/fixtures/v4/actions/metadata.xml
@@ -1,0 +1,4016 @@
+
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" xmlns="http://docs.oasis-open.org/odata/ns/edm" Version="4.0">
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_COMMUNICATION',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.Communication.v1" Alias="Communication"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_PERSONALDATA',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.PersonalData.v1" Alias="PersonalData"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_ANALYTICS',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.Analytics.v1" Alias="Analytics"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_COMMON',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.Common.v1" Alias="SAP__common"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_MEASURES',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="Org.OData.Measures.V1" Alias="SAP__measures"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_CORE',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="SAP__core"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_CAPABILITIES',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="SAP__capabilities"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_AGGREGATION',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="Org.OData.Aggregation.V1" Alias="SAP__aggregation"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_VALIDATION',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="Org.OData.Validation.V1" Alias="SAP__validation"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_CODELIST',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.CodeList.v1" Alias="SAP__CodeList"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_UI',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.UI.v1" Alias="SAP__UI"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_HTML5',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.HTML5.v1" Alias="SAP__HTML5"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_PDF',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.PDF.v1" Alias="SAP__PDF"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_SESSION',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.Session.v1" Alias="SAP__session"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_ODM',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.ODM.v1" Alias="SAP__ODM"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_HIERARCHY',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Namespace="com.sap.vocabularies.Hierarchy.v1" Alias="SAP__hierarchy"/>
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema Namespace="com.sap.gateway.srvd.eam_materialserialnumber.v0001" Alias="SAP__self">
+            <Annotation Term="SAP__core.SchemaVersion" String="1.1.0"/>
+            <EntityType Name="C_StsObjActiveStatusCodeTextType">
+                <Key>
+                    <PropertyRef Name="StatusObject"/>
+                    <PropertyRef Name="StatusCode"/>
+                </Key>
+                <Property Name="StatusObject" Type="Edm.String" Nullable="false" MaxLength="22"/>
+                <Property Name="StatusCode" Type="Edm.String" Nullable="false" MaxLength="5"/>
+                <Property Name="IsUserStatus" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="StatusProfile" Type="Edm.String" Nullable="false" MaxLength="8"/>
+                <Property Name="StatusSequenceNumber" Type="Edm.String" Nullable="false" MaxLength="2"/>
+                <Property Name="StatusName" Type="Edm.String" Nullable="false" MaxLength="30"/>
+                <Property Name="StatusShortName" Type="Edm.String" Nullable="false" MaxLength="4"/>
+            </EntityType>
+            <EntityType Name="C_EquipMaterialSerialNumberTPType">
+                <Key>
+                    <PropertyRef Name="Material"/>
+                    <PropertyRef Name="SerialNumber"/>
+                    <PropertyRef Name="DraftUUID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="Material" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="Equipment" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="TechnicalObject" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="TechObjIsEquipOrFuncnlLoc" Type="Edm.String" Nullable="false" MaxLength="20"/>
+                <Property Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="EquipmentName" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="TechnicalObjectDescription" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="UniqueItemIdentifier" Type="Edm.String" Nullable="false" MaxLength="72"/>
+                <Property Name="UniqueItemIdentifierStrucType" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="UniqueItemIdentifierRespPlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="HasEquipmentData" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="EquipmentHasStockInformation" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="CreatedByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="LastChangedByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="CreationDate" Type="Edm.Date"/>
+                <Property Name="LastChangeDate" Type="Edm.Date"/>
+                <Property Name="LastChangeDateTime" Type="Edm.DateTimeOffset"/>
+                <Property Name="EquipMaterialLastSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="InventoryStockType" Type="Edm.String" Nullable="false" MaxLength="2"/>
+                <Property Name="Plant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="StorageLocation" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="InventorySpecialStockType" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="Customer" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="Supplier" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="CompanyCode" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="SalesOrder" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="SalesOrderItem" Type="Edm.String" Nullable="false" MaxLength="6"/>
+                <Property Name="WBSElementInternalID" Type="Edm.String" Nullable="false" MaxLength="8"/>
+                <Property Name="StockOwner" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="MatlSrlNmbrMasterBatch" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="MatlSrlNmbrLastGdsMvtDte" Type="Edm.Date"/>
+                <Property Name="MaterialSerialNumberStockBatch" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="MatlSrlNmbrIsAvailable" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsDeleted" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsMrkdForDeltn" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsInactive" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsInstalled" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsAllcToParent" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsInWarehouse" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsAssgdToDeliv" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsAtCustomer" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsUndrCnstrctn" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsOnHold" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsLocked" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsIDUndefined" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsAssgdToJITCall" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrDocIsCreated" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrHndlgUntIsAssgd" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrInvtryIsActv" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrUUIDIsGnrtd" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrUUIDIsAttached" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrUUIDIsSent" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrUUIDIsConfd" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MaintObjectInternalID" Type="Edm.String" Nullable="false" MaxLength="22"/>
+                <Property Name="WBSElement" Type="Edm.String" Nullable="false" MaxLength="24"/>
+                <Property Name="ConcatenatedActiveUserStsName" Type="Edm.String" Nullable="false" MaxLength="224"/>
+                <Property Name="ConcatenatedActiveSystStsName" Type="Edm.String" Nullable="false" MaxLength="224"/>
+                <Property Name="IsCloudSystem" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MaterialName" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="CompanyCodeName" Type="Edm.String" Nullable="false" MaxLength="25"/>
+                <Property Name="EquipmentCategoryDesc" Type="Edm.String" Nullable="false" MaxLength="30"/>
+                <Property Name="InventoryStockTypeName" Type="Edm.String" Nullable="false" MaxLength="60"/>
+                <Property Name="InventorySpecialStockTypeName" Type="Edm.String" Nullable="false" MaxLength="20"/>
+                <Property Name="PlantName" Type="Edm.String" Nullable="false" MaxLength="30"/>
+                <Property Name="StorageLocationName" Type="Edm.String" Nullable="false" MaxLength="16"/>
+                <Property Name="CustomerFullName" Type="Edm.String" Nullable="false" MaxLength="220"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="DraftUUID" Type="Edm.Guid" Nullable="false"/>
+                <Property Name="DraftEntityCreationDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="DraftEntityLastChangeDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="__EntityControl" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.EntityControl"/>
+                <Property Name="__OperationControl" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPOperationControl"/>
+                <Property Name="SAP__Messages" Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.SAP__Message)" Nullable="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_DraftAdministrativeDataType"/>
+                <NavigationProperty Name="SiblingEntity" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType"/>
+                <NavigationProperty Name="_ActiveSystemStatus" Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_StsObjActiveStatusCodeTextType)"/>
+                <NavigationProperty Name="_EquipMaterialSerialNumberVH" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_EquipMaterialSerialNumberVHType"/>
+                <NavigationProperty Name="_EquipMatlSrlNmbrChgHistory" Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMatlSrlNmbrChgHistoryTPType)"/>
+                <NavigationProperty Name="_MaterialSerialNumberVH" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_MaterialSerialNumberVHType"/>
+            </EntityType>
+            <EntityType Name="C_EquipMatlSrlNmbrChgHistoryTPType">
+                <Key>
+                    <PropertyRef Name="ChangeDocObject"/>
+                    <PropertyRef Name="ChangeDocument"/>
+                    <PropertyRef Name="DatabaseTable"/>
+                    <PropertyRef Name="ChangeDocDatabaseTableField"/>
+                    <PropertyRef Name="ChangeDocItemChangeType"/>
+                    <PropertyRef Name="CreationDateTime"/>
+                    <PropertyRef Name="ChangeDocTableKey"/>
+                </Key>
+                <Property Name="ChangeDocObject" Type="Edm.String" Nullable="false" MaxLength="90"/>
+                <Property Name="ChangeDocument" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="DatabaseTable" Type="Edm.String" Nullable="false" MaxLength="30"/>
+                <Property Name="ChangeDocDatabaseTableField" Type="Edm.String" Nullable="false" MaxLength="30"/>
+                <Property Name="ChangeDocDatabaseTableField_Text" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="ChangeDocItemChangeType" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="ChangeDocItemChangeType_Text" Type="Edm.String" Nullable="false" MaxLength="60"/>
+                <Property Name="CreationDateTime" Type="Edm.DateTimeOffset" Nullable="false"/>
+                <Property Name="ChangeDocTableKey" Type="Edm.String" Nullable="false" MaxLength="70"/>
+                <Property Name="MaintObjectChangeTypeCode" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="MaintObjectChangeTypeCodeText" Type="Edm.String" Nullable="false" MaxLength="60"/>
+                <Property Name="MaterialName" Type="Edm.String" Nullable="false" MaxLength="200"/>
+                <Property Name="CreatedByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="UserDescription" Type="Edm.String" Nullable="false" MaxLength="80"/>
+                <Property Name="CreationDate" Type="Edm.Date"/>
+                <Property Name="CreationTime" Type="Edm.TimeOfDay" Nullable="false"/>
+                <Property Name="ChangeDocNewFieldValue" Type="Edm.String" Nullable="false" MaxLength="254"/>
+                <Property Name="ChangeDocPreviousFieldValue" Type="Edm.String" Nullable="false" MaxLength="254"/>
+                <Property Name="TechObjChgDocNewFldValueText" Type="Edm.String" Nullable="false" MaxLength="254"/>
+                <Property Name="TechObjChgDocOldFldValueText" Type="Edm.String" Nullable="false" MaxLength="254"/>
+                <Property Name="ChangeDocObjectClass" Type="Edm.String" Nullable="false" MaxLength="15"/>
+                <Property Name="CharcDescription" Type="Edm.String" Nullable="false" MaxLength="30"/>
+                <Property Name="Class" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="StatusName" Type="Edm.String" Nullable="false" MaxLength="30"/>
+                <Property Name="StatusProfile" Type="Edm.String" Nullable="false" MaxLength="8"/>
+                <Property Name="StatusIsInactive" Type="Edm.Boolean" Nullable="false"/>
+            </EntityType>
+            <EntityType Name="I_EquipmentCategoryStdVHType">
+                <Key>
+                    <PropertyRef Name="EquipmentCategory"/>
+                </Key>
+                <Property Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="EquipmentCategory_Text" Type="Edm.String" Nullable="false" MaxLength="30"/>
+                <Property Name="EquipmentCategoryStatusProfile" Type="Edm.String" Nullable="false" MaxLength="8"/>
+                <Property Name="EquipmentCategoryViewProfile" Type="Edm.String" Nullable="false" MaxLength="8"/>
+                <Property Name="EquipCatHasLinearAttributes" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="EquipmentCategoryOID" Type="Edm.String" Nullable="false" MaxLength="128"/>
+                <Property Name="IsUtilitiesData" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="NumberRangeForIntIDAssignment" Type="Edm.String" Nullable="false" MaxLength="2"/>
+                <Property Name="NumberRangeForExtIDAssignment" Type="Edm.String" Nullable="false" MaxLength="2"/>
+                <Property Name="TechObjInspectionLevelCode" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="EquipmentCategoryReferenceType" Type="Edm.String" Nullable="false" MaxLength="1"/>
+            </EntityType>
+            <EntityType Name="I_StorageLocationStdVHType">
+                <Key>
+                    <PropertyRef Name="Plant"/>
+                    <PropertyRef Name="StorageLocation"/>
+                </Key>
+                <Property Name="Plant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="StorageLocation" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="StorageLocationName" Type="Edm.String" Nullable="false" MaxLength="16"/>
+                <Property Name="ConfigDeprecationCode" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="ConfignDeprecationCodeName" Type="Edm.String" Nullable="false" MaxLength="60"/>
+                <Property Name="PlantName" Type="Edm.String" Nullable="false" MaxLength="30"/>
+            </EntityType>
+            <EntityType Name="I_MaterialSerialNumberVHType">
+                <Key>
+                    <PropertyRef Name="Equipment"/>
+                </Key>
+                <Property Name="Equipment" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="Equipment_Text" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="Material" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="UniqueItemIdentifier" Type="Edm.String" Nullable="false" MaxLength="72"/>
+            </EntityType>
+            <EntityType Name="I_EquipMaterialSerialNumberVHType">
+                <Key>
+                    <PropertyRef Name="Equipment"/>
+                </Key>
+                <Property Name="Equipment" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="EquipmentName" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="BusinessPartner" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="BusinessPartnerName" Type="Edm.String" Nullable="false" MaxLength="81"/>
+                <Property Name="Material" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="MaterialName" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="Customer" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="Supplier" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+            </EntityType>
+            <EntityType Name="I_EquipMatlSerialNumberType">
+                <Key>
+                    <PropertyRef Name="Material"/>
+                    <PropertyRef Name="SerialNumber"/>
+                </Key>
+                <Property Name="Material" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="Equipment" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="Equipment_Text" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="UniqueItemIdentifier" Type="Edm.String" Nullable="false" MaxLength="72"/>
+                <Property Name="UniqueItemIdentifierStrucType" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="UniqueItemIdentifierRespPlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="MaintObjectInternalID" Type="Edm.String" Nullable="false" MaxLength="22"/>
+                <Property Name="HasEquipmentData" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="EquipmentHasStockInformation" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="CreatedByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="LastChangedByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="CreationDate" Type="Edm.Date"/>
+                <Property Name="LastChangeDate" Type="Edm.Date"/>
+                <Property Name="LastChangeDateTime" Type="Edm.DateTimeOffset"/>
+                <Property Name="MatlSrlNmbrMasterBatch" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="MatlSrlNmbrLastGdsMvtDte" Type="Edm.Date"/>
+                <Property Name="EquipMaterialLastSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="InventoryStockType" Type="Edm.String" Nullable="false" MaxLength="2"/>
+                <Property Name="Plant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="StorageLocation" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="MaterialSerialNumberStockBatch" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="InventorySpecialStockType" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="Customer" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="Supplier" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="SalesOrder" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="SalesOrderItem" Type="Edm.String" Nullable="false" MaxLength="6"/>
+                <Property Name="WBSElementInternalID" Type="Edm.String" Nullable="false" MaxLength="8"/>
+                <Property Name="StockOwner" Type="Edm.String" Nullable="false" MaxLength="10"/>
+            </EntityType>
+            <EntityType Name="I_MaterialStdVHType">
+                <Key>
+                    <PropertyRef Name="Material"/>
+                </Key>
+                <Property Name="Material" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="Material_Text" Type="Edm.String" Nullable="false" MaxLength="40"/>
+            </EntityType>
+            <EntityType Name="I_DraftAdministrativeDataType">
+                <Key>
+                    <PropertyRef Name="DraftUUID"/>
+                    <PropertyRef Name="DraftEntityType"/>
+                </Key>
+                <Property Name="DraftUUID" Type="Edm.Guid" Nullable="false"/>
+                <Property Name="DraftEntityType" Type="Edm.String" Nullable="false" MaxLength="30"/>
+                <Property Name="CreationDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="CreatedByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="LastChangeDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="LastChangedByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="DraftAccessType" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="ProcessingStartDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="InProcessByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="DraftIsKeptByUser" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="EnqueueStartDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="DraftIsCreatedByMe" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="DraftIsLastChangedByMe" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="DraftIsProcessedByMe" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="CreatedByUserDescription" Type="Edm.String" Nullable="false" MaxLength="80"/>
+                <Property Name="LastChangedByUserDescription" Type="Edm.String" Nullable="false" MaxLength="80"/>
+                <Property Name="InProcessByUserDescription" Type="Edm.String" Nullable="false" MaxLength="80"/>
+            </EntityType>
+            <EntityType Name="R_EquipMatlSerialNumberTPType">
+                <Key>
+                    <PropertyRef Name="Material"/>
+                    <PropertyRef Name="SerialNumber"/>
+                    <PropertyRef Name="DraftUUID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="Material" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="Equipment" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="UniqueItemIdentifier" Type="Edm.String" Nullable="false" MaxLength="72"/>
+                <Property Name="UniqueItemIdentifierStrucType" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="UniqueItemIdentifierRespPlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="TechObjIsEquipOrFuncnlLoc" Type="Edm.String" Nullable="false" MaxLength="20"/>
+                <Property Name="MaintObjectInternalID" Type="Edm.String" Nullable="false" MaxLength="22"/>
+                <Property Name="HasEquipmentData" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="TechnicalObject" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="EquipmentHasStockInformation" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="CreatedByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="LastChangedByUser" Type="Edm.String" Nullable="false" MaxLength="12"/>
+                <Property Name="CreationDate" Type="Edm.Date"/>
+                <Property Name="LastChangeDate" Type="Edm.Date"/>
+                <Property Name="LastChangeDateTime" Type="Edm.DateTimeOffset"/>
+                <Property Name="MatlSrlNmbrMasterBatch" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="EquipMaterialLastSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="MatlSrlNmbrLastGdsMvtDte" Type="Edm.Date"/>
+                <Property Name="MaterialSerialNumberStockBatch" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="InventoryStockType" Type="Edm.String" Nullable="false" MaxLength="2"/>
+                <Property Name="Plant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="StorageLocation" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="InventorySpecialStockType" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="Customer" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="Supplier" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="SalesOrder" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="SalesOrderItem" Type="Edm.String" Nullable="false" MaxLength="6"/>
+                <Property Name="WBSElementInternalID" Type="Edm.String" Nullable="false" MaxLength="8"/>
+                <Property Name="WBSElement" Type="Edm.String" Nullable="false" MaxLength="24"/>
+                <Property Name="StockOwner" Type="Edm.String" Nullable="false" MaxLength="10"/>
+                <Property Name="CompanyCode" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Property Name="CompanyCodeName" Type="Edm.String" Nullable="false" MaxLength="25"/>
+                <Property Name="EquipmentName" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="TechnicalObjectDescription" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="MatlSrlNmbrIsAvailable" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsDeleted" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsMrkdForDeltn" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsInactive" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsInstalled" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsAllcToParent" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsInWarehouse" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsAssgdToDeliv" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsAtCustomer" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsUndrCnstrctn" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsOnHold" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsLocked" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsIDUndefined" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrIsAssgdToJITCall" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrDocIsCreated" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrHndlgUntIsAssgd" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrInvtryIsActv" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrUUIDIsGnrtd" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrUUIDIsAttached" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrUUIDIsSent" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="MatlSrlNmbrUUIDIsConfd" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="DraftUUID" Type="Edm.Guid" Nullable="false"/>
+                <Property Name="DraftEntityCreationDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="DraftEntityLastChangeDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="__EntityControl" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.EntityControl"/>
+                <Property Name="__OperationControl" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPOperationControl"/>
+                <Property Name="SAP__Messages" Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.SAP__Message)" Nullable="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_DraftAdministrativeDataType"/>
+                <NavigationProperty Name="SiblingEntity" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType"/>
+            </EntityType>
+            <ComplexType Name="C_EquipMaterialSerialNumberTPOperationControl">
+                <Property Name="ActvtSrlzdMatlItmEquipmentData" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChangeEquipmentCategory" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChangeMaintenancePlant" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChangeMaterial" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChangeUniqueItemIdentifier" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChgSrlzdMatlItemSerialNumber" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="Edit" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ResetSrlzdMatlItmFrmDeletion" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="RsetSrlzdMatlItemFromInactive" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="SetSrlzdMaterialItemToInactive" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="SetSrlzdMaterialItemToDeletion" Type="Edm.Boolean" Nullable="false"/>
+            </ComplexType>
+            <ComplexType Name="R_EquipMatlSerialNumberTPOperationControl">
+                <Property Name="ActvtSrlzdMatlItmEquipmentData" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChangeEquipmentCategory" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChangeMaintenancePlant" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChangeMaterial" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChangeUniqueItemIdentifier" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ChgSrlzdMatlItemSerialNumber" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="Edit" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="ResetSrlzdMatlItmFrmDeletion" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="RsetSrlzdMatlItemFromInactive" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="SetSrlzdMaterialItemToInactive" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="SetSrlzdMaterialItemToDeletion" Type="Edm.Boolean" Nullable="false"/>
+            </ComplexType>
+            <ComplexType Name="SerializedMatlItmChgMatlR_Type">
+                <Property Name="Material" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+            </ComplexType>
+            <ComplexType Name="SerializedMatlItmChgSrlNmbrR_Type">
+                <Property Name="Material" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+            </ComplexType>
+            <ComplexType Name="D_SerializedMatlItmCrteWthRefP">
+                <Property Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Property Name="Material" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="SrlzdMatlItmReferenceMaterial" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Property Name="SrlzdMatlItmRefSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Property Name="UniqueItemIdentifierRespPlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+            </ComplexType>
+            <ComplexType Name="EquipCrteMassMatlSrlNmbrR_Type">
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+            </ComplexType>
+            <ComplexType Name="D_EQUIPCREATESERIALNUMBERLISTP">
+                <Property Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+            </ComplexType>
+            <ComplexType Name="EntityControl">
+                <Property Name="Updatable" Type="Edm.Boolean" Nullable="false"/>
+            </ComplexType>
+            <ComplexType Name="SAP__Message">
+                <Property Name="code" Type="Edm.String" Nullable="false"/>
+                <Property Name="message" Type="Edm.String" Nullable="false"/>
+                <Property Name="target" Type="Edm.String"/>
+                <Property Name="additionalTargets" Type="Collection(Edm.String)" Nullable="false"/>
+                <Property Name="transition" Type="Edm.Boolean" Nullable="false"/>
+                <Property Name="numericSeverity" Type="Edm.Byte" Nullable="false"/>
+                <Property Name="longtextUrl" Type="Edm.String"/>
+            </ComplexType>
+            <Action Name="ChangeMaterial" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="Material" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SerializedMatlItmChgMatlR_Type" Nullable="false"/>
+            </Action>
+            <Action Name="Prepare" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ChgSrlzdMatlItemSerialNumber" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SerializedMatlItmChgSrlNmbrR_Type" Nullable="false"/>
+            </Action>
+            <Action Name="CreateMassMaterialSerialNumber" IsBound="true">
+                <Parameter Name="_it" Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)" Nullable="false"/>
+                <Parameter Name="Material" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Parameter Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Parameter Name="UniqueItemIdentifierRespPlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Parameter Name="EquipMaterialLastSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Parameter Name="EquipmentNumberOfSerialNumbers" Type="Edm.Int32" Nullable="false"/>
+                <Parameter Name="EquipmentFromSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Parameter Name="EquipmentToSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Parameter Name="_SerialList" Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.D_EQUIPCREATESERIALNUMBERLISTP)" Nullable="false"/>
+                <ReturnType Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.EquipCrteMassMatlSrlNmbrR_Type)" Nullable="false"/>
+            </Action>
+            <Action Name="ChangeEquipmentCategory" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ChangeMaintenancePlant" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="MaintenancePlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="Activate" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="SetSrlzdMaterialItemToInactive" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ChangeUniqueItemIdentifier" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="UniqueItemIdentifier" Type="Edm.String" Nullable="false" MaxLength="72"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="Activate" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ChgSrlzdMatlItemSerialNumber" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SerializedMatlItmChgSrlNmbrR_Type" Nullable="false"/>
+            </Action>
+            <Action Name="SetSrlzdMaterialItemToDeletion" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="Resume" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="CreateMassMaterialSerialNumber" IsBound="true">
+                <Parameter Name="_it" Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType)" Nullable="false"/>
+                <Parameter Name="Material" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Parameter Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Parameter Name="UniqueItemIdentifierRespPlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Parameter Name="EquipMaterialLastSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Parameter Name="EquipmentNumberOfSerialNumbers" Type="Edm.Int32" Nullable="false"/>
+                <Parameter Name="EquipmentFromSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Parameter Name="EquipmentToSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Parameter Name="_SerialList" Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.D_EQUIPCREATESERIALNUMBERLISTP)" Nullable="false"/>
+                <ReturnType Type="Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.EquipCrteMassMatlSrlNmbrR_Type)" Nullable="false"/>
+            </Action>
+            <Action Name="ChangeMaterial" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="Material" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SerializedMatlItmChgMatlR_Type" Nullable="false"/>
+            </Action>
+            <Action Name="Resume" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="SetSrlzdMaterialItemToDeletion" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="Edit" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="PreserveChanges" Type="Edm.Boolean" Nullable="false"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="Discard" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ResetSrlzdMatlItmFrmDeletion" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ChangeEquipmentCategory" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="Edit" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="PreserveChanges" Type="Edm.Boolean" Nullable="false"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ResetSrlzdMatlItmFrmDeletion" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="RsetSrlzdMatlItemFromInactive" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="CrteWthRefFrmSrlzdMaterialItem" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="ResultIsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
+                <Parameter Name="Material" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Parameter Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Parameter Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Parameter Name="UniqueItemIdentifierRespPlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Parameter Name="SrlzdMatlItmReferenceMaterial" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Parameter Name="SrlzdMatlItmRefSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="CrteWthRefFrmSrlzdMaterialItem" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="ResultIsActiveEntity" Type="Edm.Boolean" Nullable="false"/>
+                <Parameter Name="Material" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Parameter Name="SerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <Parameter Name="EquipmentCategory" Type="Edm.String" Nullable="false" MaxLength="1"/>
+                <Parameter Name="UniqueItemIdentifierRespPlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <Parameter Name="SrlzdMatlItmReferenceMaterial" Type="Edm.String" Nullable="false" MaxLength="40"/>
+                <Parameter Name="SrlzdMatlItmRefSerialNumber" Type="Edm.String" Nullable="false" MaxLength="18"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ActvtSrlzdMatlItmEquipmentData" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ChangeUniqueItemIdentifier" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="UniqueItemIdentifier" Type="Edm.String" Nullable="false" MaxLength="72"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ActvtSrlzdMatlItmEquipmentData" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="ChangeMaintenancePlant" EntitySetPath="_it" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <Parameter Name="MaintenancePlant" Type="Edm.String" Nullable="false" MaxLength="4"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="SetSrlzdMaterialItemToInactive" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="RsetSrlzdMatlItemFromInactive" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="Discard" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Action Name="Prepare" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+            </Action>
+            <Function Name="GetRefSerializedMaterialItem" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType" Nullable="false"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.D_SerializedMatlItmCrteWthRefP" Nullable="false"/>
+            </Function>
+            <Function Name="GetRefSerializedMaterialItem" IsBound="true">
+                <Parameter Name="_it" Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType" Nullable="false"/>
+                <ReturnType Type="com.sap.gateway.srvd.eam_materialserialnumber.v0001.D_SerializedMatlItmCrteWthRefP" Nullable="false"/>
+            </Function>
+            <EntityContainer Name="Container">
+                <EntitySet Name="C_EquipMaterialSerialNumberTP" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType">
+                    <NavigationPropertyBinding Path="DraftAdministrativeData" Target="I_DraftAdministrativeData"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="C_EquipMaterialSerialNumberTP"/>
+                    <NavigationPropertyBinding Path="_ActiveSystemStatus" Target="C_StsObjActiveStatusCodeText"/>
+                    <NavigationPropertyBinding Path="_EquipMaterialSerialNumberVH" Target="I_EquipMaterialSerialNumberVH"/>
+                    <NavigationPropertyBinding Path="_EquipMatlSrlNmbrChgHistory" Target="C_EquipMatlSrlNmbrChgHistoryTP"/>
+                    <NavigationPropertyBinding Path="_MaterialSerialNumberVH" Target="I_MaterialSerialNumberVH"/>
+                </EntitySet>
+                <EntitySet Name="C_EquipMatlSrlNmbrChgHistoryTP" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMatlSrlNmbrChgHistoryTPType"/>
+                <EntitySet Name="C_StsObjActiveStatusCodeText" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_StsObjActiveStatusCodeTextType"/>
+                <EntitySet Name="I_DraftAdministrativeData" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_DraftAdministrativeDataType"/>
+                <EntitySet Name="I_EquipMaterialSerialNumberVH" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_EquipMaterialSerialNumberVHType"/>
+                <EntitySet Name="I_EquipMatlSerialNumber" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_EquipMatlSerialNumberType"/>
+                <EntitySet Name="I_EquipmentCategoryStdVH" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_EquipmentCategoryStdVHType"/>
+                <EntitySet Name="I_MaterialSerialNumberVH" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_MaterialSerialNumberVHType"/>
+                <EntitySet Name="I_MaterialStdVH" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_MaterialStdVHType"/>
+                <EntitySet Name="I_StorageLocationStdVH" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_StorageLocationStdVHType"/>
+                <EntitySet Name="R_EquipMatlSerialNumberTP" EntityType="com.sap.gateway.srvd.eam_materialserialnumber.v0001.R_EquipMatlSerialNumberTPType">
+                    <NavigationPropertyBinding Path="DraftAdministrativeData" Target="I_DraftAdministrativeData"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="R_EquipMatlSerialNumberTP"/>
+                </EntitySet>
+            </EntityContainer>
+            <Annotations Target="SAP__self.SerializedMatlItmChgMatlR_Type/Material">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.SerializedMatlItmChgMatlR_Type/SerialNumber">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.SerializedMatlItmChgSrlNmbrR_Type/Material">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.SerializedMatlItmChgSrlNmbrR_Type/SerialNumber">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.D_SerializedMatlItmCrteWthRefP/EquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Category"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.D_SerializedMatlItmCrteWthRefP/Material">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.D_SerializedMatlItmCrteWthRefP/SerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.D_SerializedMatlItmCrteWthRefP/SrlzdMatlItmReferenceMaterial">
+                <Annotation Term="SAP__common.Label" String="Material Reference"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.D_SerializedMatlItmCrteWthRefP/SrlzdMatlItmRefSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number Reference"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.D_SerializedMatlItmCrteWthRefP/UniqueItemIdentifierRespPlant">
+                <Annotation Term="SAP__common.Label" String="Responsible Plant UII"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_PLANT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.EquipCrteMassMatlSrlNmbrR_Type/SerialNumber">
+                <Annotation Term="SAP__common.Label" String="Last Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.D_EQUIPCREATESERIALNUMBERLISTP/SerialNumber">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_StsObjActiveStatusCodeTextType/StatusObject">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Object Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_OBJNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_StsObjActiveStatusCodeTextType/StatusCode">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Status"/>
+                <Annotation Term="SAP__common.Heading" String="Stat."/>
+                <Annotation Term="SAP__common.QuickInfo" String="Object status"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_STATUS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_StsObjActiveStatusCodeTextType/StatusProfile">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Status Profile"/>
+                <Annotation Term="SAP__common.Heading" String="StatProf"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_STSMA"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_StsObjActiveStatusCodeTextType/StatusSequenceNumber">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation Term="SAP__common.Label" String="Status Sequence No."/>
+                <Annotation Term="SAP__common.QuickInfo" String="Status Sequence Number"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_StsObjActiveStatusCodeTextType">
+                <Annotation Term="SAP__common.Label" String="Status Object Active Status Code Text"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/C_StsObjActiveStatusCodeText">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Insertable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Bool="false"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/Material">
+                <Annotation Term="SAP__common.Text" Path="MaterialName">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextFirst"/>
+                </Annotation>
+                <Annotation Term="SAP__core.Immutable"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_materialstdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.material'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/SerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__core.Immutable"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/c_materialserialnumbervh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.serialnumber'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/Equipment">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/c_equipmaterialserialnumbervh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.equipment'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.SemanticObject" String="MaintenanceObject"/>
+                <Annotation Term="SAP__common.Label" String="Equipment"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQUNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/TechnicalObject">
+                <Annotation Term="SAP__common.Label" String="Equipment"/>
+                <Annotation Term="SAP__common.Text" Path="EquipmentName">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextFirst"/>
+                </Annotation>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_equipmaterialserialnumbervh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.technicalobject'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__common.SemanticObject" String="MaintenanceObject"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Technical Object"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/TechObjIsEquipOrFuncnlLoc">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__common.Label" String="Tech. Obj. Type"/>
+                <Annotation Term="SAP__common.Heading" String="Technical Object Type"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Technical Object Type"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/EquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Equipment Category"/>
+                <Annotation Term="SAP__common.Text" Path="EquipmentCategoryDesc">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextFirst"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_equipmentcategorystdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.equipmentcategory'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/EquipmentName">
+                <Annotation Term="SAP__common.Label" String="Description"/>
+                <Annotation Term="SAP__common.Heading" String="Description of technical object"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Description of technical object"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KTX01"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifier">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Unique Item ID"/>
+                <Annotation Term="SAP__common.Heading" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Unique Item Identifier"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifierStrucType">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="IUID Type"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Structure Type of UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=IUID_TYPE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifierRespPlant">
+                <Annotation Term="SAP__common.Label" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__core.Immutable"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_PLANT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/HasEquipmentData">
+                <Annotation Term="SAP__common.Label" String="Equipment Data exists"/>
+                <Annotation Term="SAP__common.FilterDefaultValue" Bool="false"/>
+                <Annotation Term="SAP__common.Heading" String="Equi. Data"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment data exists"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQUIP_KNZ"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/EquipmentHasStockInformation">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Has Stock Information"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Indicator: Stock Information Available"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/CreatedByUser">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Created By"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Name of Person Responsible for Creating the Object"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/LastChangedByUser">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Changed By"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Name of Person Who Changed Object"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/CreationDate">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Created On"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Record Creation Date"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/LastChangeDate">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Changed On"/>
+                <Annotation Term="SAP__common.Heading" String="Chngd On"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Last Changed On"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/LastChangeDateTime">
+                <Annotation Term="SAP__common.Label" String="Last Changed Date and Time"/>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Heading" String="Short Form of Time Stamp"/>
+                <Annotation Term="SAP__common.QuickInfo" String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=TZNTSTMPS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/EquipMaterialLastSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Last Serial Number"/>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Last num.SerialNo"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Last Numerical Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LSERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/InventoryStockType">
+                <Annotation Term="SAP__common.Text" Path="InventoryStockTypeName">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextFirst"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_inventorystocktype/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.inventorystocktype'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Label" String="Stock Type"/>
+                <Annotation Term="SAP__common.Heading" String="PP"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Stock Type of Goods Movement (Primary Posting)"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LBBSA"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/Plant">
+                <Annotation Term="SAP__common.Text" Path="PlantName">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextFirst"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_plantstdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.plant'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Label" String="Plant"/>
+                <Annotation Term="SAP__common.Heading" String="Plnt"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=WERKS_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/StorageLocation">
+                <Annotation Term="SAP__common.Label" String="Storage Location"/>
+                <Annotation Term="SAP__common.Text" Path="StorageLocationName">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextFirst"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_storagelocationstdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.storagelocation'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Storage Location"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Storage Location"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LGORT_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/InventorySpecialStockType">
+                <Annotation Term="SAP__common.Text" Path="InventorySpecialStockTypeName">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextFirst"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_srlnmbrhistspclstocktypevh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.inventoryspecialstocktype'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Label" String="Special Stock"/>
+                <Annotation Term="SAP__common.Heading" String="S"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Special Stock Indicator"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SOBKZ"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/Customer">
+                <Annotation Term="SAP__common.Label" String="Customer"/>
+                <Annotation Term="SAP__common.Text" Path="CustomerFullName">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextFirst"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_customer_vh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.customer'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Stck cust."/>
+                <Annotation Term="SAP__common.QuickInfo" String="Special stock customer account number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=B_KUNNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/Supplier">
+                <Annotation Term="SAP__common.Label" String="Special Stock Vendor"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_supplier_vh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.supplier'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="StckVendor"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Account number of the vendor"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=B_LIFNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/CompanyCode">
+                <Annotation Term="SAP__common.Text" Path="CompanyCodeName">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextFirst"/>
+                </Annotation>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_companycodestdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.companycode'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Label" String="Company Code"/>
+                <Annotation Term="SAP__common.Heading" String="CoCd"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=BUKRS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/SalesOrder">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.SemanticObject" String="SalesOrder"/>
+                <Annotation Term="SAP__common.Label" String="Sales Order"/>
+                <Annotation Term="SAP__common.Heading" String="Sales Ord."/>
+                <Annotation Term="SAP__common.QuickInfo" String="Sales Order Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KDAUF"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/SalesOrderItem">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation Term="SAP__common.Label" String="Sales Order Item"/>
+                <Annotation Term="SAP__common.Heading" String="SO Item"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Item Number in Sales Order"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KDPOS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/WBSElementInternalID">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="WBS Internal ID"/>
+                <Annotation Term="SAP__common.Heading" String="WBS Elem"/>
+                <Annotation Term="SAP__common.QuickInfo" String="WBS Element"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=PS_S4_PSPNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/StockOwner">
+                <Annotation Term="SAP__common.Label" String="Owner of Stock"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Owner of stock"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Owner of stock"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=OWNER_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrMasterBatch">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_batchvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.matlsrlnmbrmasterbatch'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Label" String="Batch"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Batch Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=CHARG_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrLastGdsMvtDte">
+                <Annotation Term="SAP__common.Label" String="Date of Last Goods Movement"/>
+                <Annotation Term="SAP__common.Heading" String="Date of Last Goods Movemnt"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Date of Last Goods Movement"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=DATLWB"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MaterialSerialNumberStockBatch">
+                <Annotation Term="SAP__common.Label" String="Stock Batch"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_batchvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-c_equipmaterialserialnumbertp.materialserialnumberstockbatch'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="StockBatch"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Batch Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=B_CHARGE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsAvailable">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsDeleted">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsMrkdForDeltn">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsInactive">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsInstalled">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsAllcToParent">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsInWarehouse">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsAssgdToDeliv">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsAtCustomer">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsUndrCnstrctn">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsOnHold">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsLocked">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsIDUndefined">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrIsAssgdToJITCall">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrDocIsCreated">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrHndlgUntIsAssgd">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrInvtryIsActv">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrUUIDIsGnrtd">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrUUIDIsAttached">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrUUIDIsSent">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MatlSrlNmbrUUIDIsConfd">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MaintObjectInternalID">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Object Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_OBJNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/WBSElement">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="WBS Element"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Work Breakdown Structure Element (WBS Element) Edited"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=PS_POSID_EDIT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/ConcatenatedActiveUserStsName">
+                <Annotation Term="SAP__common.Label" String="User Status"/>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Concatenated User Status"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/ConcatenatedActiveSystStsName">
+                <Annotation Term="SAP__common.Label" String="System Status"/>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Concatenated System Status"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/IsCloudSystem">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Truth Value"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Truth Value: True/False"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/MaterialName">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Material Description"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MAKTX"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/EquipmentCategoryDesc">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Equipment CatDesc."/>
+                <Annotation Term="SAP__common.Heading" String="Equipment category description"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category description"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=ETYTX"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/InventoryStockTypeName">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Stock Type Name"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/InventorySpecialStockTypeName">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Special stock descr."/>
+                <Annotation Term="SAP__common.QuickInfo" String="Description of special stock"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/PlantName">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Plant Name"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/StorageLocationName">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Storage Loc. Name"/>
+                <Annotation Term="SAP__common.Heading" String="Storage Location Name"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Storage Location Name"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/CustomerFullName">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Customer Name"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Customer Full Name"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/HasDraftEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Has Draft"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Draft - Indicator - Has draft document"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/DraftUUID">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Key"/>
+                <Annotation Term="SAP__common.QuickInfo" String="UUID serving as key (parent key, root key)"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/DraftEntityCreationDateTime">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Created On"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/DraftEntityLastChangeDateTime">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Last Changed On"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/HasActiveEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Has active"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Draft - Indicator - Has active document"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/IsActiveEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Is active"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Draft - Indicator - Is active document"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__EntityControl">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/C_EquipMaterialSerialNumberTP">
+                <Annotation Term="SAP__capabilities.NavigationRestrictions">
+                    <Record>
+                        <PropertyValue Property="RestrictedProperties">
+                            <Collection>
+                                <Record>
+                                    <PropertyValue Property="NavigationProperty" NavigationPropertyPath="_ActiveSystemStatus"/>
+                                    <PropertyValue Property="InsertRestrictions">
+                                        <Record>
+                                            <PropertyValue Property="Insertable" Bool="false"/>
+                                        </Record>
+                                    </PropertyValue>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="NavigationProperty" NavigationPropertyPath="_EquipMaterialSerialNumberVH"/>
+                                    <PropertyValue Property="InsertRestrictions">
+                                        <Record>
+                                            <PropertyValue Property="Insertable" Bool="false"/>
+                                        </Record>
+                                    </PropertyValue>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="NavigationProperty" NavigationPropertyPath="_EquipMatlSrlNmbrChgHistory"/>
+                                    <PropertyValue Property="InsertRestrictions">
+                                        <Record>
+                                            <PropertyValue Property="Insertable" Bool="false"/>
+                                        </Record>
+                                    </PropertyValue>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="NavigationProperty" NavigationPropertyPath="_MaterialSerialNumberVH"/>
+                                    <PropertyValue Property="InsertRestrictions">
+                                        <Record>
+                                            <PropertyValue Property="Insertable" Bool="false"/>
+                                        </Record>
+                                    </PropertyValue>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__common.DraftRoot">
+                    <Record>
+                        <PropertyValue Property="ActivationAction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.Activate"/>
+                        <PropertyValue Property="DiscardAction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.Discard"/>
+                        <PropertyValue Property="EditAction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.Edit"/>
+                        <PropertyValue Property="AdditionalNewActions">
+                            <Collection>
+                                <String>com.sap.gateway.srvd.eam_materialserialnumber.v0001.CrteWthRefFrmSrlzdMaterialItem</String>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="PreparationAction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.Prepare"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="true"/>
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group "/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Property="Filterable" Bool="true"/>
+                        <PropertyValue Property="FilterExpressionRestrictions">
+                            <Collection>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="HasEquipmentData"/>
+                                    <PropertyValue Property="AllowedExpressions" String="MultiValue"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="CreationDate"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="LastChangeDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="MatlSrlNmbrLastGdsMvtDte"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleValue"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="ConcatenatedActiveUserStsName"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SearchExpression"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="ConcatenatedActiveSystStsName"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SearchExpression"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="DraftEntityCreationDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="DraftEntityLastChangeDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="NonFilterableProperties">
+                            <Collection>
+                                <PropertyPath>__EntityControl</PropertyPath>
+                                <PropertyPath>__OperationControl</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SortRestrictions">
+                    <Record>
+                        <PropertyValue Property="NonSortableProperties">
+                            <Collection>
+                                <PropertyPath>ConcatenatedActiveUserStsName</PropertyPath>
+                                <PropertyPath>ConcatenatedActiveSystStsName</PropertyPath>
+                                <PropertyPath>IsCloudSystem</PropertyPath>
+                                <PropertyPath>__EntityControl</PropertyPath>
+                                <PropertyPath>__OperationControl</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="RequiredProperties">
+                            <Collection>
+                                <PropertyPath>Material</PropertyPath>
+                                <PropertyPath>EquipmentCategory</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Path="__EntityControl/Updatable"/>
+                        <PropertyValue Property="NonUpdatableNavigationProperties">
+                            <Collection>
+                                <PropertyPath>DraftAdministrativeData</PropertyPath>
+                                <PropertyPath>SiblingEntity</PropertyPath>
+                                <PropertyPath>_ActiveSystemStatus</PropertyPath>
+                                <PropertyPath>_EquipMaterialSerialNumberVH</PropertyPath>
+                                <PropertyPath>_EquipMatlSrlNmbrChgHistory</PropertyPath>
+                                <PropertyPath>_MaterialSerialNumberVH</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__core.OptimisticConcurrency">
+                    <Collection>
+                        <PropertyPath>LastChangeDateTime</PropertyPath>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaterial(SAP__self.C_EquipMaterialSerialNumberTPType)/Material">
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.ValueListForValidation" String=""/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_materialstdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-c_equipmaterialserialnumbertp.changematerial.material.C_EquipMaterialSerialNumberTPType'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaterial(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChangeMaterial"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/Material">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/c_sermatitmlastserialnumbervh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-c_equipmaterialserialnumbertp.createmassmaterialserialnumber.material.C_EquipMaterialSerialNumberTPType.X'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/EquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Category"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_equipmentcategorystdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-c_equipmaterialserialnumbertp.createmassmaterialserialnumber.equipmentcategory.C_EquipMaterialSerialNumberTPType.X'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/UniqueItemIdentifierRespPlant">
+                <Annotation Term="SAP__common.Label" String="Responsible Plant UII"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_PLANT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/EquipMaterialLastSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Last Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="Last num.SerialNo"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Last Numerical Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LSERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/EquipmentNumberOfSerialNumbers">
+                <Annotation Term="SAP__common.Label" String="Number of Serial Numbers"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="No. serial numbers"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Number of Serial Numbers/Pieces of Equipment to be Created"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=ANZSER"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/EquipmentFromSerialNumber">
+                <Annotation Term="SAP__common.Label" String="From Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="From serial number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="From Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SERVON"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/EquipmentToSerialNumber">
+                <Annotation Term="SAP__common.Label" String="To Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="To serial number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="To Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SERBIS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChgSrlzdMatlItemSerialNumber(SAP__self.C_EquipMaterialSerialNumberTPType)/SerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_materialserialnumbervh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-c_equipmaterialserialnumbertp.chgsrlzdmatlitemserialnumber.serialnumber.C_EquipMaterialSerialNumberTPType'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChgSrlzdMatlItemSerialNumber(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChgSrlzdMatlItemSerialNumber"/>
+            </Annotations>
+            <Annotations Target="SAP__self.SetSrlzdMaterialItemToDeletion(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/SetSrlzdMaterialItemToDeletion"/>
+                <Annotation Term="SAP__common.SideEffects" Qualifier="SAP__Action_SetSrlzdMaterialItemToDeletion">
+                    <Record Type="SAP__common.SideEffectsType">
+                        <PropertyValue Property="TargetProperties">
+                            <Collection>
+                                <String>_it/ConcatenatedActiveSystStsName</String>
+                                <String>_it/__OperationControl/ActvtSrlzdMatlItmEquipmentData</String>
+                                <String>_it/__OperationControl/ChangeEquipmentCategory</String>
+                                <String>_it/__OperationControl/ChangeMaintenancePlant</String>
+                                <String>_it/__OperationControl/ChangeMaterial</String>
+                                <String>_it/__OperationControl/ChangeUniqueItemIdentifier</String>
+                                <String>_it/__OperationControl/ChgSrlzdMatlItemSerialNumber</String>
+                                <String>_it/__OperationControl/ResetSrlzdMatlItmFrmDeletion</String>
+                                <String>_it/__OperationControl/RsetSrlzdMatlItemFromInactive</String>
+                                <String>_it/__OperationControl/SetSrlzdMaterialItemToDeletion</String>
+                                <String>_it/__OperationControl/SetSrlzdMaterialItemToInactive</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ResetSrlzdMatlItmFrmDeletion(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ResetSrlzdMatlItmFrmDeletion"/>
+                <Annotation Term="SAP__common.SideEffects" Qualifier="SAP__Action_ResetSrlzdMatlItmFrmDeletion">
+                    <Record Type="SAP__common.SideEffectsType">
+                        <PropertyValue Property="TargetProperties">
+                            <Collection>
+                                <String>_it/ConcatenatedActiveSystStsName</String>
+                                <String>_it/__OperationControl/ActvtSrlzdMatlItmEquipmentData</String>
+                                <String>_it/__OperationControl/ChangeEquipmentCategory</String>
+                                <String>_it/__OperationControl/ChangeMaintenancePlant</String>
+                                <String>_it/__OperationControl/ChangeMaterial</String>
+                                <String>_it/__OperationControl/ChangeUniqueItemIdentifier</String>
+                                <String>_it/__OperationControl/ChgSrlzdMatlItemSerialNumber</String>
+                                <String>_it/__OperationControl/ResetSrlzdMatlItmFrmDeletion</String>
+                                <String>_it/__OperationControl/RsetSrlzdMatlItemFromInactive</String>
+                                <String>_it/__OperationControl/SetSrlzdMaterialItemToDeletion</String>
+                                <String>_it/__OperationControl/SetSrlzdMaterialItemToInactive</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeEquipmentCategory(SAP__self.C_EquipMaterialSerialNumberTPType)/EquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Category"/>
+                <Annotation Term="SAP__common.ValueListForValidation" String=""/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_equipmentcategorystdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-c_equipmaterialserialnumbertp.changeequipmentcategory.equipmentcategory.C_EquipMaterialSerialNumberTPType'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeEquipmentCategory(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChangeEquipmentCategory"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Edit(SAP__self.C_EquipMaterialSerialNumberTPType)/PreserveChanges">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="TRUE"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Data element for domain BOOLE: TRUE (='X') and FALSE (=' ')"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Edit(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/Edit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.C_EquipMaterialSerialNumberTPType)/Material">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.C_EquipMaterialSerialNumberTPType)/SerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.C_EquipMaterialSerialNumberTPType)/EquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Category"/>
+                <Annotation Term="SAP__common.FieldControl" EnumMember="SAP__common.FieldControlType/Mandatory"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.C_EquipMaterialSerialNumberTPType)/UniqueItemIdentifierRespPlant">
+                <Annotation Term="SAP__common.Label" String="Responsible Plant UII"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_PLANT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.C_EquipMaterialSerialNumberTPType)/SrlzdMatlItmReferenceMaterial">
+                <Annotation Term="SAP__common.Label" String="Material Reference"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.C_EquipMaterialSerialNumberTPType)/SrlzdMatlItmRefSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number Reference"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ActvtSrlzdMatlItmEquipmentData(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ActvtSrlzdMatlItmEquipmentData"/>
+                <Annotation Term="SAP__common.SideEffects" Qualifier="SAP__Action_ActvtSrlzdMatlItmEquipmentData">
+                    <Record Type="SAP__common.SideEffectsType">
+                        <PropertyValue Property="TargetProperties">
+                            <Collection>
+                                <String>_it/TechnicalObject</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeUniqueItemIdentifier(SAP__self.C_EquipMaterialSerialNumberTPType)/UniqueItemIdentifier">
+                <Annotation Term="SAP__common.Label" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Unique Item Identifier"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeUniqueItemIdentifier(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChangeUniqueItemIdentifier"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaintenancePlant(SAP__self.C_EquipMaterialSerialNumberTPType)/MaintenancePlant">
+                <Annotation Term="SAP__common.Label" String="Maintenance Plant"/>
+                <Annotation Term="SAP__common.ValueListForValidation" String=""/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_plantstdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-c_equipmaterialserialnumbertp.changemaintenanceplant.maintenanceplant.C_EquipMaterialSerialNumberTPType'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Plnt"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Maintenance Plant"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SWERK"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaintenancePlant(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChangeMaintenancePlant"/>
+            </Annotations>
+            <Annotations Target="SAP__self.SetSrlzdMaterialItemToInactive(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/SetSrlzdMaterialItemToInactive"/>
+                <Annotation Term="SAP__common.SideEffects" Qualifier="SAP__Action_SetSrlzdMaterialItemToInactive">
+                    <Record Type="SAP__common.SideEffectsType">
+                        <PropertyValue Property="TargetProperties">
+                            <Collection>
+                                <String>_it/ConcatenatedActiveSystStsName</String>
+                                <String>_it/__OperationControl/RsetSrlzdMatlItemFromInactive</String>
+                                <String>_it/__OperationControl/SetSrlzdMaterialItemToInactive</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.RsetSrlzdMatlItemFromInactive(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/RsetSrlzdMatlItemFromInactive"/>
+                <Annotation Term="SAP__common.SideEffects" Qualifier="SAP__Action_RsetSrlzdMatlItemFromInactive">
+                    <Record Type="SAP__common.SideEffectsType">
+                        <PropertyValue Property="TargetProperties">
+                            <Collection>
+                                <String>_it/ConcatenatedActiveSystStsName</String>
+                                <String>_it/__OperationControl/RsetSrlzdMatlItemFromInactive</String>
+                                <String>_it/__OperationControl/SetSrlzdMaterialItemToInactive</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType">
+                <Annotation Term="SAP__common.SemanticKey">
+                    <Collection>
+                        <PropertyPath>SerialNumber</PropertyPath>
+                        <PropertyPath>Material</PropertyPath>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.SideEffects" Qualifier="SAP__Field_MaterialSerialNumberStockBatch">
+                    <Record Type="SAP__common.SideEffectsType">
+                        <PropertyValue Property="SourceProperties">
+                            <Collection>
+                                <PropertyPath>MaterialSerialNumberStockBatch</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="TargetProperties">
+                            <Collection>
+                                <String>MatlSrlNmbrMasterBatch</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__common.SideEffects" Qualifier="SAP__Field_Plant">
+                    <Record Type="SAP__common.SideEffectsType">
+                        <PropertyValue Property="SourceProperties">
+                            <Collection>
+                                <PropertyPath>Plant</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="TargetProperties">
+                            <Collection>
+                                <String>CompanyCode</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__common.SideEffects" Qualifier="SAP__Field_StorageLocation">
+                    <Record Type="SAP__common.SideEffectsType">
+                        <PropertyValue Property="SourceProperties">
+                            <Collection>
+                                <PropertyPath>StorageLocation</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="TargetProperties">
+                            <Collection>
+                                <String>CompanyCode</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__UI.HeaderInfo">
+                    <Record>
+                        <PropertyValue Property="TypeName" String="Manage Material Serial Numbers"/>
+                        <PropertyValue Property="TypeNamePlural" String="Material Serial Numbers"/>
+                        <PropertyValue Property="Title">
+                            <Record Type="SAP__UI.DataField">
+                                <PropertyValue Property="Value" Path="Material"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__UI.Identification">
+                    <Collection>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Activate Equipment View"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ActvtSrlzdMatlItmEquipmentData(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Change Equipment Category"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeEquipmentCategory(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Change Maintenance Plant"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeMaintenancePlant(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Set Material Item to Inactive"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Set Material Item to Active"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.RsetSrlzdMatlItemFromInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Set Material Item to Deletion"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Set Material Item From Deletion"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ResetSrlzdMatlItmFrmDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForIntentBasedNavigation">
+                            <PropertyValue Property="Label" String="Serial Number History"/>
+                            <PropertyValue Property="SemanticObject" String="Material"/>
+                            <PropertyValue Property="Action" String="displaySerHistoryInfo"/>
+                            <PropertyValue Property="RequiresContext" Bool="false"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Change Serial Number"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChgSrlzdMatlItemSerialNumber(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Change Material Number"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeMaterial(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.LineItem">
+                    <Collection>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Mass Create"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber(Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType))"/>
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="Material"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="SerialNumber"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="TechnicalObject"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="EquipmentCategory"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="ConcatenatedActiveSystStsName"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="Customer"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="Plant"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="StorageLocation"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="InventoryStockType"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaterialSerialNumberStockBatch"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="CreationDate"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="EquipmentName"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="Material"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="SerialNumber"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="Equipment"/>
+                            <Annotation Term="SAP__UI.Hidden"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="TechnicalObject"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="TechObjIsEquipOrFuncnlLoc"/>
+                            <Annotation Term="SAP__UI.Hidden"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="EquipmentName"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="CreationDate"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaterialName"/>
+                            <Annotation Term="SAP__UI.Hidden"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.PresentationVariant">
+                    <Record>
+                        <PropertyValue Property="SortOrder">
+                            <Collection>
+                                <Record Type="SAP__common.SortOrderType">
+                                    <PropertyValue Property="Property" PropertyPath="CreationDate"/>
+                                    <PropertyValue Property="Descending" Bool="true"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="RequestAtLeast">
+                            <Collection>
+                                <PropertyPath>TechnicalObject</PropertyPath>
+                                <PropertyPath>TechObjIsEquipOrFuncnlLoc</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="Visualizations">
+                            <Collection>
+                                <AnnotationPath>@SAP__UI.LineItem</AnnotationPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__UI.SelectionFields">
+                    <Collection>
+                        <PropertyPath>Material</PropertyPath>
+                        <PropertyPath>SerialNumber</PropertyPath>
+                        <PropertyPath>Equipment</PropertyPath>
+                        <PropertyPath>ConcatenatedActiveSystStsName</PropertyPath>
+                        <PropertyPath>InventoryStockType</PropertyPath>
+                        <PropertyPath>EquipmentCategory</PropertyPath>
+                        <PropertyPath>Plant</PropertyPath>
+                        <PropertyPath>MaterialSerialNumberStockBatch</PropertyPath>
+                        <PropertyPath>StorageLocation</PropertyPath>
+                        <PropertyPath>Customer</PropertyPath>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Messages" Path="SAP__Messages"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="SAP__common.SideEffects" Qualifier="SAP__Action_CrteWthRefFrmSrlzdMaterialItem">
+                    <Record Type="SAP__common.SideEffectsType">
+                        <PropertyValue Property="TargetProperties">
+                            <Collection>
+                                <String>_it/Equipment</String>
+                                <String>_it/__OperationControl/ActvtSrlzdMatlItmEquipmentData</String>
+                                <String>_it/__OperationControl/ChangeMaintenancePlant</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocument">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Document Number"/>
+                <Annotation Term="SAP__common.Heading" String="Doc.Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Change Number of Document"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/DatabaseTable">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Table Name"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=TABNAME"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocDatabaseTableField">
+                <Annotation Term="SAP__common.Text" Path="ChangeDocDatabaseTableField_Text">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextOnly"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Field Name"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=FIELDNAME"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocDatabaseTableField_Text">
+                <Annotation Term="SAP__common.Label" String="Field Name"/>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Heading" String="Long Field Label"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Long Field Label"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SCRTEXT_L"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocItemChangeType">
+                <Annotation Term="SAP__common.Label" String="Activity"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Activity"/>
+                <Annotation Term="SAP__common.Text" Path="ChangeDocItemChangeType_Text">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextOnly"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Change Indicator"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=CDCHNGIND"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocItemChangeType_Text">
+                <Annotation Term="SAP__common.Label" String="Change Method"/>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Heading" String="Short Description"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Short Text for Fixed Values"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=VAL_TEXT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/CreationDateTime">
+                <Annotation Term="SAP__common.Label" String="Edited On"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Edited On"/>
+                <Annotation Term="SAP__common.Heading" String="Short Form of Time Stamp"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=TZNTSTMPS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/MaintObjectChangeTypeCode">
+                <Annotation Term="SAP__common.Label" String="Edit Type"/>
+                <Annotation Term="SAP__common.Text" Path="MaintObjectChangeTypeCodeText">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextOnly"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/MaintObjectChangeTypeCodeText">
+                <Annotation Term="SAP__common.Label" String="Edit Type Text"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Edit Type Text"/>
+                <Annotation Term="SAP__common.Heading" String="Short Description"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=VAL_TEXT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/MaterialName">
+                <Annotation Term="SAP__common.Label" String="Short Description"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/CreatedByUser">
+                <Annotation Term="SAP__common.Label" String="Edited By"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Edited By"/>
+                <Annotation Term="SAP__common.Text" Path="UserDescription">
+                    <Annotation Term="SAP__UI.TextArrangement" EnumMember="SAP__UI.TextArrangementType/TextOnly"/>
+                </Annotation>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="User"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=CDUSERNAME"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/UserDescription">
+                <Annotation Term="SAP__common.Label" String="Edited By Name"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Edited By Name"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocNewFieldValue">
+                <Annotation Term="SAP__common.Label" String="New Value"/>
+                <Annotation Term="SAP__common.QuickInfo" String="New Value"/>
+                <Annotation Term="SAP__common.Heading" String="New Value"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocPreviousFieldValue">
+                <Annotation Term="SAP__common.Label" String="Old Value"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Old Value"/>
+                <Annotation Term="SAP__common.Heading" String="Old Value"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/TechObjChgDocNewFldValueText">
+                <Annotation Term="SAP__common.Label" String="New Value Display"/>
+                <Annotation Term="SAP__common.QuickInfo" String="New Value Display"/>
+                <Annotation Term="SAP__common.Heading" String="New Value"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/TechObjChgDocOldFldValueText">
+                <Annotation Term="SAP__common.Label" String="Old Value Display"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Old Value Display"/>
+                <Annotation Term="SAP__common.Heading" String="Old Value"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocObjectClass">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Change Doc. Object"/>
+                <Annotation Term="SAP__common.Heading" String="Object"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Object Class"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/Class">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Class"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Class number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KLASSE_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/StatusProfile">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Status Profile"/>
+                <Annotation Term="SAP__common.Heading" String="StatProf"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_STSMA"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType">
+                <Annotation Term="SAP__common.Label" String="Equip Mat Serial Number Change History"/>
+                <Annotation Term="SAP__UI.Identification">
+                    <Collection>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaintObjectChangeTypeCode"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaterialName"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/High"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.LineItem">
+                    <Collection>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaintObjectChangeTypeCode"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaterialName"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/High"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="CreatedByUser"/>
+                            <Annotation Term="SAP__UI.Importance" EnumMember="SAP__UI.ImportanceType/Medium"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.PresentationVariant">
+                    <Record>
+                        <PropertyValue Property="RequestAtLeast">
+                            <Collection>
+                                <PropertyPath>CharcDescription</PropertyPath>
+                                <PropertyPath>Class</PropertyPath>
+                                <PropertyPath>StatusIsInactive</PropertyPath>
+                                <PropertyPath>StatusName</PropertyPath>
+                                <PropertyPath>ChangeDocObjectClass</PropertyPath>
+                                <PropertyPath>CreationDateTime</PropertyPath>
+                                <PropertyPath>CreatedByUser</PropertyPath>
+                                <PropertyPath>ChangeDocItemChangeType</PropertyPath>
+                                <PropertyPath>MaintObjectChangeTypeCode</PropertyPath>
+                                <PropertyPath>ChangeDocDatabaseTableField</PropertyPath>
+                                <PropertyPath>DatabaseTable</PropertyPath>
+                                <PropertyPath>ChangeDocument</PropertyPath>
+                                <PropertyPath>ChangeDocObject</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/C_EquipMatlSrlNmbrChgHistoryTP">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Property="NonFilterableProperties">
+                            <Collection>
+                                <PropertyPath>TechObjChgDocNewFldValueText</PropertyPath>
+                                <PropertyPath>TechObjChgDocOldFldValueText</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SortRestrictions">
+                    <Record>
+                        <PropertyValue Property="NonSortableProperties">
+                            <Collection>
+                                <PropertyPath>TechObjChgDocNewFldValueText</PropertyPath>
+                                <PropertyPath>TechObjChgDocOldFldValueText</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Insertable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Bool="false"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/EquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Equipment Category"/>
+                <Annotation Term="SAP__common.Text" Path="EquipmentCategory_Text"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/EquipmentCategory_Text">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Equipment CatDesc."/>
+                <Annotation Term="SAP__common.Heading" String="Equipment category description"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category description"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=ETYTX"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/EquipmentCategoryStatusProfile">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Status Profile"/>
+                <Annotation Term="SAP__common.Heading" String="StatProf"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_STSMA"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/EquipmentCategoryViewProfile">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="View profile"/>
+                <Annotation Term="SAP__common.Heading" String="Profl."/>
+                <Annotation Term="SAP__common.QuickInfo" String="View profile for tab index Customizing"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=ITOBVIEW_PROFILE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/NumberRangeForIntIDAssignment">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="No. Range Int. Asst"/>
+                <Annotation Term="SAP__common.Heading" String="IntNR"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Number Range of Internal Number Assignment"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=NUMKI"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/NumberRangeForExtIDAssignment">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="No. Range Ext. Asst"/>
+                <Annotation Term="SAP__common.Heading" String="ExtNR"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Number Range of External Number Assignment"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=NUMKE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/TechObjInspectionLevelCode">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Inspection Level"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Level at Which the Object is Represented"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EAME_IDMS_TYPE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/EquipmentCategoryReferenceType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="EquipRefCateg."/>
+                <Annotation Term="SAP__common.Heading" String="R"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment reference category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=REFTP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType">
+                <Annotation Term="SAP__common.Label" String="Equipment Category"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/I_EquipmentCategoryStdVH">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="true"/>
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group "/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Insertable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Bool="false"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_StorageLocationStdVHType/Plant">
+                <Annotation Term="SAP__common.Text" Path="PlantName"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_plantstdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-i_storagelocationstdvh.plant'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Label" String="Plant"/>
+                <Annotation Term="SAP__common.Heading" String="Plnt"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=WERKS_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_StorageLocationStdVHType/StorageLocation">
+                <Annotation Term="SAP__common.Text" Path="StorageLocationName"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Storage Location"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LGORT_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_StorageLocationStdVHType/ConfigDeprecationCode">
+                <Annotation Term="SAP__common.Text" Path="ConfignDeprecationCodeName"/>
+                <Annotation Term="SAP__CodeList.IsConfigurationDeprecationCode"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_configndeprecationcode/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-i_storagelocationstdvh.configdeprecationcode'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.ValueListWithFixedValues"/>
+                <Annotation Term="SAP__common.Label" String="Validity"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Deprecated Entries"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=CONFIG_DEPRECATION_CODE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_StorageLocationStdVHType">
+                <Annotation Term="SAP__common.Label" String="Storage Location"/>
+                <Annotation Term="SAP__UI.LineItem">
+                    <Collection>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="StorageLocation"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="StorageLocationName"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="Plant"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/I_StorageLocationStdVH">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="true"/>
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group "/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Insertable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Bool="false"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_MaterialSerialNumberVHType/Equipment">
+                <Annotation Term="SAP__common.Text" Path="Equipment_Text"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Equipment"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQUNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_MaterialSerialNumberVHType/Equipment_Text">
+                <Annotation Term="SAP__common.Label" String="Description"/>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Heading" String="Description of technical object"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Description of technical object"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KTX01"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_MaterialSerialNumberVHType/Material">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_MaterialSerialNumberVHType/SerialNumber">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_MaterialSerialNumberVHType/UniqueItemIdentifier">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="UII"/>
+                <Annotation Term="SAP__common.Heading" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_CHAR72"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_MaterialSerialNumberVHType">
+                <Annotation Term="SAP__common.Label" String="Material Serial Number"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/I_MaterialSerialNumberVH">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="true"/>
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group "/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Insertable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Bool="false"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/Equipment">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Equipment"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQUNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/EquipmentName">
+                <Annotation Term="SAP__common.Label" String="Description"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Description"/>
+                <Annotation Term="SAP__common.Heading" String="Description of technical object"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KTX01"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/BusinessPartner">
+                <Annotation Term="SAP__common.Label" String="Business Partner ID"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Business Partner ID"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Business Partner"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=BU_PARTNER"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/BusinessPartnerName">
+                <Annotation Term="SAP__common.Label" String="Business Partner Name"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Business Partner Name"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/Material">
+                <Annotation Term="SAP__common.Label" String="Material ID"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material ID"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_materialvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-i_equipmaterialserialnumbervh.material'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Material"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/MaterialName">
+                <Annotation Term="SAP__common.Label" String="Material Description"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Description"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__common.Heading" String="Material Description"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MAKTX"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/SerialNumber">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=CRM_GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/Customer">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Current customer"/>
+                <Annotation Term="SAP__common.Heading" String="CurCustomer"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Customer to Whom Serial Number was Delivered"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KUNDSE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/Supplier">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Vendor"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Vendor number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=ELIEF"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType/EquipmentCategory">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Equipment category"/>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMaterialSerialNumberVHType">
+                <Annotation Term="SAP__common.Label" String="Equipment"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/I_EquipMaterialSerialNumberVH">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="true"/>
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group "/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Insertable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Bool="false"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/Material">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/SerialNumber">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/Equipment">
+                <Annotation Term="SAP__common.Text" Path="Equipment_Text"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Equipment"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQUNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/Equipment_Text">
+                <Annotation Term="SAP__common.Label" String="Description"/>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Heading" String="Description of technical object"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Description of technical object"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KTX01"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/EquipmentCategory">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Equipment category"/>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/UniqueItemIdentifier">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="UII"/>
+                <Annotation Term="SAP__common.Heading" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_CHAR72"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/UniqueItemIdentifierStrucType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="IUID Type"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Structure Type of UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=IUID_TYPE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/UniqueItemIdentifierRespPlant">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Resp. Plant UII"/>
+                <Annotation Term="SAP__common.Heading" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_PLANT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/MaintObjectInternalID">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Object Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_OBJNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/CreatedByUser">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Created By"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Name of Person Responsible for Creating the Object"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType">
+                <Annotation Term="SAP__common.CreatedBy" Path="CreatedByUser"/>
+                <Annotation Term="SAP__common.ChangedBy" Path="LastChangedByUser"/>
+                <Annotation Term="SAP__common.ChangedAt" Path="LastChangeDateTime"/>
+                <Annotation Term="SAP__common.Label" String="Material Serial Number"/>
+                <Annotation Term="SAP__common.SemanticKey">
+                    <Collection>
+                        <PropertyPath>Equipment</PropertyPath>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/LastChangedByUser">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Changed By"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Name of Person Who Changed Object"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/MatlSrlNmbrMasterBatch">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Batch"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Batch Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=CHARG_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/EquipMaterialLastSerialNumber">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Last num.SerialNo"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Last Numerical Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LSERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/InventoryStockType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Stock Type"/>
+                <Annotation Term="SAP__common.Heading" String="PP"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Stock Type of Goods Movement (Primary Posting)"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LBBSA"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/Plant">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Plant"/>
+                <Annotation Term="SAP__common.Heading" String="Plnt"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=WERKS_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/StorageLocation">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Storage Location"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LGORT_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/MaterialSerialNumberStockBatch">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Stock batch"/>
+                <Annotation Term="SAP__common.Heading" String="StockBatch"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Batch Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=B_CHARGE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/InventorySpecialStockType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Special Stock"/>
+                <Annotation Term="SAP__common.Heading" String="S"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Special Stock Indicator"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SOBKZ"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/Customer">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Spec. stock customer"/>
+                <Annotation Term="SAP__common.Heading" String="Stck cust."/>
+                <Annotation Term="SAP__common.QuickInfo" String="Special stock customer account number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=B_KUNNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/Supplier">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Special stock vendor"/>
+                <Annotation Term="SAP__common.Heading" String="StckVendor"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Account number of the vendor"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=B_LIFNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/SalesOrder">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Sales Order"/>
+                <Annotation Term="SAP__common.Heading" String="Sales Ord."/>
+                <Annotation Term="SAP__common.QuickInfo" String="Sales Order Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KDAUF"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/SalesOrderItem">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation Term="SAP__common.Label" String="Sales Order Item"/>
+                <Annotation Term="SAP__common.Heading" String="SO Item"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Item Number in Sales Order"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KDPOS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/WBSElementInternalID">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation Term="SAP__common.Label" String="WBS Internal ID"/>
+                <Annotation Term="SAP__common.Heading" String="WBS Elem"/>
+                <Annotation Term="SAP__common.QuickInfo" String="WBS Element"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=PS_S4_PSPNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/StockOwner">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Owner of stock"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=OWNER_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/I_EquipMatlSerialNumber">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Insertable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Bool="false"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_MaterialStdVHType/Material">
+                <Annotation Term="SAP__common.Text" Path="Material_Text"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_MaterialStdVHType/Material_Text">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Material Description"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MAKTX"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_MaterialStdVHType">
+                <Annotation Term="SAP__common.Label" String="Material"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/I_MaterialStdVH">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="true"/>
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group "/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Insertable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Bool="false"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftEntityType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Entity ID"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/CreatedByUser">
+                <Annotation Term="SAP__common.Text" Path="CreatedByUserDescription"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_draftadministrativeuservh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-i_draftadministrativedata.createdbyuser'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Label" String="Draft Created By"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/LastChangedByUser">
+                <Annotation Term="SAP__common.Text" Path="LastChangedByUserDescription"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_draftadministrativeuservh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.et-i_draftadministrativedata.lastchangedbyuser'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Label" String="Draft Last Changed By"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftAccessType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Access Type"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/InProcessByUser">
+                <Annotation Term="SAP__common.Text" Path="InProcessByUserDescription"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft In Process By"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType">
+                <Annotation Term="SAP__common.Label" String="Draft Administration Data"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/I_DraftAdministrativeData">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="true"/>
+                        <PropertyValue Property="UnsupportedExpressions" EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group "/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Property="Filterable" Bool="true"/>
+                        <PropertyValue Property="FilterExpressionRestrictions">
+                            <Collection>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="CreationDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="LastChangeDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="Insertable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Bool="false"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/Material">
+                <Annotation Term="SAP__core.Immutable"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/SerialNumber">
+                <Annotation Term="SAP__core.Immutable"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/Equipment">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Equipment"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQUNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/EquipmentCategory">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Equipment category"/>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/UniqueItemIdentifier">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Unique Item ID"/>
+                <Annotation Term="SAP__common.Heading" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Unique Item Identifier"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/UniqueItemIdentifierStrucType">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="IUID Type"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Structure Type of UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=IUID_TYPE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/UniqueItemIdentifierRespPlant">
+                <Annotation Term="SAP__core.Immutable"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Resp. Plant UII"/>
+                <Annotation Term="SAP__common.Heading" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_PLANT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/TechObjIsEquipOrFuncnlLoc">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Tech. Obj. Type"/>
+                <Annotation Term="SAP__common.Heading" String="Technical Object Type"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Technical Object Type"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MaintObjectInternalID">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Object Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_OBJNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/TechnicalObject">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Technical Object"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/EquipmentHasStockInformation">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Has Stock Information"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Indicator: Stock Information Available"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/CreatedByUser">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Created By"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Name of Person Responsible for Creating the Object"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/LastChangedByUser">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Changed By"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Name of Person Who Changed Object"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/CreationDate">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Created On"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Record Creation Date"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/LastChangeDate">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Changed On"/>
+                <Annotation Term="SAP__common.Heading" String="Chngd On"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Last Changed On"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/LastChangeDateTime">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Short Time Stamp"/>
+                <Annotation Term="SAP__common.Heading" String="Short Form of Time Stamp"/>
+                <Annotation Term="SAP__common.QuickInfo" String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=TZNTSTMPS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrMasterBatch">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Batch"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Batch Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=CHARG_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/EquipMaterialLastSerialNumber">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Last num.SerialNo"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Last Numerical Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LSERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MaterialSerialNumberStockBatch">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Stock batch"/>
+                <Annotation Term="SAP__common.Heading" String="StockBatch"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Batch Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=B_CHARGE"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/InventoryStockType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Stock Type"/>
+                <Annotation Term="SAP__common.Heading" String="PP"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Stock Type of Goods Movement (Primary Posting)"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LBBSA"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/Plant">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Plant"/>
+                <Annotation Term="SAP__common.Heading" String="Plnt"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=WERKS_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/StorageLocation">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Storage Location"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LGORT_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/InventorySpecialStockType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Special Stock"/>
+                <Annotation Term="SAP__common.Heading" String="S"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Special Stock Indicator"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SOBKZ"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/Customer">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Spec. stock customer"/>
+                <Annotation Term="SAP__common.Heading" String="Stck cust."/>
+                <Annotation Term="SAP__common.QuickInfo" String="Special stock customer account number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=B_KUNNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/Supplier">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Special stock vendor"/>
+                <Annotation Term="SAP__common.Heading" String="StckVendor"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Account number of the vendor"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=B_LIFNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/SalesOrder">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Sales Order"/>
+                <Annotation Term="SAP__common.Heading" String="Sales Ord."/>
+                <Annotation Term="SAP__common.QuickInfo" String="Sales Order Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KDAUF"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/SalesOrderItem">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation Term="SAP__common.Label" String="Sales Order Item"/>
+                <Annotation Term="SAP__common.Heading" String="SO Item"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Item Number in Sales Order"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KDPOS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/WBSElementInternalID">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation Term="SAP__common.Label" String="WBS Internal ID"/>
+                <Annotation Term="SAP__common.Heading" String="WBS Elem"/>
+                <Annotation Term="SAP__common.QuickInfo" String="WBS Element"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=PS_S4_PSPNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/WBSElement">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="WBS Element"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Work Breakdown Structure Element (WBS Element) Edited"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=PS_POSID_EDIT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/StockOwner">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Owner of stock"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=OWNER_D"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/CompanyCode">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Company Code"/>
+                <Annotation Term="SAP__common.Heading" String="CoCd"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=BUKRS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsAvailable">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsDeleted">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsMrkdForDeltn">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsInactive">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsInstalled">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsAllcToParent">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsInWarehouse">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsAssgdToDeliv">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsAtCustomer">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsUndrCnstrctn">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsOnHold">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsLocked">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsIDUndefined">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrIsAssgdToJITCall">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrDocIsCreated">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrHndlgUntIsAssgd">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrInvtryIsActv">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrUUIDIsGnrtd">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrUUIDIsAttached">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrUUIDIsSent">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrUUIDIsConfd">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__common.Label" String="Checkbox"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/HasDraftEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Has Draft"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Draft - Indicator - Has draft document"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/DraftUUID">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Key"/>
+                <Annotation Term="SAP__common.QuickInfo" String="UUID serving as key (parent key, root key)"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/DraftEntityCreationDateTime">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Created On"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/DraftEntityLastChangeDateTime">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Last Changed On"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/HasActiveEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Has active"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Draft - Indicator - Has active document"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/IsActiveEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Is active"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Draft - Indicator - Is active document"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__EntityControl">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/R_EquipMatlSerialNumberTP">
+                <Annotation Term="SAP__common.DraftRoot">
+                    <Record>
+                        <PropertyValue Property="PreparationAction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.Prepare"/>
+                        <PropertyValue Property="ActivationAction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.Activate"/>
+                        <PropertyValue Property="EditAction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.Edit"/>
+                        <PropertyValue Property="AdditionalNewActions">
+                            <Collection>
+                                <String>com.sap.gateway.srvd.eam_materialserialnumber.v0001.CrteWthRefFrmSrlzdMaterialItem</String>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="DiscardAction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.Discard"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Property="Searchable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Property="Filterable" Bool="true"/>
+                        <PropertyValue Property="FilterExpressionRestrictions">
+                            <Collection>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="DraftEntityCreationDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="DraftEntityLastChangeDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="NonFilterableProperties">
+                            <Collection>
+                                <PropertyPath>__EntityControl</PropertyPath>
+                                <PropertyPath>__OperationControl</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SortRestrictions">
+                    <Record>
+                        <PropertyValue Property="NonSortableProperties">
+                            <Collection>
+                                <PropertyPath>__EntityControl</PropertyPath>
+                                <PropertyPath>__OperationControl</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Property="RequiredProperties">
+                            <Collection>
+                                <PropertyPath>Material</PropertyPath>
+                                <PropertyPath>EquipmentCategory</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Property="Deletable" Bool="false"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Property="Updatable" Path="__EntityControl/Updatable"/>
+                        <PropertyValue Property="NonUpdatableNavigationProperties">
+                            <Collection>
+                                <PropertyPath>DraftAdministrativeData</PropertyPath>
+                                <PropertyPath>SiblingEntity</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Property="SelectSupported" Bool="true"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__core.OptimisticConcurrency">
+                    <Collection>
+                        <PropertyPath>LastChangeDateTime</PropertyPath>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChgSrlzdMatlItemSerialNumber(SAP__self.R_EquipMatlSerialNumberTPType)/SerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_materialserialnumbervh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-r_equipmatlserialnumbertp.chgsrlzdmatlitemserialnumber.serialnumber.R_EquipMatlSerialNumberTPType'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChgSrlzdMatlItemSerialNumber(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChgSrlzdMatlItemSerialNumber"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeEquipmentCategory(SAP__self.R_EquipMatlSerialNumberTPType)/EquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Category"/>
+                <Annotation Term="SAP__common.ValueListForValidation" String=""/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_equipmentcategorystdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-r_equipmatlserialnumbertp.changeequipmentcategory.equipmentcategory.R_EquipMatlSerialNumberTPType'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeEquipmentCategory(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChangeEquipmentCategory"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaintenancePlant(SAP__self.R_EquipMatlSerialNumberTPType)/MaintenancePlant">
+                <Annotation Term="SAP__common.Label" String="Maintenance Plant"/>
+                <Annotation Term="SAP__common.ValueListForValidation" String=""/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_plantstdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-r_equipmatlserialnumbertp.changemaintenanceplant.maintenanceplant.R_EquipMatlSerialNumberTPType'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Plnt"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Maintenance Plant"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SWERK"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaintenancePlant(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChangeMaintenancePlant"/>
+            </Annotations>
+            <Annotations Target="SAP__self.SetSrlzdMaterialItemToInactive(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/SetSrlzdMaterialItemToInactive"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeUniqueItemIdentifier(SAP__self.R_EquipMatlSerialNumberTPType)/UniqueItemIdentifier">
+                <Annotation Term="SAP__common.Label" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Unique Item Identifier"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Unique Item Identifier"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeUniqueItemIdentifier(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChangeUniqueItemIdentifier"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.R_EquipMatlSerialNumberTPType))/Material">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/c_sermatitmlastserialnumbervh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-r_equipmatlserialnumbertp.createmassmaterialserialnumber.material.R_EquipMatlSerialNumberTPType.X'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.R_EquipMatlSerialNumberTPType))/EquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Category"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_equipmentcategorystdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-r_equipmatlserialnumbertp.createmassmaterialserialnumber.equipmentcategory.R_EquipMatlSerialNumberTPType.X'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.R_EquipMatlSerialNumberTPType))/UniqueItemIdentifierRespPlant">
+                <Annotation Term="SAP__common.Label" String="Responsible Plant UII"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_PLANT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.R_EquipMatlSerialNumberTPType))/EquipMaterialLastSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Last Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="Last num.SerialNo"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Last Numerical Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=LSERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.R_EquipMatlSerialNumberTPType))/EquipmentNumberOfSerialNumbers">
+                <Annotation Term="SAP__common.Label" String="Number of Serial Numbers"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="No. serial numbers"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Number of Serial Numbers/Pieces of Equipment to be Created"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=ANZSER"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.R_EquipMatlSerialNumberTPType))/EquipmentFromSerialNumber">
+                <Annotation Term="SAP__common.Label" String="From Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="From serial number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="From Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SERVON"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.R_EquipMatlSerialNumberTPType))/EquipmentToSerialNumber">
+                <Annotation Term="SAP__common.Label" String="To Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__core.OptionalParameter"/>
+                <Annotation Term="SAP__common.Heading" String="To serial number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="To Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=SERBIS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaterial(SAP__self.R_EquipMatlSerialNumberTPType)/Material">
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.ValueListForValidation" String=""/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_materialstdvh/0001;ps='srvd-eam_materialserialnumber-0001';va='com.sap.gateway.srvd.eam_materialserialnumber.v0001.ae-r_equipmatlserialnumbertp.changematerial.material.R_EquipMatlSerialNumberTPType'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__common.Heading" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaterial(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ChangeMaterial"/>
+            </Annotations>
+            <Annotations Target="SAP__self.SetSrlzdMaterialItemToDeletion(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/SetSrlzdMaterialItemToDeletion"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Edit(SAP__self.R_EquipMatlSerialNumberTPType)/PreserveChanges">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="TRUE"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Data element for domain BOOLE: TRUE (='X') and FALSE (=' ')"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Edit(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/Edit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ResetSrlzdMatlItmFrmDeletion(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ResetSrlzdMatlItmFrmDeletion"/>
+            </Annotations>
+            <Annotations Target="SAP__self.RsetSrlzdMatlItemFromInactive(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/RsetSrlzdMatlItemFromInactive"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.R_EquipMatlSerialNumberTPType)/Material">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Label" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.R_EquipMatlSerialNumberTPType)/SerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.R_EquipMatlSerialNumberTPType)/EquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Category"/>
+                <Annotation Term="SAP__common.FieldControl" EnumMember="SAP__common.FieldControlType/Mandatory"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="C"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment category"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQTYP"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.R_EquipMatlSerialNumberTPType)/UniqueItemIdentifierRespPlant">
+                <Annotation Term="SAP__common.Label" String="Responsible Plant UII"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Plant Responsible for UII"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=UII_PLANT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.R_EquipMatlSerialNumberTPType)/SrlzdMatlItmReferenceMaterial">
+                <Annotation Term="SAP__common.Label" String="Material Reference"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Material"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Material Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=MATNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.R_EquipMatlSerialNumberTPType)/SrlzdMatlItmRefSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number Reference"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.Heading" String="Serial Number"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.ActvtSrlzdMatlItmEquipmentData(SAP__self.R_EquipMatlSerialNumberTPType)">
+                <Annotation Term="SAP__core.OperationAvailable" Path="_it/__OperationControl/ActvtSrlzdMatlItmEquipmentData"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType">
+                <Annotation Term="SAP__common.Label" String="Material Serial Number - TP"/>
+                <Annotation Term="SAP__common.SAPObjectNodeType">
+                    <Record>
+                        <PropertyValue Property="Name" String="Equipment"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__ODM.entityName" String="Equipment"/>
+                <Annotation Term="SAP__common.Messages" Path="SAP__Messages"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container">
+                <Annotation Term="SAP__common.ApplyMultiUnitBehaviorForSortingAndFiltering" Bool="true"/>
+                <Annotation Term="SAP__capabilities.FilterFunctions">
+                    <Collection>
+                        <String>eq</String>
+                        <String>ne</String>
+                        <String>gt</String>
+                        <String>ge</String>
+                        <String>lt</String>
+                        <String>le</String>
+                        <String>and</String>
+                        <String>or</String>
+                        <String>contains</String>
+                        <String>startswith</String>
+                        <String>endswith</String>
+                        <String>any</String>
+                        <String>all</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SupportedFormats">
+                    <Collection>
+                        <String>application/json</String>
+                        <String>application/pdf</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__PDF.Features">
+                    <Record>
+                        <PropertyValue Property="DocumentDescriptionReference" String="../../../../default/iwbep/common/0001/$metadata"/>
+                        <PropertyValue Property="DocumentDescriptionCollection" String="MyDocumentDescriptions"/>
+                        <PropertyValue Property="ArchiveFormat" Bool="true"/>
+                        <PropertyValue Property="Border" Bool="true"/>
+                        <PropertyValue Property="CoverPage" Bool="true"/>
+                        <PropertyValue Property="FitToPage" Bool="true"/>
+                        <PropertyValue Property="FontName" Bool="true"/>
+                        <PropertyValue Property="FontSize" Bool="true"/>
+                        <PropertyValue Property="HeaderFooter" Bool="true"/>
+                        <PropertyValue Property="IANATimezoneFormat" Bool="true"/>
+                        <PropertyValue Property="Margin" Bool="true"/>
+                        <PropertyValue Property="Padding" Bool="true"/>
+                        <PropertyValue Property="ResultSizeDefault" Int="20000"/>
+                        <PropertyValue Property="ResultSizeMaximum" Int="20000"/>
+                        <PropertyValue Property="Signature" Bool="true"/>
+                        <PropertyValue Property="TextDirectionLayout" Bool="true"/>
+                        <PropertyValue Property="Treeview" Bool="true"/>
+                        <PropertyValue Property="UploadToFileShare" Bool="true"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.KeyAsSegmentSupported"/>
+                <Annotation Term="SAP__capabilities.AsynchronousRequestsSupported"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/_ActiveSystemStatus">
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/_EquipMatlSrlNmbrChgHistory">
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocObject">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Object value"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/ChangeDocTableKey">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Table Key"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Key of Modified Table Row"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/CreationDate">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Date"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Creation Date of Change Document"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=CDDATUM"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/CreationTime">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Time"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Time of Change"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/CharcDescription">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Characteristic Description"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/StatusName">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Status"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Individual Status of an Object"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_TXT30"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType/StatusIsInactive">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Status inactive"/>
+                <Annotation Term="SAP__common.Heading" String="I"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Indicator: Status Is Inactive"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_INACT"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftUUID">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft (Technical ID)"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/ProcessingStartDateTime">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft In Process Since"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftIsKeptByUser">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Is Kept By User"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/EnqueueStartDateTime">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Locked Since"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftIsCreatedByMe">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Created By Me"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftIsLastChangedByMe">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Last Changed By Me"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftIsProcessedByMe">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft In Process By Me"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/CreatedByUserDescription">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Created By (Description)"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/LastChangedByUserDescription">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft Last Changed By (Description)"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/InProcessByUserDescription">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Draft In Process By (Description)"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/EquipCatHasLinearAttributes">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Linear Asset"/>
+                <Annotation Term="SAP__common.Heading" String="Linear"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Indicator: Object Belongs to Linear Asset Management"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EAML_LFE_IND"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/EquipmentCategoryOID">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="Equi Cat Obj Inst ID"/>
+                <Annotation Term="SAP__common.Heading" String="Equipment Category Obj Instance ID"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Object Instance ID of Equipment Category"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipmentCategoryStdVHType/IsUtilitiesData">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation Term="SAP__common.Label" String="IS-U"/>
+                <Annotation Term="SAP__common.Heading" String="ISU"/>
+                <Annotation Term="SAP__common.QuickInfo" String="IS-U data"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=ISU_KNZ"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_StsObjActiveStatusCodeTextType/StatusName">
+                <Annotation Term="SAP__common.Label" String="Status"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Individual Status of an Object"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_TXT30"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_StsObjActiveStatusCodeTextType/StatusShortName">
+                <Annotation Term="SAP__common.Label" String="Status"/>
+                <Annotation Term="SAP__common.Heading" String="Stat"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Individual status of an object (short form)"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=J_TXT04"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/TechnicalObjectDescription">
+                <Annotation Term="SAP__common.Label" String="Object Description"/>
+                <Annotation Term="SAP__common.Heading" String="Description of technical object"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Description of technical object"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KTX01"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/CompanyCodeName">
+                <Annotation Term="SAP__common.Label" String="Company Name"/>
+                <Annotation Term="SAP__common.Heading" String="Name of Company"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Name of Company Code or Company"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__EntityControl/Updatable">
+                <Annotation Term="SAP__common.Label" String="Dyn. Method Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Method Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Method Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/ActvtSrlzdMatlItmEquipmentData">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/ChangeEquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/ChangeMaintenancePlant">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/ChangeMaterial">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/ChangeUniqueItemIdentifier">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/ChgSrlzdMatlItemSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/Edit">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/ResetSrlzdMatlItmFrmDeletion">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/RsetSrlzdMatlItemFromInactive">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/SetSrlzdMaterialItemToInactive">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/__OperationControl/SetSrlzdMaterialItemToDeletion">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_StorageLocationStdVHType/StorageLocationName">
+                <Annotation Term="SAP__common.Label" String="Storage Loc. Name"/>
+                <Annotation Term="SAP__common.Heading" String="Storage Location Name"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Storage Location Name"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_StorageLocationStdVHType/ConfignDeprecationCodeName">
+                <Annotation Term="SAP__common.Label" String="Validity Text"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Value Help: Flag Obsolete Entries"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_StorageLocationStdVHType/PlantName">
+                <Annotation Term="SAP__common.Label" String="Plant Name"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/HasEquipmentData">
+                <Annotation Term="SAP__common.Label" String="EquipmentData exists"/>
+                <Annotation Term="SAP__common.Heading" String="Equi. Data"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment data exists"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQUIP_KNZ"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/EquipmentHasStockInformation">
+                <Annotation Term="SAP__common.Label" String="Has Stock Information"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Indicator: Stock Information Available"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/CreationDate">
+                <Annotation Term="SAP__common.Label" String="Created On"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Record Creation Date"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/LastChangeDate">
+                <Annotation Term="SAP__common.Label" String="Changed On"/>
+                <Annotation Term="SAP__common.Heading" String="Chngd On"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Last Changed On"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/LastChangeDateTime">
+                <Annotation Term="SAP__common.Label" String="Short Time Stamp"/>
+                <Annotation Term="SAP__common.Heading" String="Short Form of Time Stamp"/>
+                <Annotation Term="SAP__common.QuickInfo" String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=TZNTSTMPS"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_EquipMatlSerialNumberType/MatlSrlNmbrLastGdsMvtDte">
+                <Annotation Term="SAP__common.Label" String="Date L.GoodsMvt"/>
+                <Annotation Term="SAP__common.Heading" String="Date of Last Goods Movemnt"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Date of Last Goods Movement"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=DATLWB"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/CreationDateTime">
+                <Annotation Term="SAP__common.Label" String="Draft Created On"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/LastChangeDateTime">
+                <Annotation Term="SAP__common.Label" String="Draft Last Changed On"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/HasEquipmentData">
+                <Annotation Term="SAP__common.Label" String="EquipmentData exists"/>
+                <Annotation Term="SAP__common.Heading" String="Equi. Data"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Equipment data exists"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=EQUIP_KNZ"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/MatlSrlNmbrLastGdsMvtDte">
+                <Annotation Term="SAP__common.Label" String="Date L.GoodsMvt"/>
+                <Annotation Term="SAP__common.Heading" String="Date of Last Goods Movemnt"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Date of Last Goods Movement"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=DATLWB"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/CompanyCodeName">
+                <Annotation Term="SAP__common.Label" String="Company Name"/>
+                <Annotation Term="SAP__common.Heading" String="Name of Company"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Name of Company Code or Company"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/EquipmentName">
+                <Annotation Term="SAP__common.Label" String="Object Description"/>
+                <Annotation Term="SAP__common.Heading" String="Description of technical object"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Description of technical object"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KTX01"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/TechnicalObjectDescription">
+                <Annotation Term="SAP__common.Label" String="Object Description"/>
+                <Annotation Term="SAP__common.Heading" String="Description of technical object"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Description of technical object"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=KTX01"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__EntityControl/Updatable">
+                <Annotation Term="SAP__common.Label" String="Dyn. Method Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Method Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Method Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/ActvtSrlzdMatlItmEquipmentData">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/ChangeEquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/ChangeMaintenancePlant">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/ChangeMaterial">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/ChangeUniqueItemIdentifier">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/ChgSrlzdMatlItemSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/Edit">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/ResetSrlzdMatlItmFrmDeletion">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/RsetSrlzdMatlItemFromInactive">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/SetSrlzdMaterialItemToInactive">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPType/__OperationControl/SetSrlzdMaterialItemToDeletion">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/ActvtSrlzdMatlItmEquipmentData">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/ChangeEquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/ChangeMaintenancePlant">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/ChangeMaterial">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/ChangeUniqueItemIdentifier">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/ChgSrlzdMatlItemSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/Edit">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/ResetSrlzdMatlItmFrmDeletion">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/RsetSrlzdMatlItemFromInactive">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/SetSrlzdMaterialItemToInactive">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPOperationControl/SetSrlzdMaterialItemToDeletion">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/ActvtSrlzdMatlItmEquipmentData">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/ChangeEquipmentCategory">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/ChangeMaintenancePlant">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/ChangeMaterial">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/ChangeUniqueItemIdentifier">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/ChgSrlzdMatlItemSerialNumber">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/Edit">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/ResetSrlzdMatlItmFrmDeletion">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/RsetSrlzdMatlItemFromInactive">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/SetSrlzdMaterialItemToInactive">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.R_EquipMatlSerialNumberTPOperationControl/SetSrlzdMaterialItemToDeletion">
+                <Annotation Term="SAP__common.Label" String="Dyn. Action Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Action Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Action Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.EntityControl/Updatable">
+                <Annotation Term="SAP__common.Label" String="Dyn. Method Control"/>
+                <Annotation Term="SAP__common.Heading" String="Dynamic Method Control"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Dynamic Method Property"/>
+            </Annotations>
+            <Annotations Target="SAP__self.SAP__VIRTUAL_CO_TY_3/_SerialList/SerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.SAP__VIRTUAL_CO_TY_8/_SerialList/SerialNumber">
+                <Annotation Term="SAP__common.Label" String="Serial Number"/>
+                <Annotation Term="SAP__common.DocumentationRef" String="urn:sap-com:documentation:key?=type=DE&amp;id=GERNR"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/_SerialList">
+                <Annotation Term="SAP__core.OptionalParameter"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.R_EquipMatlSerialNumberTPType))/_SerialList">
+                <Annotation Term="SAP__core.OptionalParameter"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.C_EquipMaterialSerialNumberTPType)/ResultIsActiveEntity">
+                <Annotation Term="SAP__common.Label" String="Result is active"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Draft - Indicator - Is active document"/>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem(SAP__self.R_EquipMatlSerialNumberTPType)/ResultIsActiveEntity">
+                <Annotation Term="SAP__common.Label" String="Result is active"/>
+                <Annotation Term="SAP__common.QuickInfo" String="Draft - Indicator - Is active document"/>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
When the action FQDN was defined on top of a Collection of items, the way we resolved the unspecific anntotation definition was incorrect and was missing some annotations