### PR TITLE
fix(mockserver): service paths with asterisks

### DIFF
--- a/.changeset/chilled-starfishes-teach.md
+++ b/.changeset/chilled-starfishes-teach.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+fix: gracefully handle service paths with asterisks

--- a/packages/fe-mockserver-core/src/middleware.ts
+++ b/packages/fe-mockserver-core/src/middleware.ts
@@ -135,13 +135,13 @@ export async function createMockMiddleware(
             if (mockService.contextBasedIsolation || newConfig.contextBasedIsolation) {
                 const subRouter = new Router();
                 try {
-                    subRouter.use(`${mockService.urlPath}`, oDataHandlerInstance);
+                    subRouter.use(mockService.urlPath, oDataHandlerInstance);
                 } catch {
                     // Can happen if the URL contains asterisks. As the encoded path is registered below, this might not
                     // be a problem since clients usually call the encoded path.
                     log.error(`Could not register service path: ${mockService.urlPath}`);
                 }
-                subRouter.use(`${encode(mockService.urlPath)}`, oDataHandlerInstance);
+                subRouter.use(encode(mockService.urlPath), oDataHandlerInstance);
                 app.use(/^\/tenant-(\d{1,3})/, subRouter);
             }
             if (mockService.debug) {
@@ -149,13 +149,13 @@ export async function createMockMiddleware(
                 log.info(`Service path: ${mockService.urlPath}`);
             }
             try {
-                app.use(`${mockService.urlPath}`, oDataHandlerInstance);
+                app.use(mockService.urlPath, oDataHandlerInstance);
             } catch {
                 // Can happen if the URL contains asterisks. As the encoded path is registered below, this might not
                 // be a problem since clients usually call the encoded path.
                 log.error(`Could not register path: ${mockService.urlPath}`);
             }
-            app.use(`${encode(mockService.urlPath)}`, oDataHandlerInstance);
+            app.use(encode(mockService.urlPath), oDataHandlerInstance);
         } catch (e) {
             log.error(e as any);
             throw new Error('Failed to start ' + JSON.stringify(mockService, null, 4));

--- a/packages/fe-mockserver-core/src/middleware.ts
+++ b/packages/fe-mockserver-core/src/middleware.ts
@@ -23,14 +23,15 @@ function escapeRegex(strValue: string) {
 }
 
 /**
- * Encore single quote as string element so that they cna be matched as well.
+ * Encode single quotes and asterisks in the string.
  *
- * @param str
+ * @param str the string to encode
  * @returns the encoded string
  */
 function encode(str: string) {
-    return str.replace(/'/g, '%27');
+    return str.replaceAll("'", '%27').replaceAll('*', '%2A');
 }
+
 async function loadMetadata(service: ServiceConfigEx, metadataProcessor: IMetadataProcessor) {
     const edmx = await metadataProcessor.loadMetadata(service.metadataPath);
     if (!service.noETag) {
@@ -133,7 +134,13 @@ export async function createMockMiddleware(
             const oDataHandlerInstance = await serviceRouter(mockService, dataAccess);
             if (mockService.contextBasedIsolation || newConfig.contextBasedIsolation) {
                 const subRouter = new Router();
-                subRouter.use(`${mockService.urlPath}`, oDataHandlerInstance);
+                try {
+                    subRouter.use(`${mockService.urlPath}`, oDataHandlerInstance);
+                } catch {
+                    // Can happen if the URL contains asterisks. As the encoded path is registered below, this might not
+                    // be a problem since clients usually call the encoded path.
+                    log.error(`Could not register service path: ${mockService.urlPath}`);
+                }
                 subRouter.use(`${encode(mockService.urlPath)}`, oDataHandlerInstance);
                 app.use(/^\/tenant-(\d{1,3})/, subRouter);
             }
@@ -141,7 +148,13 @@ export async function createMockMiddleware(
                 log.info(`Mockdata location: ${mockService.mockdataPath}`);
                 log.info(`Service path: ${mockService.urlPath}`);
             }
-            app.use(`${mockService.urlPath}`, oDataHandlerInstance);
+            try {
+                app.use(`${mockService.urlPath}`, oDataHandlerInstance);
+            } catch {
+                // Can happen if the URL contains asterisks. As the encoded path is registered below, this might not
+                // be a problem since clients usually call the encoded path.
+                log.error(`Could not register path: ${mockService.urlPath}`);
+            }
             app.use(`${encode(mockService.urlPath)}`, oDataHandlerInstance);
         } catch (e) {
             log.error(e as any);


### PR DESCRIPTION
Services exposed using RAP can include elements in an ABAP namespace, such as `/DMO/UI_TRAVEL_D_D`. Such a pattern results in service paths with `/` replaced by `*` (`/DMO/UI_TRAVEL_D_D` &rarr; `*dmo*ui_travel_d_d`). This causes issues when mocking such a RAP service without manually adjusting URLs.

The router package (or rather "path-to-regexp") treats asterisks as special elements in the path pattern, which causes route setup to fail.

This change works around this issue by only registering the unencoded path if it can be done successfully, and otherwise only using the encoded version (`%2Admo%2Aui_travel_d_d` in this example). As clients usually call the encoded version, this should still work.