### PR TITLE
fix: action with similar name are now properly identified

### DIFF
--- a/.changeset/famous-hotels-hang.md
+++ b/.changeset/famous-hotels-hang.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-converter': patch
+---
+
+We fixed an issue with action name resolution in case of conflicting names

--- a/packages/annotation-converter/src/converter.ts
+++ b/packages/annotation-converter/src/converter.ts
@@ -1380,7 +1380,8 @@ function convertActionImport(converter: Converter, rawActionImport: RawActionImp
 
     lazy(convertedActionImport, 'action', () => {
         const rawActions = converter.rawSchema.actions.filter(
-            (rawAction) => !rawAction.isBound && rawAction.fullyQualifiedName.startsWith(rawActionImport.actionName)
+            (rawAction) =>
+                !rawAction.isBound && rawAction.fullyQualifiedName.startsWith(rawActionImport.actionName + '(')
         );
 
         // this always resolves to a unique unbound action, but resolution of unbound functions can be ambiguous:

--- a/packages/annotation-converter/test/converterTest.spec.ts
+++ b/packages/annotation-converter/test/converterTest.spec.ts
@@ -983,7 +983,7 @@ describe('Annotation Converter', () => {
         expect(dataFields1[3].ActionTarget).toBe(getAction('TestService.function()'));
         expect(dataFields1[4].ActionTarget).toBe(getAction('TestService.action(TestService.Entity1)'));
         expect(dataFields1[5].ActionTarget).toBe(undefined);
-        expect(dataFields1[6].ActionTarget).toBe(getAction('TestService.action2(TestService.Entity2)'));
+        expect(dataFields1[6].ActionTarget).toBe(undefined);
         expect(dataFields1[7].ActionTarget).toBe(getAction('TestService.action()'));
         expect(dataFields1[8].ActionTarget).toBe(getAction('TestService.function()'));
 

--- a/packages/annotation-converter/test/fixtures/v4/actions-and-functions-overload.cds
+++ b/packages/annotation-converter/test/fixtures/v4/actions-and-functions-overload.cds
@@ -3,6 +3,7 @@ service TestService {
         key ID : String;
     } actions {
         action   action();
+        action   action2();
         function function() returns Integer;
     }
 
@@ -10,10 +11,12 @@ service TestService {
         key ID : String;
     } actions {
         action   action();
+        action   action2();
         function function() returns Integer;
     }
 
     action   action();
+    action   action2();
     function function() returns Integer;
 }
 

--- a/packages/annotation-converter/test/fixtures/v4/actions-and-functions-overload.xml
+++ b/packages/annotation-converter/test/fixtures/v4/actions-and-functions-overload.xml
@@ -14,6 +14,7 @@
       <EntityContainer Name="EntityContainer">
         <EntitySet Name="Entity1" EntityType="TestService.Entity1"/>
         <EntitySet Name="Entity2" EntityType="TestService.Entity2"/>
+        <ActionImport Name="action2" Action="TestService.action2"/>
         <ActionImport Name="action" Action="TestService.action"/>
         <FunctionImport Name="function" Function="TestService.function"/>
       </EntityContainer>
@@ -35,12 +36,19 @@
       <Action Name="action" IsBound="true">
         <Parameter Name="in" Type="TestService.Entity2"/>
       </Action>
+      <Action Name="action2" IsBound="true">
+        <Parameter Name="in" Type="TestService.Entity1"/>
+      </Action>
+      <Action Name="action2" IsBound="true">
+        <Parameter Name="in" Type="TestService.Entity2"/>
+      </Action>
       <Action Name="actionFrom1" IsBound="true">
         <Parameter Name="in" Type="TestService.Entity1"/>
       </Action>
       <Action Name="action2" IsBound="true">
         <Parameter Name="in" Type="TestService.Entity2"/>
       </Action>
+      <Action Name="action2" IsBound="false"/>
       <Action Name="action" IsBound="false"/>
       <Function Name="function" IsBound="true" IsComposable="false">
         <Parameter Name="in" Type="TestService.Entity1"/>
@@ -82,11 +90,11 @@
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Bound action of the incorrect entity type indirect reference"/>
-              <PropertyValue Property="Action" String="TestService.action2"/>
+              <PropertyValue Property="Action" String="TestService.action3"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Bound action of the incorrect entity type (explicit reference)"/>
-              <PropertyValue Property="Action" String="TestService.action2(TestService.Entity2)"/>
+              <PropertyValue Property="Action" String="TestService.action3(TestService.Entity2)"/>
             </Record>
             <Record Type="UI.DataFieldForAction">
               <PropertyValue Property="Label" String="Unbound action with simple name"/>


### PR DESCRIPTION
The current code was performing a startsWIith and was subject to issue when action shared the same starting name