### PR TITLE
fix: support odata filter with tolower or toupper when mockdata contains null

### DIFF
--- a/.changeset/fuzzy-rocks-change.md
+++ b/.changeset/fuzzy-rocks-change.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+We now properly support filter with string values null

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -26,11 +26,11 @@ function makeTransformationFn(type: string, preparedArgs: PreparedFunction[]) {
 function transformationFn(type: string, check?: any) {
     switch (type) {
         case 'tolower':
-            return (data: string) => data.toLowerCase();
+            return (data: string) => data?.toLowerCase();
         case 'toupper':
-            return (data: string) => data.toUpperCase();
+            return (data: string) => data?.toUpperCase();
         case 'trim':
-            return (data: string) => data.trim();
+            return (data: string) => data?.trim();
         case 'length':
             return (data: string) => {
                 return data && data.length;
@@ -45,7 +45,7 @@ function transformationFn(type: string, check?: any) {
             return (data: string) => {
                 switch (check) {
                     case 'Edm.String':
-                        return data.toString();
+                        return data?.toString();
                     case 'Edm.Boolean':
                         return data === 'true';
                     case 'Edm.Byte':
@@ -64,19 +64,19 @@ function transformationFn(type: string, check?: any) {
             };
         case 'startswith':
             return (data: string) => {
-                return data.startsWith(prepareLiteral(check, 'Edm.String') as string);
+                return data?.startsWith(prepareLiteral(check, 'Edm.String') as string);
             };
         case 'endswith':
             return (data: string) => {
-                return data.endsWith(prepareLiteral(check, 'Edm.String') as string);
+                return data?.endsWith(prepareLiteral(check, 'Edm.String') as string);
             };
         case 'substringof':
             return (data: string) => {
-                return check.indexOf(prepareLiteral(data, 'Edm.String') as string) !== -1;
+                return check?.indexOf(prepareLiteral(data, 'Edm.String') as string) !== -1;
             };
         case 'contains':
             return (data: string) => {
-                return data.indexOf(prepareLiteral(check, 'Edm.String') as string) !== -1;
+                return data?.indexOf(prepareLiteral(check, 'Edm.String') as string) !== -1;
             };
         case 'concat':
             return (data: string) => {
@@ -84,11 +84,11 @@ function transformationFn(type: string, check?: any) {
             };
         case 'indexof':
             return (data: string) => {
-                return data.indexOf(prepareLiteral(check, 'Edm.String') as string);
+                return data?.indexOf(prepareLiteral(check, 'Edm.String') as string);
             };
         case 'substring':
             return (data: string) => {
-                return data.substring(check);
+                return data?.substring(check);
             };
         case 'matchesPattern':
             const regExp = new RegExp(prepareLiteral(check, 'Edm.String') as string);

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -143,7 +143,7 @@ describe('Data Access', () => {
         expect(countryData[0].Country_Code).toEqual('DE');
         countryData = await dataAccess.getData(
             new ODataRequest(
-                { method: 'GET', url: "/Countries?$filter=tolower(Country_Code) eq tolower('dE')" },
+                { method: 'GET', url: "/Countries?$filter=toupper(Country_Code) eq toupper('dE')" },
                 dataAccess
             )
         );

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -36,8 +36,8 @@ describe('Data Access', () => {
             dataAccess
         );
         let countryData = await dataAccess.getData(odataRequest);
-        expect(countryData.length).toEqual(6);
-        expect(odataRequest.dataCount).toEqual(6);
+        expect(countryData.length).toEqual(7);
+        expect(odataRequest.dataCount).toEqual(7);
         odataRequest = new ODataRequest(
             {
                 url: '/Countries?$skip=0&$top=3',
@@ -47,7 +47,7 @@ describe('Data Access', () => {
         );
         countryData = await dataAccess.getData(odataRequest);
         expect(countryData.length).toEqual(3);
-        expect(odataRequest.dataCount).toEqual(6);
+        expect(odataRequest.dataCount).toEqual(7);
         expect(countryData[0].Country_Code).toEqual('DE');
         expect(countryData[0].PeopleCount).toEqual(70);
         expect(countryData[0].SuperHeroCount).toEqual(7);
@@ -87,7 +87,7 @@ describe('Data Access', () => {
                 dataAccess
             )
         );
-        expect(countryData.length).toEqual(1);
+        expect(countryData.length).toEqual(2);
         expect(countryData[0].Country_Code).toEqual('DE');
 
         countryData = await dataAccess.getData(
@@ -96,7 +96,7 @@ describe('Data Access', () => {
                 dataAccess
             )
         );
-        expect(countryData.length).toEqual(0);
+        expect(countryData.length).toEqual(1);
 
         countryData = await dataAccess.getData(
             new ODataRequest(
@@ -104,7 +104,7 @@ describe('Data Access', () => {
                 dataAccess
             )
         );
-        expect(countryData.length).toEqual(1);
+        expect(countryData.length).toEqual(2);
         expect(countryData[0].Country_Code).toEqual('DE');
 
         countryData = await dataAccess.getData(
@@ -162,28 +162,31 @@ describe('Data Access', () => {
         countryData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/Countries?$orderby=PeopleCount,Country_Code' }, dataAccess)
         );
-        expect(countryData.length).toEqual(6);
-        expect(countryData[0].Country_Code).toEqual('LV');
-        expect(countryData[1].Country_Code).toEqual('IR');
-        expect(countryData[2].Country_Code).toEqual('FR');
-        expect(countryData[3].Country_Code).toEqual('DE');
-        expect(countryData[4].Country_Code).toEqual('US');
-        expect(countryData[5].Country_Code).toEqual('IN');
+        expect(countryData.length).toEqual(7);
+        expect(countryData[0].Country_Code).toEqual(null);
+        expect(countryData[1].Country_Code).toEqual('LV');
+        expect(countryData[2].Country_Code).toEqual('IR');
+        expect(countryData[3].Country_Code).toEqual('FR');
+        expect(countryData[4].Country_Code).toEqual('DE');
+        expect(countryData[5].Country_Code).toEqual('US');
+        expect(countryData[6].Country_Code).toEqual('IN');
         countryData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/Countries?$orderby=PeopleCount,Country_Code desc' }, dataAccess)
         );
-        expect(countryData.length).toEqual(6);
-        expect(countryData[0].Country_Code).toEqual('LV');
-        expect(countryData[1].Country_Code).toEqual('IR');
-        expect(countryData[2].Country_Code).toEqual('FR');
-        expect(countryData[3].Country_Code).toEqual('US');
-        expect(countryData[4].Country_Code).toEqual('DE');
-        expect(countryData[5].Country_Code).toEqual('IN');
+        expect(countryData.length).toEqual(7);
+        expect(countryData[0].Country_Code).toEqual(null);
+        expect(countryData[1].Country_Code).toEqual('LV');
+        expect(countryData[2].Country_Code).toEqual('IR');
+        expect(countryData[3].Country_Code).toEqual('FR');
+        expect(countryData[4].Country_Code).toEqual('US');
+        expect(countryData[5].Country_Code).toEqual('DE');
+        expect(countryData[6].Country_Code).toEqual('IN');
         countryData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/Countries?$orderby=PeopleCount desc,Country_Code' }, dataAccess)
         );
-        expect(countryData.length).toEqual(6);
-        expect(countryData[5].Country_Code).toEqual('LV');
+        expect(countryData.length).toEqual(7);
+        expect(countryData[6].Country_Code).toEqual('LV');
+        expect(countryData[5].Country_Code).toEqual(null);
         expect(countryData[4].Country_Code).toEqual('IR');
         expect(countryData[3].Country_Code).toEqual('FR');
         expect(countryData[2].Country_Code).toEqual('US');
@@ -421,7 +424,7 @@ describe('Data Access', () => {
 
     test('v4metadata - it can POST data for an entity', async () => {
         let countryData = await dataAccess.getData(new ODataRequest({ method: 'GET', url: '/Countries' }, dataAccess));
-        expect(countryData.length).toEqual(6);
+        expect(countryData.length).toEqual(7);
         countryData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/Countries?$filter=PeopleCount gt 750' }, dataAccess)
         );
@@ -458,12 +461,12 @@ describe('Data Access', () => {
         countryData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/Countries?$filter=PeopleCount lt 3' }, dataAccess)
         );
-        expect(countryData.length).toEqual(1);
+        expect(countryData.length).toEqual(2);
         // LE
         countryData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/Countries?$filter=PeopleCount le 3' }, dataAccess)
         );
-        expect(countryData.length).toEqual(2);
+        expect(countryData.length).toEqual(3);
         // EQ
         countryData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/Countries?$filter=PeopleCount eq 3' }, dataAccess)
@@ -473,7 +476,7 @@ describe('Data Access', () => {
         countryData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/Countries?$filter=PeopleCount ne 3' }, dataAccess)
         );
-        expect(countryData.length).toEqual(5);
+        expect(countryData.length).toEqual(6);
         // Boolean
         countryData = await dataAccess.getData(
             new ODataRequest({ method: 'GET', url: '/Countries?$filter=IsHot eq true' }, dataAccess)
@@ -494,7 +497,7 @@ describe('Data Access', () => {
                 dataAccess
             )
         );
-        expect(countryData.length).toEqual(3);
+        expect(countryData.length).toEqual(4);
     });
     test('v4 metadata with draft, POST', async () => {
         // Create Empty Element
@@ -1051,7 +1054,7 @@ describe('Data Access', () => {
         let odataRequest = new ODataRequest({ method: 'GET', url: '/Countries?$skip=0&$top=3' }, dataAccess);
         let countryData = await dataAccess.getData(odataRequest);
         expect(countryData.length).toEqual(3);
-        expect(odataRequest.dataCount).toEqual(6);
+        expect(odataRequest.dataCount).toEqual(7);
         expect(countryData[0].Country_Code).toEqual('DE');
         expect(countryData[0].PeopleCount).toEqual(70);
 

--- a/packages/fe-mockserver-core/test/unit/v4/services/formSample/Countries.json
+++ b/packages/fe-mockserver-core/test/unit/v4/services/formSample/Countries.json
@@ -46,5 +46,13 @@
         "SpokenLanguages": ["Lettish"],
         "MainLanguage": "Lettish",
         "IsHot": false
+    },
+    {
+        "Country_Code": null,
+        "Name": "Null",
+        "PeopleCount": 2,
+        "SpokenLanguages": ["Nullish"],
+        "MainLanguage": "Nullish",
+        "IsHot": false
     }
 ]


### PR DESCRIPTION
Current code expect all strings have values