### PR TITLE
fix: we now properly deal with draft in case of complex cross navigation

### DIFF
--- a/.changeset/neat-forks-beg.md
+++ b/.changeset/neat-forks-beg.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+We now properly deal with draft in case of complex cross navigation

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -844,6 +844,140 @@ describe('Data Access', () => {
         expect(formData[0].FirstName).toEqual('Mark');
         expect(formData[0]._Elements.length).toEqual(1);
     });
+
+    test('v4 cross draft scenarios', async () => {
+        // Create Empty Element
+        const formElement = await dataAccess.createData(
+            new ODataRequest({ method: 'GET', url: '/FormRoot', tenantId: 'other' }, dataAccess),
+            {
+                ID: 2,
+                FirstName: 'Bob'
+            }
+        );
+        expect(formElement).toBeDefined;
+        expect(formElement.IsActiveEntity).toEqual(false);
+        expect(formElement.HasActiveEntity).toEqual(false);
+        expect(formElement.HasDraftEntity).toEqual(false);
+
+        expect(formElement.ID).toEqual(2);
+        let subElement = await dataAccess.createData(
+            new ODataRequest(
+                { method: 'GET', url: '/FormRoot(ID=2,IsActiveEntity=false)/_Elements', tenantId: 'other' },
+                dataAccess
+            ),
+            {
+                Name: 'Child'
+            }
+        );
+        expect(subElement).toBeDefined;
+        const otherElement = await dataAccess.createData(
+            new ODataRequest(
+                { method: 'GET', url: '/FormRoot(ID=2,IsActiveEntity=false)/_OtherChild', tenantId: 'other' },
+                dataAccess
+            ),
+            {
+                Name: 'OtherChild'
+            }
+        );
+        subElement = await dataAccess.createData(
+            new ODataRequest(
+                {
+                    method: 'GET',
+                    url: '/FormRoot(ID=2,IsActiveEntity=false)/_OtherChild(ID=1,IsActiveEntity=false)/SpecialOne',
+                    tenantId: 'other'
+                },
+                dataAccess
+            ),
+            {
+                Name: 'My Favorite'
+            }
+        );
+        // Activate it
+        let actionResult = await dataAccess.performAction(
+            new ODataRequest(
+                {
+                    method: 'GET',
+                    url: '/FormRoot(ID=2,IsActiveEntity=false)/sap.fe.core.Form.draftActivate',
+                    tenantId: 'other'
+                },
+                dataAccess
+            )
+        );
+        expect(actionResult).toBeDefined;
+        expect(actionResult.DraftAdministrativeData).toBeNull();
+        let formData = await dataAccess.getData(
+            new ODataRequest({ method: 'GET', url: '/FormRoot', tenantId: 'other' }, dataAccess)
+        );
+        expect(formData.length).toEqual(1);
+
+        formData = await dataAccess.getData(
+            new ODataRequest(
+                { method: 'GET', url: '/FormRoot?$expand=_Elements,_OtherChild', tenantId: 'other' },
+                dataAccess
+            )
+        );
+        expect(formData.length).toEqual(1);
+        expect(formData[0]._Elements.length).toEqual(1);
+        expect(formData[0]._OtherChild.length).toEqual(1);
+        actionResult = await dataAccess.performAction(
+            new ODataRequest(
+                {
+                    method: 'GET',
+                    url: '/FormRoot(ID=2,IsActiveEntity=true)/sap.fe.core.Form.draftEdit',
+                    tenantId: 'other'
+                },
+                dataAccess
+            )
+        );
+        subElement = await dataAccess.updateData(
+            new ODataRequest(
+                { method: 'PATCH', url: '/SubElements(ID=1,IsActiveEntity=false)', tenantId: 'other' },
+                dataAccess
+            ),
+            {
+                Name: 'Child2'
+            }
+        );
+        subElement = await dataAccess.updateData(
+            new ODataRequest(
+                { method: 'PATCH', url: '/OtherElements(ID=1,IsActiveEntity=false)', tenantId: 'other' },
+                dataAccess
+            ),
+            {
+                Name: 'OtherChild2'
+            }
+        );
+        subElement = await dataAccess.updateData(
+            new ODataRequest(
+                { method: 'PATCH', url: '/OtherElements(ID=1,IsActiveEntity=false)/SpecialOne', tenantId: 'other' },
+                dataAccess
+            ),
+            {
+                Name: 'Not My Favorite anymore'
+            }
+        );
+
+        actionResult = await dataAccess.performAction(
+            new ODataRequest(
+                {
+                    method: 'GET',
+                    url: '/FormRoot(ID=2,IsActiveEntity=false)/sap.fe.core.Form.draftActivate',
+                    tenantId: 'other'
+                },
+                dataAccess
+            )
+        );
+        formData = await dataAccess.getData(
+            new ODataRequest(
+                { method: 'GET', url: '/FormRoot?$expand=_Elements,_OtherChild', tenantId: 'other' },
+                dataAccess
+            )
+        );
+        expect(formData.length).toEqual(1);
+        expect(formData[0]._Elements.length).toEqual(1);
+        expect(formData[0]._OtherChild.length).toEqual(1);
+    });
+
     test('v4metadata - generator', async () => {
         let part3Data = await dataAccess.getData(new ODataRequest({ method: 'GET', url: '/Part3' }, dataAccess));
         expect(part3Data.length).toEqual(150);

--- a/packages/fe-mockserver-core/test/unit/v4/services/formSample/FormTemplate.cds
+++ b/packages/fe-mockserver-core/test/unit/v4/services/formSample/FormTemplate.cds
@@ -12,8 +12,10 @@ entity FormRoot {
         LastName     : String  @Common.Label :                                'Last Name';
         DateOfBirth  : Date    @Common.Label :                                'Date of Birth';
         EmailAddress : String  @Communication.IsEmailAddress  @Common.Label : 'Email Address';
-        _Elements    :Association to many SubElements
+        _Elements    :Composition of many SubElements
                                   on _Elements.owner = $self;
+        _OtherChild  : Composition of many OtherElements
+                                    on _OtherChild.owner = $self;
         SpecialOne: Composition of one SubElements;
         Currency     : Currency;
         Country      : String  @(Common : {
@@ -36,12 +38,24 @@ entity FormRoot {
         });
 };
 
+entity OtherElements           @(cds.autoexpose) {
+    key ID       : Integer   @Core.Computed;
+        Name     : String(20)@(Common : {Label : 'Name'});
+        owner_ID : Integer;
+        sibling_ID : Integer;
+        SpecialOne: Composition of one SubElements;
+        subElementsibling : Association to SubElements on subElementsibling.owner_ID = owner_ID;
+        owner    : Association to FormRoot
+                       on owner.ID = owner_ID;
+}
+
 entity SubElements           @(cds.autoexpose) {
     key ID       : Integer   @Core.Computed;
         Name     : String(20)@(Common : {Label : 'Name'});
         owner_ID : Integer;
         sibling_ID : Integer;
         sibling : Association to SubElements on sibling.ID = sibling_ID;
+        otherElementSiblings : Association to OtherElements on otherElementSiblings.owner_ID = owner_ID;
         owner    : Association to FormRoot
                        on owner.ID = owner_ID;
 }


### PR DESCRIPTION
Currently, the logic for activate has a tendency to discard part of the draft when the object and the relationship becomes a bit too complicated.