### PR TITLE
fix: type mismatch

### DIFF
--- a/.changeset/angry-berries-cheer.md
+++ b/.changeset/angry-berries-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/vocabularies-types': patch
+---
+
+Export `ArrayWithType` type definition.

--- a/.changeset/many-lemons-cheat.md
+++ b/.changeset/many-lemons-cheat.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/annotation-converter': minor
+'@sap-ux/edmx-parser': minor
+---
+
+**BREAKING CHANGE**: parser and writeback no longer incorrectly convert string Collections entries as `string`. Now returned values correctly match the `StringExpression` type and function signatures.

--- a/packages/annotation-converter/src/writeback.ts
+++ b/packages/annotation-converter/src/writeback.ts
@@ -7,7 +7,8 @@ import type {
     PathExpression,
     PropertyPathExpression,
     RawAnnotation,
-    Reference
+    Reference,
+    StringExpression
 } from '@sap-ux/vocabularies-types';
 import { unalias } from './utils';
 
@@ -213,14 +214,17 @@ function revertCollectionItemToRawType(
     collectionItem: any
 ):
     | AnnotationRecord
-    | string
+    | StringExpression
     | PropertyPathExpression
     | PathExpression
     | NavigationPropertyPathExpression
     | AnnotationPathExpression
     | undefined {
     if (typeof collectionItem === 'string') {
-        return collectionItem;
+        return {
+            type: 'String',
+            String: collectionItem
+        };
     } else if (typeof collectionItem === 'object') {
         if (collectionItem.hasOwnProperty('$Type')) {
             // Annotation Record

--- a/packages/annotation-converter/test/__snapshots__/writeback.spec.ts.snap
+++ b/packages/annotation-converter/test/__snapshots__/writeback.spec.ts.snap
@@ -1890,7 +1890,10 @@ exports[`Writeback capabilities can revert further SideEffects definition 1`] = 
         "name": "TargetProperties",
         "value": {
           "Collection": [
-            "WarrantyYear",
+            {
+              "String": "WarrantyYear",
+              "type": "String",
+            },
           ],
           "type": "Collection",
         },

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -4,6 +4,7 @@ import type {
     AnnotationList,
     AnnotationPathExpression,
     AnnotationRecord,
+    ArrayWithType,
     Expression,
     FullyQualifiedName,
     NavigationPropertyPathExpression,
@@ -32,8 +33,7 @@ import type {
     RawV4NavigationProperty,
     Reference,
     ReferentialConstraint,
-    SimpleIdentifier,
-    ArrayWithType
+    SimpleIdentifier
 } from '@sap-ux/vocabularies-types';
 import type { StringExpression } from '@sap-ux/vocabularies-types/src';
 import { xml2js } from 'xml-js';
@@ -278,6 +278,12 @@ function parseNavigationProperties(
     );
 }
 
+/**
+ *
+ * @param associations
+ * @param namespace
+ * @param entityContainer
+ */
 function parseAssociationSets(
     associations: EDMX.AssociationSet[],
     namespace: string,
@@ -302,6 +308,11 @@ function parseAssociationSets(
     });
 }
 
+/**
+ *
+ * @param associations
+ * @param namespace
+ */
 function parseAssociations(associations: EDMX.Association[], namespace: string): RawAssociation[] {
     return associations.map((association) => {
         const associationFQN = `${namespace}.${association._attributes.Name}`;
@@ -326,6 +337,12 @@ function parseAssociations(associations: EDMX.Association[], namespace: string):
     });
 }
 
+/**
+ *
+ * @param entityTypes
+ * @param annotationLists
+ * @param namespace
+ */
 function parseEntityTypes(
     entityTypes: EDMX.EntityType[],
     annotationLists: AnnotationList[],
@@ -368,6 +385,12 @@ function parseEntityTypes(
     }, []);
 }
 
+/**
+ *
+ * @param complexTypes
+ * @param annotationLists
+ * @param namespace
+ */
 function parseComplexTypes(
     complexTypes: EDMX.ComplexType[],
     annotationLists: AnnotationList[],
@@ -398,6 +421,11 @@ function parseComplexTypes(
     }, []);
 }
 
+/**
+ *
+ * @param typeDefinitions
+ * @param namespace
+ */
 function parseTypeDefinitions(typeDefinitions: EDMX.TypeDefinition[], namespace: string): RawTypeDefinition[] {
     return typeDefinitions.reduce((outArray: RawTypeDefinition[], typeDefinition) => {
         const typeDefinitionFQN = `${namespace}.${typeDefinition._attributes.Name}`;
@@ -411,6 +439,13 @@ function parseTypeDefinitions(typeDefinitions: EDMX.TypeDefinition[], namespace:
     }, []);
 }
 
+/**
+ *
+ * @param entitySets
+ * @param namespace
+ * @param entityContainerName
+ * @param annotationLists
+ */
 function parseEntitySets(
     entitySets: EDMX.EntitySet[],
     namespace: string,
@@ -448,6 +483,13 @@ function parseEntitySets(
     return outEntitySets;
 }
 
+/**
+ *
+ * @param singletons
+ * @param namespace
+ * @param entityContainerName
+ * @param annotationLists
+ */
 function parseSingletons(
     singletons: EDMX.Singleton[],
     namespace: string,
@@ -486,6 +528,12 @@ function parseSingletons(
     return outSingletons;
 }
 
+/**
+ *
+ * @param actions
+ * @param namespace
+ * @param isFunction
+ */
 function parseActions(actions: (EDMX.Action | EDMX.Function)[], namespace: string, isFunction: boolean): RawAction[] {
     return actions.map((action) => {
         const parameters = ensureArray(action.Parameter);
@@ -542,6 +590,12 @@ function parseActions(actions: (EDMX.Action | EDMX.Function)[], namespace: strin
     });
 }
 
+/**
+ *
+ * @param actions
+ * @param entitySets
+ * @param namespace
+ */
 function parseV2FunctionImport(
     actions: EDMX.FunctionImportV2[],
     entitySets: RawEntitySet[],
@@ -574,6 +628,11 @@ function parseV2FunctionImport(
     });
 }
 
+/**
+ *
+ * @param imports
+ * @param namespace
+ */
 function parseActionImports(
     imports: (EDMX.FunctionImport | EDMX.ActionImport)[],
     namespace: string
@@ -592,6 +651,12 @@ function parseActionImports(
     });
 }
 
+/**
+ *
+ * @param propertyValues
+ * @param currentTarget
+ * @param annotationsLists
+ */
 function parsePropertyValues(
     propertyValues: EDMX.PropertyValue[],
     currentTarget: string,
@@ -632,6 +697,12 @@ function parsePropertyValues(
     });
 }
 
+/**
+ *
+ * @param record
+ * @param currentTarget
+ * @param annotationsLists
+ */
 function parseRecord(
     record: EDMX.RecordExpression,
     currentTarget: string,
@@ -659,6 +730,11 @@ function isExpressionOfType<K>(annotation: any, propertyNameToCheck: string): an
     return annotation[propertyNameToCheck] != null;
 }
 
+/**
+ *
+ * @param propertyPath
+ * @param modelPathType
+ */
 function parseModelPath(
     propertyPath: EDMX.ModelPath,
     modelPathType: 'AnnotationPath' | 'PropertyPath' | 'NavigationPropertyPath' | 'Path'
@@ -675,6 +751,12 @@ function parseModelPath(
     }
 }
 
+/**
+ *
+ * @param collection
+ * @param currentTarget
+ * @param annotationsLists
+ */
 function parseCollection(
     collection: EDMX.CollectionExpression,
     currentTarget: string,
@@ -738,6 +820,10 @@ function parseCollection(
     return [];
 }
 
+/**
+ *
+ * @param expressionWithChild
+ */
 function parseChildren(expressionWithChild: any): any {
     const keys = Object.keys(expressionWithChild).filter(
         (keyValue) => keyValue !== '_attributes' && keyValue !== 'Annotation'
@@ -757,6 +843,12 @@ function parseChildren(expressionWithChild: any): any {
     return outObj;
 }
 
+/**
+ *
+ * @param expression
+ * @param currentTarget
+ * @param annotationsLists
+ */
 function parseInlineExpression(
     expression: EDMX.InlineExpression,
     currentTarget: string,
@@ -912,6 +1004,13 @@ function parseExpression(
     annotationsLists: AnnotationList[],
     simplifyPrimitive: true
 ): Expression | PrimitiveType;
+/**
+ *
+ * @param expression
+ * @param currentTarget
+ * @param annotationsLists
+ * @param simplifyPrimitive
+ */
 function parseExpression(
     expression: EDMX.Expression<{}>,
     currentTarget: string,
@@ -1080,6 +1179,12 @@ function parseExpression(
     }
 }
 
+/**
+ *
+ * @param annotation
+ * @param currentTarget
+ * @param annotationsLists
+ */
 function parseAnnotation(
     annotation: EDMX.Annotation,
     currentTarget: string,
@@ -1126,6 +1231,12 @@ function parseAnnotation(
     return outAnnotation as RawAnnotation;
 }
 
+/**
+ *
+ * @param annotations
+ * @param currentTarget
+ * @param annotationsLists
+ */
 function parseAnnotations(
     annotations: EDMX.Annotation[],
     currentTarget: string,
@@ -1134,6 +1245,11 @@ function parseAnnotations(
     return annotations.map((annotation) => parseAnnotation(annotation, currentTarget, annotationsLists));
 }
 
+/**
+ *
+ * @param target
+ * @param annotations
+ */
 function createAnnotationList(target: string, annotations: RawAnnotation[]): AnnotationList {
     return {
         target: target,
@@ -1162,6 +1278,12 @@ function parseAnnotationLists(annotationLists: EDMX.AnnotationList[], annotation
         });
 }
 
+/**
+ *
+ * @param edmSchema
+ * @param edmVersion
+ * @param identification
+ */
 function parseSchema(edmSchema: EDMX.Schema, edmVersion: string, identification: string): RawSchema {
     const namespace = edmSchema._attributes.Namespace;
     const annotations: AnnotationList[] = [];
@@ -1256,6 +1378,10 @@ function parseSchema(edmSchema: EDMX.Schema, edmVersion: string, identification:
     };
 }
 
+/**
+ *
+ * @param references
+ */
 function parseReferences(references: EDMX.Reference[]): Reference[] {
     return references.reduce((referencesArray: Reference[], reference: EDMX.Reference) => {
         const includes = ensureArray(reference['edmx:Include']);
@@ -1272,6 +1398,10 @@ function parseReferences(references: EDMX.Reference[]): Reference[] {
 
 let aliases: Record<string, string> = {};
 
+/**
+ *
+ * @param type
+ */
 function unaliasType(type: string) {
     const collection = type.match(collectionRegexp);
     const _type = collection ? collection[1] : type;
@@ -1284,6 +1414,10 @@ function unaliasType(type: string) {
 
 function unalias(aliasedValue: string): string;
 function unalias(aliasedValue: undefined): undefined;
+/**
+ *
+ * @param aliasedValue
+ */
 function unalias(aliasedValue: string | undefined): string | undefined {
     if (!aliasedValue) {
         return aliasedValue;
@@ -1311,6 +1445,10 @@ function unalias(aliasedValue: string | undefined): string | undefined {
     return unaliased.join('');
 }
 
+/**
+ *
+ * @param schemas
+ */
 function mergeSchemas(schemas: RawSchema[]): RawSchema {
     const associations = schemas.reduce((associationsToReduce: RawAssociation[], schema) => {
         return associationsToReduce.concat(schema.associations);
@@ -1407,6 +1545,11 @@ function mergeSchemas(schemas: RawSchema[]): RawSchema {
     };
 }
 
+/**
+ *
+ * @param references
+ * @param schemas
+ */
 function createAliasMap(references: Reference[], schemas: EDMX.Schema[]) {
     aliases = references.reduce((map, reference) => {
         map[reference.alias] = reference.namespace;

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -278,12 +278,6 @@ function parseNavigationProperties(
     );
 }
 
-/**
- *
- * @param associations
- * @param namespace
- * @param entityContainer
- */
 function parseAssociationSets(
     associations: EDMX.AssociationSet[],
     namespace: string,
@@ -308,11 +302,6 @@ function parseAssociationSets(
     });
 }
 
-/**
- *
- * @param associations
- * @param namespace
- */
 function parseAssociations(associations: EDMX.Association[], namespace: string): RawAssociation[] {
     return associations.map((association) => {
         const associationFQN = `${namespace}.${association._attributes.Name}`;
@@ -337,12 +326,6 @@ function parseAssociations(associations: EDMX.Association[], namespace: string):
     });
 }
 
-/**
- *
- * @param entityTypes
- * @param annotationLists
- * @param namespace
- */
 function parseEntityTypes(
     entityTypes: EDMX.EntityType[],
     annotationLists: AnnotationList[],
@@ -385,12 +368,6 @@ function parseEntityTypes(
     }, []);
 }
 
-/**
- *
- * @param complexTypes
- * @param annotationLists
- * @param namespace
- */
 function parseComplexTypes(
     complexTypes: EDMX.ComplexType[],
     annotationLists: AnnotationList[],
@@ -421,11 +398,6 @@ function parseComplexTypes(
     }, []);
 }
 
-/**
- *
- * @param typeDefinitions
- * @param namespace
- */
 function parseTypeDefinitions(typeDefinitions: EDMX.TypeDefinition[], namespace: string): RawTypeDefinition[] {
     return typeDefinitions.reduce((outArray: RawTypeDefinition[], typeDefinition) => {
         const typeDefinitionFQN = `${namespace}.${typeDefinition._attributes.Name}`;
@@ -439,13 +411,6 @@ function parseTypeDefinitions(typeDefinitions: EDMX.TypeDefinition[], namespace:
     }, []);
 }
 
-/**
- *
- * @param entitySets
- * @param namespace
- * @param entityContainerName
- * @param annotationLists
- */
 function parseEntitySets(
     entitySets: EDMX.EntitySet[],
     namespace: string,
@@ -483,13 +448,6 @@ function parseEntitySets(
     return outEntitySets;
 }
 
-/**
- *
- * @param singletons
- * @param namespace
- * @param entityContainerName
- * @param annotationLists
- */
 function parseSingletons(
     singletons: EDMX.Singleton[],
     namespace: string,
@@ -528,12 +486,6 @@ function parseSingletons(
     return outSingletons;
 }
 
-/**
- *
- * @param actions
- * @param namespace
- * @param isFunction
- */
 function parseActions(actions: (EDMX.Action | EDMX.Function)[], namespace: string, isFunction: boolean): RawAction[] {
     return actions.map((action) => {
         const parameters = ensureArray(action.Parameter);
@@ -590,12 +542,6 @@ function parseActions(actions: (EDMX.Action | EDMX.Function)[], namespace: strin
     });
 }
 
-/**
- *
- * @param actions
- * @param entitySets
- * @param namespace
- */
 function parseV2FunctionImport(
     actions: EDMX.FunctionImportV2[],
     entitySets: RawEntitySet[],
@@ -628,11 +574,6 @@ function parseV2FunctionImport(
     });
 }
 
-/**
- *
- * @param imports
- * @param namespace
- */
 function parseActionImports(
     imports: (EDMX.FunctionImport | EDMX.ActionImport)[],
     namespace: string
@@ -651,12 +592,6 @@ function parseActionImports(
     });
 }
 
-/**
- *
- * @param propertyValues
- * @param currentTarget
- * @param annotationsLists
- */
 function parsePropertyValues(
     propertyValues: EDMX.PropertyValue[],
     currentTarget: string,
@@ -697,12 +632,6 @@ function parsePropertyValues(
     });
 }
 
-/**
- *
- * @param record
- * @param currentTarget
- * @param annotationsLists
- */
 function parseRecord(
     record: EDMX.RecordExpression,
     currentTarget: string,
@@ -730,11 +659,6 @@ function isExpressionOfType<K>(annotation: any, propertyNameToCheck: string): an
     return annotation[propertyNameToCheck] != null;
 }
 
-/**
- *
- * @param propertyPath
- * @param modelPathType
- */
 function parseModelPath(
     propertyPath: EDMX.ModelPath,
     modelPathType: 'AnnotationPath' | 'PropertyPath' | 'NavigationPropertyPath' | 'Path'
@@ -751,12 +675,6 @@ function parseModelPath(
     }
 }
 
-/**
- *
- * @param collection
- * @param currentTarget
- * @param annotationsLists
- */
 function parseCollection(
     collection: EDMX.CollectionExpression,
     currentTarget: string,
@@ -820,10 +738,6 @@ function parseCollection(
     return [];
 }
 
-/**
- *
- * @param expressionWithChild
- */
 function parseChildren(expressionWithChild: any): any {
     const keys = Object.keys(expressionWithChild).filter(
         (keyValue) => keyValue !== '_attributes' && keyValue !== 'Annotation'
@@ -843,12 +757,6 @@ function parseChildren(expressionWithChild: any): any {
     return outObj;
 }
 
-/**
- *
- * @param expression
- * @param currentTarget
- * @param annotationsLists
- */
 function parseInlineExpression(
     expression: EDMX.InlineExpression,
     currentTarget: string,
@@ -1004,13 +912,6 @@ function parseExpression(
     annotationsLists: AnnotationList[],
     simplifyPrimitive: true
 ): Expression | PrimitiveType;
-/**
- *
- * @param expression
- * @param currentTarget
- * @param annotationsLists
- * @param simplifyPrimitive
- */
 function parseExpression(
     expression: EDMX.Expression<{}>,
     currentTarget: string,
@@ -1179,12 +1080,6 @@ function parseExpression(
     }
 }
 
-/**
- *
- * @param annotation
- * @param currentTarget
- * @param annotationsLists
- */
 function parseAnnotation(
     annotation: EDMX.Annotation,
     currentTarget: string,
@@ -1231,12 +1126,6 @@ function parseAnnotation(
     return outAnnotation as RawAnnotation;
 }
 
-/**
- *
- * @param annotations
- * @param currentTarget
- * @param annotationsLists
- */
 function parseAnnotations(
     annotations: EDMX.Annotation[],
     currentTarget: string,
@@ -1245,11 +1134,6 @@ function parseAnnotations(
     return annotations.map((annotation) => parseAnnotation(annotation, currentTarget, annotationsLists));
 }
 
-/**
- *
- * @param target
- * @param annotations
- */
 function createAnnotationList(target: string, annotations: RawAnnotation[]): AnnotationList {
     return {
         target: target,
@@ -1278,12 +1162,6 @@ function parseAnnotationLists(annotationLists: EDMX.AnnotationList[], annotation
         });
 }
 
-/**
- *
- * @param edmSchema
- * @param edmVersion
- * @param identification
- */
 function parseSchema(edmSchema: EDMX.Schema, edmVersion: string, identification: string): RawSchema {
     const namespace = edmSchema._attributes.Namespace;
     const annotations: AnnotationList[] = [];
@@ -1378,10 +1256,6 @@ function parseSchema(edmSchema: EDMX.Schema, edmVersion: string, identification:
     };
 }
 
-/**
- *
- * @param references
- */
 function parseReferences(references: EDMX.Reference[]): Reference[] {
     return references.reduce((referencesArray: Reference[], reference: EDMX.Reference) => {
         const includes = ensureArray(reference['edmx:Include']);
@@ -1398,10 +1272,6 @@ function parseReferences(references: EDMX.Reference[]): Reference[] {
 
 let aliases: Record<string, string> = {};
 
-/**
- *
- * @param type
- */
 function unaliasType(type: string) {
     const collection = type.match(collectionRegexp);
     const _type = collection ? collection[1] : type;
@@ -1414,10 +1284,6 @@ function unaliasType(type: string) {
 
 function unalias(aliasedValue: string): string;
 function unalias(aliasedValue: undefined): undefined;
-/**
- *
- * @param aliasedValue
- */
 function unalias(aliasedValue: string | undefined): string | undefined {
     if (!aliasedValue) {
         return aliasedValue;
@@ -1445,10 +1311,6 @@ function unalias(aliasedValue: string | undefined): string | undefined {
     return unaliased.join('');
 }
 
-/**
- *
- * @param schemas
- */
 function mergeSchemas(schemas: RawSchema[]): RawSchema {
     const associations = schemas.reduce((associationsToReduce: RawAssociation[], schema) => {
         return associationsToReduce.concat(schema.associations);
@@ -1545,11 +1407,6 @@ function mergeSchemas(schemas: RawSchema[]): RawSchema {
     };
 }
 
-/**
- *
- * @param references
- * @param schemas
- */
 function createAliasMap(references: Reference[], schemas: EDMX.Schema[]) {
     aliases = references.reduce((map, reference) => {
         map[reference.alias] = reference.namespace;

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -32,7 +32,8 @@ import type {
     RawV4NavigationProperty,
     Reference,
     ReferentialConstraint,
-    SimpleIdentifier
+    SimpleIdentifier,
+    ArrayWithType
 } from '@sap-ux/vocabularies-types';
 import type { StringExpression } from '@sap-ux/vocabularies-types/src';
 import { xml2js } from 'xml-js';
@@ -705,9 +706,14 @@ function parseCollection(
         (navPropertyPathArray as any).type = 'NavigationPropertyPath';
         return navPropertyPathArray;
     } else if (isExpressionOfType<EDMX.StringCollectionWrapper>(collection, 'String')) {
-        const stringArray = ensureArray(collection.String).map((stringValue) => stringValue._text);
-        (stringArray as any).type = 'String';
-        return stringArray as unknown as StringExpression[];
+        const stringArray: ArrayWithType<StringExpression, 'String'> = ensureArray(collection.String).map(
+            (stringValue): StringExpression => ({
+                type: 'String',
+                String: stringValue._text
+            })
+        );
+        stringArray.type = 'String';
+        return stringArray;
     } else if (isExpressionOfType<EDMX.AnnotationPathCollectionWrapper>(collection, 'AnnotationPath')) {
         const annotationPathArray = ensureArray(collection.AnnotationPath).map(
             (annotationPath) => parseModelPath(annotationPath, 'AnnotationPath') as AnnotationPathExpression

--- a/packages/edmx-parser/src/utils.ts
+++ b/packages/edmx-parser/src/utils.ts
@@ -65,10 +65,16 @@ export class RawMetadataInstance implements RawMetadata {
  *
  */
 export class MergedRawMetadata implements RawMetadataInstance {
+    /**
+     *
+     */
     get references(): Reference[] {
         return this._references;
     }
 
+    /**
+     *
+     */
     get schema(): RawSchema {
         return {
             associations: this._associations,

--- a/packages/edmx-parser/src/utils.ts
+++ b/packages/edmx-parser/src/utils.ts
@@ -65,16 +65,10 @@ export class RawMetadataInstance implements RawMetadata {
  *
  */
 export class MergedRawMetadata implements RawMetadataInstance {
-    /**
-     *
-     */
     get references(): Reference[] {
         return this._references;
     }
 
-    /**
-     *
-     */
     get schema(): RawSchema {
         return {
             associations: this._associations,

--- a/packages/edmx-parser/test/__snapshots__/parser.spec.ts.snap
+++ b/packages/edmx-parser/test/__snapshots__/parser.spec.ts.snap
@@ -13425,7 +13425,10 @@ RawMetadataInstance {
             },
             {
               "collection": [
-                "SEPMRA_PROD_MAN.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_Product",
+                {
+                  "String": "SEPMRA_PROD_MAN.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_Product",
+                  "type": "String",
+                },
               ],
               "qualifier": undefined,
               "term": "com.sap.vocabularies.Common.v1.DraftActivationVia",
@@ -13566,7 +13569,10 @@ RawMetadataInstance {
             },
             {
               "collection": [
-                "SEPMRA_PROD_MAN.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_Product",
+                {
+                  "String": "SEPMRA_PROD_MAN.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_Product",
+                  "type": "String",
+                },
               ],
               "qualifier": undefined,
               "term": "com.sap.vocabularies.Common.v1.DraftActivationVia",
@@ -28808,7 +28814,10 @@ RawMetadataInstance {
             },
             {
               "collection": [
-                "SEPMRA_PROD_MAN.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_Product",
+                {
+                  "String": "SEPMRA_PROD_MAN.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_Product",
+                  "type": "String",
+                },
               ],
               "qualifier": undefined,
               "term": "com.sap.vocabularies.Common.v1.DraftActivationVia",
@@ -28843,7 +28852,10 @@ RawMetadataInstance {
             },
             {
               "collection": [
-                "SEPMRA_PROD_MAN.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_Product",
+                {
+                  "String": "SEPMRA_PROD_MAN.SEPMRA_PROD_MAN_Entities/SEPMRA_C_PD_Product",
+                  "type": "String",
+                },
               ],
               "qualifier": undefined,
               "term": "com.sap.vocabularies.Common.v1.DraftActivationVia",
@@ -35603,7 +35615,10 @@ RawMetadataInstance {
           "annotations": [
             {
               "collection": [
-                undefined,
+                {
+                  "String": undefined,
+                  "type": "String",
+                },
               ],
               "qualifier": undefined,
               "term": "com.sap.vocabularies.Common.v1.ValueListRelevantQualifiers",
@@ -111901,9 +111916,18 @@ RawMetadataInstance {
                     "name": "Transformations",
                     "value": {
                       "Collection": [
-                        "aggregate",
-                        "groupby",
-                        "filter",
+                        {
+                          "String": "aggregate",
+                          "type": "String",
+                        },
+                        {
+                          "String": "groupby",
+                          "type": "String",
+                        },
+                        {
+                          "String": "filter",
+                          "type": "String",
+                        },
                       ],
                       "type": "Collection",
                     },

--- a/packages/vocabularies-types/src/BaseEdm.ts
+++ b/packages/vocabularies-types/src/BaseEdm.ts
@@ -6,7 +6,7 @@ type GenericExpression<K extends keyof any, T> = {
 } & {
     type: K;
 };
-type ArrayWithType<T, K> = T[] & { type?: K };
+export type ArrayWithType<T, K> = T[] & { type?: K };
 
 export type Apply = any;
 export type If = any;


### PR DESCRIPTION
Types for collection string values did not match the implementation. Type definitions use `StringExpression`, but in parser and wrtieback implementation plain string values were used.