### PR TITLE
fix: properly identify entityset for parametrized queries

### DIFF
--- a/.changeset/gentle-cherries-exist.md
+++ b/.changeset/gentle-cherries-exist.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+We now properly identify the entityset in case of parametrized query in v2

--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -674,7 +674,12 @@ export class DataAccess implements DataAccessInterface {
                                 // Fake containment for result set
                                 targetContainedEntityType = navPropDetail.targetType;
                                 targetContainedData = innerData[queryPathPart.path];
-                                currentEntitySet = undefined;
+                                if (this.metadata.getVersion() === '2.0') {
+                                    // In V2 there might be a target entityset as containment doesn't exist
+                                    currentEntitySet = currentEntitySet?.navigationPropertyBinding[navPropDetail.name];
+                                } else {
+                                    currentEntitySet = undefined;
+                                }
                                 currentEntityType = targetContainedEntityType;
                                 if (hasOnlyDraftKeyOrNoKeys) {
                                     currentKeys = {};


### PR DESCRIPTION
In V2, there should be an entityset behind everything navigation, as such we can try and resolve it :()