### PR TITLE
handle odata v4 minor versions - fix "Unsupported EDMX version:" message 

### DIFF
--- a/.changeset/brave-rules-compete.md
+++ b/.changeset/brave-rules-compete.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/edmx-parser": patch
+---
+
+handle odata v4 minor versions - fix "Unsupported EDMX version:" message 

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -1160,7 +1160,7 @@ describe('Annotation Converter', () => {
         const convertedTypes = convert({
             identification: '',
             references: [{ alias: 'MyAlias', namespace: 'MyNamespace', uri: 'MyUri' }],
-            version: '4.0',
+            version: '4.1',
             schema: {
                 namespace: '',
                 actions: [],

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -1160,7 +1160,7 @@ describe('Annotation Converter', () => {
         const convertedTypes = convert({
             identification: '',
             references: [{ alias: 'MyAlias', namespace: 'MyNamespace', uri: 'MyUri' }],
-            version: '4.1',
+            version: '4.0',
             schema: {
                 namespace: '',
                 actions: [],

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -1211,7 +1211,8 @@ function parseSchema(edmSchema: EDMX.Schema, edmVersion: string, identification:
                     entityContainer.fullyQualifiedName
                 )
             );
-        } else if (edmVersion === '4.0') {
+            // major version 4
+        } else if (edmVersion?.startsWith('4.')) {
             // FunctionImports
             actionImports = actionImports.concat(
                 parseActionImports(
@@ -1231,7 +1232,8 @@ function parseSchema(edmSchema: EDMX.Schema, edmVersion: string, identification:
             throw new Error(`Unsupported EDMX version: ${edmVersion}`);
         }
     }
-    if (edmVersion === '4.0') {
+    // major version 4
+    if (edmVersion.startsWith('4.')) {
         actions = actions.concat(parseActions(ensureArray(edmSchema.Action), namespace, false));
         actions = actions.concat(parseActions(ensureArray(edmSchema.Function), namespace, true));
     }

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -1212,7 +1212,7 @@ function parseSchema(edmSchema: EDMX.Schema, edmVersion: string, identification:
                 )
             );
             // major version 4
-        } else if (edmVersion?.startsWith('4.')) {
+        } else if (edmVersion.startsWith('4.')) {
             // FunctionImports
             actionImports = actionImports.concat(
                 parseActionImports(

--- a/packages/edmx-parser/test/fixtures/v4/action-parameters_4.01.xml
+++ b/packages/edmx-parser/test/fixtures/v4/action-parameters_4.01.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.01" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="Entity1" EntityType="TestService.Entity1"/>
+        <EntitySet Name="Entity2" EntityType="TestService.Entity2"/>
+        <ActionImport Name="action" Action="TestService.action"/>
+        <FunctionImport Name="function" Function="TestService.function"/>
+      </EntityContainer>
+      <EntityType Name="Entity1">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="Entity2">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <Action Name="action" IsBound="true">
+        <Parameter Name="in" Type="TestService.Entity1"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+      </Action>
+      <Action Name="action" IsBound="true">
+        <Parameter Name="in" Type="TestService.Entity2"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+      </Action>
+      <Action Name="action" IsBound="false">
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+      </Action>
+      <Function Name="function" IsBound="true" IsComposable="false">
+        <Parameter Name="in" Type="TestService.Entity1"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Function>
+      <Function Name="function" IsBound="true" IsComposable="false">
+        <Parameter Name="in" Type="TestService.Entity2"/>
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Function>
+      <Function Name="function" IsBound="false" IsComposable="false">
+        <Parameter Name="param1" Type="Edm.String"/>
+        <Parameter Name="param2" Type="Edm.String"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Function>
+      <Annotations Target="TestService.action(TestService.Entity1)/param1">
+        <Annotation Term="Common.Label" String="[specific bound overload] Entity1/action/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.function(TestService.Entity1,Edm.String,Edm.String)/param1">
+        <Annotation Term="Common.Label" String="[specific bound overload] Entity1/function/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.function(Edm.String,Edm.String)/param1">
+        <Annotation Term="Common.Label" String="[specific unbound overload] function/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.action()/param1">
+        <Annotation Term="Common.Label" String="[specific unbound overload] action/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.action/param1">
+        <Annotation Term="Common.Label" String="[unspecific] action/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.action/param2">
+        <Annotation Term="Common.Label" String="[unspecific] action/param2"/>
+      </Annotations>
+      <Annotations Target="TestService.function/param1">
+        <Annotation Term="Common.Label" String="[unspecific] function/param1"/>
+      </Annotations>
+      <Annotations Target="TestService.function/param2">
+        <Annotation Term="Common.Label" String="[unspecific] function/param2"/>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/edmx-parser/test/parser.spec.ts
+++ b/packages/edmx-parser/test/parser.spec.ts
@@ -125,6 +125,23 @@ describe('Parser', function () {
         `);
     });
 
+    it('creates the correct fully-qualified names for functions and actions - odata version 4.01', async () => {
+        const xmlFile = await loadFixture('v4/action-parameters_4.01.xml');
+        const schema = parse(xmlFile);
+
+        const fqns = schema.schema.actions.map((action) => action.fullyQualifiedName);
+        expect(fqns).toMatchInlineSnapshot(`
+            [
+              "TestService.action(TestService.Entity1)",
+              "TestService.action(TestService.Entity2)",
+              "TestService.action()",
+              "TestService.function(TestService.Entity1,Edm.String,Edm.String)",
+              "TestService.function(TestService.Entity2,Edm.String,Edm.String)",
+              "TestService.function(Edm.String,Edm.String)",
+            ]
+        `);
+    });
+
     it('can parse an EDMX file with if / eq / ...', async () => {
         const xmlFile = await loadFixture('v4/edmJson.metadata.xml');
         const schema: RawMetadata = parse(xmlFile);


### PR DESCRIPTION
handle odata v4 minor versions - 
fix "Unsupported EDMX version:" message which blocks using a service using odata 4.01 in the fiori generator. 

