### PR TITLE
fix: ignore trailing text content during expression parsing

### DIFF
--- a/.changeset/strange-jeans-argue.md
+++ b/.changeset/strange-jeans-argue.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/edmx-parser': patch
+---
+
+Ignore trailing text content during parsing of expressions

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -919,7 +919,7 @@ function parseExpression(
     simplifyPrimitive: boolean
 ): Expression | PrimitiveType {
     const expressionKeys = Object.keys(expression);
-    if (expressionKeys.length > 1) {
+    if (expressionKeys.filter((value) => value !== '_text').length > 1) {
         throw new Error(`Too many expressions defined on a single object ${JSON.stringify(expression)}`);
     }
     const expressionKey = expressionKeys[0];

--- a/packages/edmx-parser/test/__snapshots__/parser.spec.ts.snap
+++ b/packages/edmx-parser/test/__snapshots__/parser.spec.ts.snap
@@ -46066,6 +46066,2943 @@ RawMetadataInstance {
 }
 `;
 
+exports[`Parser can parse an EDMX with comments inside 1`] = `
+RawMetadataInstance {
+  "identification": "serviceFile",
+  "references": [
+    {
+      "alias": "Common",
+      "namespace": "com.sap.vocabularies.Common.v1",
+      "uri": "https://sap.github.io/odata-vocabularies/vocabularies/Common.xml",
+    },
+    {
+      "alias": "UI",
+      "namespace": "com.sap.vocabularies.UI.v1",
+      "uri": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml",
+    },
+    {
+      "alias": "SAP__self",
+      "namespace": "com.sap.gateway.srvd.eam_materialserialnumber.v0001",
+      "uri": "/sap/opu/odata4/sap/eam_sb_materialserialnumber/srvd/sap/eam_materialserialnumber/0001/$metadata",
+    },
+    {
+      "alias": "SAP__UI",
+      "namespace": "com.sap.vocabularies.UI.v1",
+      "uri": "/sap/opu/odata4/sap/eam_sb_materialserialnumber/srvd/sap/eam_materialserialnumber/0001/$metadata",
+    },
+  ],
+  "schema": {
+    "actionImports": [],
+    "actions": [],
+    "annotations": {
+      "serviceFile": [
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Hidden",
+              "value": {
+                "Bool": true,
+                "type": "Bool",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_MaterialSerialNumberVHType/UniqueItemIdentifier",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Hidden",
+              "value": {
+                "Bool": true,
+                "type": "Bool",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifier",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Hidden",
+              "value": {
+                "Bool": true,
+                "type": "Bool",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifierStrucType",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Hidden",
+              "value": {
+                "Bool": true,
+                "type": "Bool",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifierRespPlant",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Hidden",
+              "value": {
+                "Bool": true,
+                "type": "Bool",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType/ConcatenatedActiveUserStsName",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.FieldControl",
+              "value": {
+                "EnumMember": "Common.FieldControlType/ReadOnly",
+                "type": "EnumMember",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber(Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType))/EquipMaterialLastSerialNumber",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": "LastChangeDateTimeChanged",
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_EquipMatlSrlNmbrChgHistoryTP",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType/SetSrlzdMaterialItemToInactive",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": "MaterialLinks",
+              "term": "com.sap.vocabularies.Common.v1.SemanticObject",
+              "value": {
+                "String": "Material",
+                "type": "String",
+              },
+            },
+            {
+              "collection": [
+                {
+                  "String": "displayInAssetViewer",
+                  "type": "String",
+                },
+                {
+                  "String": "displayBreakdownAnalysis",
+                  "type": "String",
+                },
+                {
+                  "String": "displayDamageAnalysis",
+                  "type": "String",
+                },
+                {
+                  "String": "postprocessDataTransfer",
+                  "type": "String",
+                },
+                {
+                  "String": "transferDataFromEquipment",
+                  "type": "String",
+                },
+                {
+                  "String": "transferDataFromFunctionalLoc",
+                  "type": "String",
+                },
+                {
+                  "String": "analyzeInventoryTurnover",
+                  "type": "String",
+                },
+                {
+                  "String": "analyzeInventoryKPIsTimeseries",
+                  "type": "String",
+                },
+                {
+                  "String": "analyzeStockinDateRange",
+                  "type": "String",
+                },
+                {
+                  "String": "displayDeadStock",
+                  "type": "String",
+                },
+                {
+                  "String": "displayMaterialDocuments",
+                  "type": "String",
+                },
+                {
+                  "String": "displayOverdueGRBlockedStock",
+                  "type": "String",
+                },
+                {
+                  "String": "displayOverdueStockInTransit",
+                  "type": "String",
+                },
+                {
+                  "String": "displaySerialNumberInfo",
+                  "type": "String",
+                },
+                {
+                  "String": "displaySerStockInfo",
+                  "type": "String",
+                },
+                {
+                  "String": "displaySlowOrNonMoving",
+                  "type": "String",
+                },
+                {
+                  "String": "displayStockForPostingDate",
+                  "type": "String",
+                },
+                {
+                  "String": "displayStockInTransitInWebGUI",
+                  "type": "String",
+                },
+                {
+                  "String": "displayStockMultipleMaterials",
+                  "type": "String",
+                },
+                {
+                  "String": "displayStockOverview",
+                  "type": "String",
+                },
+                {
+                  "String": "displayStockOverviewInWebGUI",
+                  "type": "String",
+                },
+                {
+                  "String": "displayWarehouseStockInWebGUI",
+                  "type": "String",
+                },
+                {
+                  "String": "manageBySubcontractingSupplier",
+                  "type": "String",
+                },
+                {
+                  "String": "postGoodsIssueInWebGUI",
+                  "type": "String",
+                },
+                {
+                  "String": "postGoodsMovementInWebGUI",
+                  "type": "String",
+                },
+                {
+                  "String": "postGoodsReceiptInWebGUI",
+                  "type": "String",
+                },
+                {
+                  "String": "postTransferPostingInWebGUI",
+                  "type": "String",
+                },
+                {
+                  "String": "transferStock",
+                  "type": "String",
+                },
+                {
+                  "String": "transferStockCrossPlant",
+                  "type": "String",
+                },
+                {
+                  "String": "change",
+                  "type": "String",
+                },
+                {
+                  "String": "create",
+                  "type": "String",
+                },
+                {
+                  "String": "displayEquipment",
+                  "type": "String",
+                },
+                {
+                  "String": "display",
+                  "type": "String",
+                },
+                {
+                  "String": "displayFactSheet",
+                  "type": "String",
+                },
+                {
+                  "String": "createMatlSerialNumber",
+                  "type": "String",
+                },
+                {
+                  "String": "createMultipleMatlSerialNumber",
+                  "type": "String",
+                },
+                {
+                  "String": "displayComplianceInfo",
+                  "type": "String",
+                },
+                {
+                  "String": "activatePlannedChanges",
+                  "type": "String",
+                },
+                {
+                  "String": "maintainCyCIndicator",
+                  "type": "String",
+                },
+              ],
+              "qualifier": "MaterialLinks",
+              "term": "com.sap.vocabularies.Common.v1.SemanticObjectUnavailableActions",
+            },
+            {
+              "collection": [
+                {
+                  "propertyValues": [
+                    {
+                      "name": "LocalProperty",
+                      "value": {
+                        "PropertyPath": "TechnicalObject",
+                        "type": "PropertyPath",
+                      },
+                    },
+                    {
+                      "name": "SemanticObjectProperty",
+                      "value": {
+                        "String": "Equipment",
+                        "type": "String",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.Common.v1.SemanticObjectMappingType",
+                },
+              ],
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.SemanticObjectMapping",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType/Material",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Hidden",
+              "value": {
+                "$If": [
+                  {
+                    "$Eq": [
+                      {
+                        "Path": "HasEquipmentData",
+                        "type": "Path",
+                      },
+                      false,
+                    ],
+                    "type": "Eq",
+                  },
+                  true,
+                  false,
+                ],
+                "type": "If",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType/EquipmentName",
+        },
+        {
+          "annotations": [
+            {
+              "collection": [
+                {
+                  "String": "displayInAssetViewer",
+                  "type": "String",
+                },
+                {
+                  "String": "changeMatlSerialNumber",
+                  "type": "String",
+                },
+                {
+                  "String": "createMatlSerialNumber",
+                  "type": "String",
+                },
+                {
+                  "String": "createMultipleMatlSerialNumber",
+                  "type": "String",
+                },
+                {
+                  "String": "displayMatlSerialNumberList",
+                  "type": "String",
+                },
+                {
+                  "String": "displayMatlSerialNumber",
+                  "type": "String",
+                },
+                {
+                  "String": "displayBreakdownAnalysis",
+                  "type": "String",
+                },
+                {
+                  "String": "displayDamageAnalysis",
+                  "type": "String",
+                },
+                {
+                  "String": "postprocessDataTransfer",
+                  "type": "String",
+                },
+                {
+                  "String": "transferDataFromEquipment",
+                  "type": "String",
+                },
+                {
+                  "String": "transferDataFromFunctionalLoc",
+                  "type": "String",
+                },
+                {
+                  "String": "displayFactSheet",
+                  "type": "String",
+                },
+                {
+                  "String": "createMatlSerialNumber",
+                  "type": "String",
+                },
+                {
+                  "String": "createMultipleMatlSerialNumber",
+                  "type": "String",
+                },
+              ],
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.SemanticObjectUnavailableActions",
+            },
+            {
+              "collection": [
+                {
+                  "propertyValues": [
+                    {
+                      "name": "LocalProperty",
+                      "value": {
+                        "PropertyPath": "TechObjIsEquipOrFuncnlLoc",
+                        "type": "PropertyPath",
+                      },
+                    },
+                    {
+                      "name": "SemanticObjectProperty",
+                      "value": {
+                        "String": "TechObjIsEquipOrFuncnlLoc",
+                        "type": "String",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.Common.v1.SemanticObjectMappingType",
+                },
+              ],
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.SemanticObjectMapping",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType/TechnicalObject",
+        },
+        {
+          "annotations": [
+            {
+              "collection": [
+                {
+                  "PropertyPath": "Material",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "SerialNumber",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "Equipment",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "ConcatenatedActiveSystStsName",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "InventoryStockType",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "EquipmentCategory",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "Plant",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "MaterialSerialNumberStockBatch",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "StorageLocation",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "Customer",
+                  "type": "PropertyPath",
+                },
+                {
+                  "PropertyPath": "HasEquipmentData",
+                  "type": "PropertyPath",
+                },
+              ],
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.SelectionFields",
+            },
+            {
+              "collection": [
+                {
+                  "annotations": [
+                    {
+                      "qualifier": undefined,
+                      "term": "com.sap.vocabularies.UI.v1.Hidden",
+                      "value": {
+                        "$If": [
+                          {
+                            "$Or": [
+                              {
+                                "$And": [
+                                  {
+                                    "$Eq": [
+                                      {
+                                        "Path": "HasActiveEntity",
+                                        "type": "Path",
+                                      },
+                                      false,
+                                    ],
+                                    "type": "Eq",
+                                  },
+                                  {
+                                    "$Eq": [
+                                      {
+                                        "Path": "IsActiveEntity",
+                                        "type": "Path",
+                                      },
+                                      true,
+                                    ],
+                                    "type": "Eq",
+                                  },
+                                ],
+                                "type": "And",
+                              },
+                              {
+                                "$And": [
+                                  {
+                                    "$Eq": [
+                                      {
+                                        "Path": "HasActiveEntity",
+                                        "type": "Path",
+                                      },
+                                      true,
+                                    ],
+                                    "type": "Eq",
+                                  },
+                                  {
+                                    "$Eq": [
+                                      {
+                                        "Path": "IsActiveEntity",
+                                        "type": "Path",
+                                      },
+                                      false,
+                                    ],
+                                    "type": "Eq",
+                                  },
+                                ],
+                                "type": "And",
+                              },
+                            ],
+                            "type": "Or",
+                          },
+                          false,
+                          true,
+                        ],
+                        "type": "If",
+                      },
+                    },
+                  ],
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>serialNumberHistory}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "SemanticObject",
+                      "value": {
+                        "String": "Material",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Action",
+                      "value": {
+                        "String": "displaySerHistoryInfo",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "RequiresContext",
+                      "value": {
+                        "Bool": false,
+                        "type": "Bool",
+                      },
+                    },
+                    {
+                      "name": "NavigationAvailable",
+                      "value": {
+                        "Bool": true,
+                        "type": "Bool",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataFieldForIntentBasedNavigation",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>activateEquipmentView}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Action",
+                      "value": {
+                        "String": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ActvtSrlzdMatlItmEquipmentData(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "InvocationGrouping",
+                      "value": {
+                        "EnumMember": "SAP__UI.OperationGroupingType/Isolated",
+                        "type": "EnumMember",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>changeEquipmentCategory}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Action",
+                      "value": {
+                        "String": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeEquipmentCategory(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "InvocationGrouping",
+                      "value": {
+                        "EnumMember": "SAP__UI.OperationGroupingType/Isolated",
+                        "type": "EnumMember",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>changePlant}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Action",
+                      "value": {
+                        "String": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeMaintenancePlant(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "InvocationGrouping",
+                      "value": {
+                        "EnumMember": "SAP__UI.OperationGroupingType/Isolated",
+                        "type": "EnumMember",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                },
+                {
+                  "annotations": [
+                    {
+                      "qualifier": undefined,
+                      "term": "com.sap.vocabularies.UI.v1.Hidden",
+                      "value": {
+                        "$If": [
+                          {
+                            "$Eq": [
+                              {
+                                "Path": "IsCloudSystem",
+                                "type": "Path",
+                              },
+                              true,
+                            ],
+                            "type": "Eq",
+                          },
+                          true,
+                          false,
+                        ],
+                        "type": "If",
+                      },
+                    },
+                  ],
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>changeUII}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Action",
+                      "value": {
+                        "String": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeUniqueItemIdentifier(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "InvocationGrouping",
+                      "value": {
+                        "EnumMember": "SAP__UI.OperationGroupingType/Isolated",
+                        "type": "EnumMember",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>setMaterialItemInactive}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Action",
+                      "value": {
+                        "String": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "InvocationGrouping",
+                      "value": {
+                        "EnumMember": "SAP__UI.OperationGroupingType/Isolated",
+                        "type": "EnumMember",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>resetMaterialItemInactive}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Action",
+                      "value": {
+                        "String": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.RsetSrlzdMatlItemFromInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "InvocationGrouping",
+                      "value": {
+                        "EnumMember": "SAP__UI.OperationGroupingType/Isolated",
+                        "type": "EnumMember",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>setMaterialItemDeletion}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Action",
+                      "value": {
+                        "String": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "InvocationGrouping",
+                      "value": {
+                        "EnumMember": "SAP__UI.OperationGroupingType/Isolated",
+                        "type": "EnumMember",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>resetMaterialItemDeletion}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Action",
+                      "value": {
+                        "String": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ResetSrlzdMatlItmFrmDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "InvocationGrouping",
+                      "value": {
+                        "EnumMember": "SAP__UI.OperationGroupingType/Isolated",
+                        "type": "EnumMember",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataFieldForAction",
+                },
+              ],
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Identification",
+            },
+            {
+              "qualifier": "SalesOrder",
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "Data",
+                    "value": {
+                      "Record": {
+                        "propertyValues": [
+                          {
+                            "name": "SalesOrder",
+                            "value": {
+                              "Record": {
+                                "propertyValues": [
+                                  {
+                                    "name": "Value",
+                                    "value": {
+                                      "Path": "SalesOrder",
+                                      "type": "Path",
+                                    },
+                                  },
+                                ],
+                                "type": "com.sap.vocabularies.UI.v1.DataField",
+                              },
+                              "type": "Record",
+                            },
+                          },
+                          {
+                            "name": "SalesOrderItem",
+                            "value": {
+                              "Record": {
+                                "propertyValues": [
+                                  {
+                                    "name": "Value",
+                                    "value": {
+                                      "Path": "SalesOrderItem",
+                                      "type": "Path",
+                                    },
+                                  },
+                                ],
+                                "type": "com.sap.vocabularies.UI.v1.DataField",
+                              },
+                              "type": "Record",
+                            },
+                          },
+                        ],
+                        "type": undefined,
+                      },
+                      "type": "Record",
+                    },
+                  },
+                  {
+                    "name": "Label",
+                    "value": {
+                      "String": "{@i18n>salesOrder} / {@i18n>salesOrderItem}",
+                      "type": "String",
+                    },
+                  },
+                  {
+                    "name": "Template",
+                    "value": {
+                      "String": "{SalesOrder} / {SalesOrderItem}",
+                      "type": "String",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.UI.v1.ConnectedFields",
+            },
+            {
+              "collection": [
+                {
+                  "propertyValues": [
+                    {
+                      "name": "ID",
+                      "value": {
+                        "String": "General",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Target",
+                      "value": {
+                        "AnnotationPath": "@UI.FieldGroup#HeaderFacetMain",
+                        "type": "AnnotationPath",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                },
+              ],
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.HeaderFacets",
+            },
+            {
+              "qualifier": "HeaderFacetMain",
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "Data",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "EquipmentCategory",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "SerialNumber",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "UniqueItemIdentifierRespPlant",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "UniqueItemIdentifier",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "UniqueItemIdentifierStrucType",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "ConcatenatedActiveSystStsName",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.FieldGroupType",
+              },
+              "term": "com.sap.vocabularies.UI.v1.FieldGroup",
+            },
+            {
+              "collection": [
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>serialNumberData}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "ID",
+                      "value": {
+                        "String": "SerialNumberData",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Facets",
+                      "value": {
+                        "Collection": [
+                          {
+                            "propertyValues": [
+                              {
+                                "name": "Label",
+                                "value": {
+                                  "String": "{@i18n>general}",
+                                  "type": "String",
+                                },
+                              },
+                              {
+                                "name": "ID",
+                                "value": {
+                                  "String": "General",
+                                  "type": "String",
+                                },
+                              },
+                              {
+                                "name": "Target",
+                                "value": {
+                                  "AnnotationPath": "@UI.FieldGroup#General",
+                                  "type": "AnnotationPath",
+                                },
+                              },
+                            ],
+                            "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                          },
+                          {
+                            "propertyValues": [
+                              {
+                                "name": "Label",
+                                "value": {
+                                  "String": "{@i18n>stockInformation}",
+                                  "type": "String",
+                                },
+                              },
+                              {
+                                "name": "ID",
+                                "value": {
+                                  "String": "StockInformation",
+                                  "type": "String",
+                                },
+                              },
+                              {
+                                "name": "Target",
+                                "value": {
+                                  "AnnotationPath": "@UI.FieldGroup#StockInformation",
+                                  "type": "AnnotationPath",
+                                },
+                              },
+                            ],
+                            "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                          },
+                        ],
+                        "type": "Collection",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.CollectionFacet",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>PartnersTable}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "ID",
+                      "value": {
+                        "String": "Partners",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Facets",
+                      "value": {
+                        "type": "Unknown",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.CollectionFacet",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>WarrantySection}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "ID",
+                      "value": {
+                        "String": "WarrantySection",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Facets",
+                      "value": {
+                        "Collection": [
+                          {
+                            "propertyValues": [
+                              {
+                                "name": "ID",
+                                "value": {
+                                  "String": "WarrantyTable",
+                                  "type": "String",
+                                },
+                              },
+                              {
+                                "name": "Target",
+                                "value": {
+                                  "AnnotationPath": "_Warranty/@SAP__UI.LineItem#WarrantyTable",
+                                  "type": "AnnotationPath",
+                                },
+                              },
+                            ],
+                            "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                          },
+                        ],
+                        "type": "Collection",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.CollectionFacet",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Label",
+                      "value": {
+                        "String": "{@i18n>history}",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "ID",
+                      "value": {
+                        "String": "History",
+                        "type": "String",
+                      },
+                    },
+                    {
+                      "name": "Facets",
+                      "value": {
+                        "Collection": [
+                          {
+                            "propertyValues": [
+                              {
+                                "name": "ID",
+                                "value": {
+                                  "String": "History1",
+                                  "type": "String",
+                                },
+                              },
+                              {
+                                "name": "Target",
+                                "value": {
+                                  "AnnotationPath": "_EquipMatlSrlNmbrChgHistory/@SAP__UI.LineItem#History",
+                                  "type": "AnnotationPath",
+                                },
+                              },
+                            ],
+                            "type": "com.sap.vocabularies.UI.v1.ReferenceFacet",
+                          },
+                        ],
+                        "type": "Collection",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.CollectionFacet",
+                },
+              ],
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Facets",
+            },
+            {
+              "qualifier": "General",
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "Data",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "TechnicalObject",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "EquipMaterialLastSerialNumber",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "EquipmentName",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.FieldGroupType",
+              },
+              "term": "com.sap.vocabularies.UI.v1.FieldGroup",
+            },
+            {
+              "qualifier": "StockInformation",
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "Data",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "InventoryStockType",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "Plant",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "CompanyCode",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "StorageLocation",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "MatlSrlNmbrLastGdsMvtDte",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "MaterialSerialNumberStockBatch",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "InventorySpecialStockType",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "MatlSrlNmbrMasterBatch",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "Customer",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "Supplier",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Target",
+                              "value": {
+                                "AnnotationPath": "@UI.ConnectedFields#SalesOrder",
+                                "type": "AnnotationPath",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataFieldForAnnotation",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "WBSElement",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Value",
+                              "value": {
+                                "Path": "StockOwner",
+                                "type": "Path",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.UI.v1.DataField",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.UI.v1.FieldGroupType",
+              },
+              "term": "com.sap.vocabularies.UI.v1.FieldGroup",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.FieldControl",
+              "value": {
+                "EnumMember": "Common.FieldControlType/Mandatory",
+                "type": "EnumMember",
+              },
+            },
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "CollectionPath",
+                    "value": {
+                      "String": "I_MaterialSerialNumberVH",
+                      "type": "String",
+                    },
+                  },
+                  {
+                    "name": "Parameters",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "Material",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Material",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterInOut",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment_Text",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "SerialNumber",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "UniqueItemIdentifier",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.Common.v1.ValueList",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CrteWthRefFrmSrlzdMaterialItem/Material",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "CollectionPath",
+                    "value": {
+                      "String": "C_EquipMaterialSerialNumberTPType",
+                      "type": "String",
+                    },
+                  },
+                  {
+                    "name": "Parameters",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "StorageLocation",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "StorageLocation",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterIn",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "Plant",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Plant",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterOut",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "StorageLocation",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "StorageLocation",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterOut",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "Plant",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Plant",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "StorageLocation",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "StorageLocation",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.Common.v1.ValueList",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.I_StorageLocationStdVH/StorageLocation",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "CollectionPath",
+                    "value": {
+                      "String": "I_MaterialSerialNumberVH",
+                      "type": "String",
+                    },
+                  },
+                  {
+                    "name": "Parameters",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "SrlzdMatlItmReferenceMaterial",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Material",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterInOut",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "SerialNumber",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment_Text",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.Common.v1.ValueList",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CrteWthRefFrmSrlzdMaterialItem/SrlzdMatlItmReferenceMaterial",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "CollectionPath",
+                    "value": {
+                      "String": "I_EquipmentCategoryStdVH",
+                      "type": "String",
+                    },
+                  },
+                  {
+                    "name": "Parameters",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "EquipmentCategory",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "EquipmentCategory",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterInOut",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.Common.v1.ValueList",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CrteWthRefFrmSrlzdMaterialItem/EquipmentCategory",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.FieldControl",
+              "value": {
+                "EnumMember": "Common.FieldControlType/Mandatory",
+                "type": "EnumMember",
+              },
+            },
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "CollectionPath",
+                    "value": {
+                      "String": "I_MaterialSerialNumberVH",
+                      "type": "String",
+                    },
+                  },
+                  {
+                    "name": "Parameters",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "SerialNumber",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "SerialNumber",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterInOut",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "Material",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Material",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterIn",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment_Text",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.Common.v1.ValueList",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CrteWthRefFrmSrlzdMaterialItem/SerialNumber",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "CollectionPath",
+                    "value": {
+                      "String": "I_MaterialSerialNumberVH",
+                      "type": "String",
+                    },
+                  },
+                  {
+                    "name": "Parameters",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "SrlzdMatlItmRefSerialNumber",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "SerialNumber",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterInOut",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "SrlzdMatlItmReferenceMaterial",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Material",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterIn",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment_Text",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.Common.v1.ValueList",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CrteWthRefFrmSrlzdMaterialItem/SrlzdMatlItmRefSerialNumber",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.FieldControl",
+              "value": {
+                "EnumMember": "Common.FieldControlType/Mandatory",
+                "type": "EnumMember",
+              },
+            },
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "CollectionPath",
+                    "value": {
+                      "String": "I_MaterialSerialNumberVH",
+                      "type": "String",
+                    },
+                  },
+                  {
+                    "name": "Parameters",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "LocalDataProperty",
+                              "value": {
+                                "PropertyPath": "SerialNumber",
+                                "type": "PropertyPath",
+                              },
+                            },
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "SerialNumber",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterInOut",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Material",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "ValueListProperty",
+                              "value": {
+                                "String": "Equipment_Text",
+                                "type": "String",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.ValueListParameterDisplayOnly",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.Common.v1.ValueList",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChgSrlzdMatlItemSerialNumber/SerialNumber",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Hidden",
+              "value": {
+                "Bool": true,
+                "type": "Bool",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CrteWthRefFrmSrlzdMaterialItem/UniqueItemIdentifierRespPlant",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Hidden",
+              "value": {
+                "Bool": true,
+                "type": "Bool",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber/UniqueItemIdentifierRespPlant",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.FieldControl",
+              "value": {
+                "EnumMember": "Common.FieldControlType/Mandatory",
+                "type": "EnumMember",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber/Material",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.FieldControl",
+              "value": {
+                "EnumMember": "Common.FieldControlType/Mandatory",
+                "type": "EnumMember",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber/EquipmentCategory",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.FieldControl",
+              "value": {
+                "EnumMember": "Common.FieldControlType/ReadOnly",
+                "type": "EnumMember",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber/EquipMaterialLastSerialNumber",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.FieldControl",
+              "value": {
+                "EnumMember": "Common.FieldControlType/Mandatory",
+                "type": "EnumMember",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeMaintenancePlant/MaintenancePlant",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.UI.v1.Hidden",
+              "value": {
+                "Bool": true,
+                "type": "Bool",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.CreateMassMaterialSerialNumber(Collection(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType))/_SerialList",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "term": "com.sap.vocabularies.Common.v1.IsActionCritical",
+              "value": {
+                "Bool": true,
+                "type": "Bool",
+              },
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ActvtSrlzdMatlItmEquipmentData",
+        },
+        {
+          "annotations": [
+            {
+              "collection": [
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "PartnerFunctionForEdit",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "EquipmentPartner",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "PersonFullName",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "SearchTerm1",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "CityName",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "PostalCode",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "FaxAreaCodeSubscriberNumber",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "PhoneNumber",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+              ],
+              "qualifier": "Partners",
+              "term": "com.sap.vocabularies.UI.v1.LineItem",
+            },
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "MaxItems",
+                    "value": {
+                      "Int": 2,
+                      "type": "Int",
+                    },
+                  },
+                  {
+                    "name": "SortOrder",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Property",
+                              "value": {
+                                "PropertyPath": "CreationDateTime",
+                                "type": "PropertyPath",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.SortOrderType",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                  {
+                    "name": "Visualizations",
+                    "value": {
+                      "Collection": [
+                        {
+                          "AnnotationPath": "@UI.LineItem",
+                          "type": "AnnotationPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.UI.v1.PresentationVariant",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMatlSrlNmbrPrtnTPType",
+        },
+        {
+          "annotations": [
+            {
+              "collection": [
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "WarrantyType",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "WarrantyCategory",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "MasterWarranty",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "WarrantyStartDate",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "WarrantyEndDate",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "WrntyIsInhtdFromSuperiorObject",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "WrntyIsPassedOnToChildObject",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+              ],
+              "qualifier": "WarrantyTable",
+              "term": "com.sap.vocabularies.UI.v1.LineItem",
+            },
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "Visualizations",
+                    "value": {
+                      "Collection": [
+                        {
+                          "AnnotationPath": "@UI.LineItem",
+                          "type": "AnnotationPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.UI.v1.PresentationVariant",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMatlSrlNmbrWarrantyTPType",
+        },
+        {
+          "annotations": [
+            {
+              "collection": [
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "ChangeDocDatabaseTableField",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "ChangeDocItemChangeType",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "ChangeDocNewFieldValue",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "ChangeDocPreviousFieldValue",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "CreatedByUser",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "CreationDateTime",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "TechObjChgDocNewFldValueText",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "TechObjChgDocOldFldValueText",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "MaterialName",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "MaintObjectChangeTypeCodeText",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "MaintObjectChangeTypeCode",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+                {
+                  "propertyValues": [
+                    {
+                      "name": "Value",
+                      "value": {
+                        "Path": "UserDescription",
+                        "type": "Path",
+                      },
+                    },
+                  ],
+                  "type": "com.sap.vocabularies.UI.v1.DataField",
+                },
+              ],
+              "qualifier": "History",
+              "term": "com.sap.vocabularies.UI.v1.LineItem",
+            },
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "MaxItems",
+                    "value": {
+                      "Int": 2,
+                      "type": "Int",
+                    },
+                  },
+                  {
+                    "name": "SortOrder",
+                    "value": {
+                      "Collection": [
+                        {
+                          "propertyValues": [
+                            {
+                              "name": "Property",
+                              "value": {
+                                "PropertyPath": "CreationDateTime",
+                                "type": "PropertyPath",
+                              },
+                            },
+                          ],
+                          "type": "com.sap.vocabularies.Common.v1.SortOrderType",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                  {
+                    "name": "Visualizations",
+                    "value": {
+                      "Collection": [
+                        {
+                          "AnnotationPath": "@UI.LineItem",
+                          "type": "AnnotationPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": undefined,
+              },
+              "term": "com.sap.vocabularies.UI.v1.PresentationVariant",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMatlSrlNmbrChgHistoryTPType",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_it/_EquipMatlSrlNmbrChgHistory",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.Common.v1.SideEffectsType",
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeMaterial(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_it/_EquipMatlSrlNmbrChgHistory",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.Common.v1.SideEffectsType",
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChgSrlzdMatlItemSerialNumber(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_it/_EquipMatlSrlNmbrChgHistory",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.Common.v1.SideEffectsType",
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeEquipmentCategory(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_it/_EquipMatlSrlNmbrChgHistory",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.Common.v1.SideEffectsType",
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeMaintenancePlant(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_it/_EquipMatlSrlNmbrChgHistory",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.Common.v1.SideEffectsType",
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ActvtSrlzdMatlItmEquipmentData(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_it/_EquipMatlSrlNmbrChgHistory",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.Common.v1.SideEffectsType",
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_it/_EquipMatlSrlNmbrChgHistory",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.Common.v1.SideEffectsType",
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.RsetSrlzdMatlItemFromInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_it/_EquipMatlSrlNmbrChgHistory",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.Common.v1.SideEffectsType",
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+        },
+        {
+          "annotations": [
+            {
+              "qualifier": undefined,
+              "record": {
+                "propertyValues": [
+                  {
+                    "name": "TargetEntities",
+                    "value": {
+                      "Collection": [
+                        {
+                          "NavigationPropertyPath": "_it/_EquipMatlSrlNmbrChgHistory",
+                          "type": "NavigationPropertyPath",
+                        },
+                      ],
+                      "type": "Collection",
+                    },
+                  },
+                ],
+                "type": "com.sap.vocabularies.Common.v1.SideEffectsType",
+              },
+              "term": "com.sap.vocabularies.Common.v1.SideEffects",
+            },
+          ],
+          "target": "com.sap.gateway.srvd.eam_materialserialnumber.v0001.ResetSrlzdMatlItmFrmDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)",
+        },
+      ],
+    },
+    "associationSets": [],
+    "associations": [],
+    "complexTypes": [],
+    "entityContainer": {
+      "_type": "EntityContainer",
+      "fullyQualifiedName": "",
+    },
+    "entitySets": [],
+    "entityTypes": [],
+    "namespace": "local",
+    "singletons": [],
+    "typeDefinitions": [],
+  },
+  "version": "4.0",
+}
+`;
+
 exports[`Parser can parse an edmx file 1`] = `
 MergedRawMetadata {
   "_actionImports": [

--- a/packages/edmx-parser/test/fixtures/inlineError.metadata.xml
+++ b/packages/edmx-parser/test/fixtures/inlineError.metadata.xml
@@ -1,0 +1,887 @@
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+        <edmx:Include Namespace="com.sap.vocabularies.Common.v1" Alias="Common" />
+    </edmx:Reference>
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+        <edmx:Include Namespace="com.sap.vocabularies.UI.v1" Alias="UI" />
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata4/sap/eam_sb_materialserialnumber/srvd/sap/eam_materialserialnumber/0001/$metadata">
+        <edmx:Include Namespace="com.sap.gateway.srvd.eam_materialserialnumber.v0001" Alias="SAP__self" />
+        <edmx:Include Namespace="com.sap.vocabularies.UI.v1" Alias="SAP__UI" />
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="local">
+            <Annotations Target="SAP__self.I_MaterialSerialNumberVHType/UniqueItemIdentifier">
+                <Annotation Term="UI.Hidden" Bool="true" />
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifier">
+                <Annotation Term="UI.Hidden" Bool="true" />
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifierStrucType">
+                <Annotation Term="UI.Hidden" Bool="true" />
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/UniqueItemIdentifierRespPlant">
+                <Annotation Term="UI.Hidden" Bool="true" />
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/ConcatenatedActiveUserStsName">
+                <Annotation Term="UI.Hidden" Bool="true" />
+            </Annotations>
+            <!-- <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/EquipMaterialLastSerialNumber">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/ReadOnly" />
+            </Annotations> -->
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/EquipMaterialLastSerialNumber">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/ReadOnly" />
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/SetSrlzdMaterialItemToInactive">
+                <Annotation Term="com.sap.vocabularies.Common.v1.SideEffects" Qualifier="LastChangeDateTimeChanged">
+                    <Record>
+                        <!-- <PropertyValue Property="SourceProperties">
+                            <Collection>
+                                <PropertyPath>LastChangeDateTime</PropertyPath>
+                            </Collection>
+                        </PropertyValue> -->
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_EquipMatlSrlNmbrChgHistoryTP</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <!-- <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/Material">
+                <Annotation Term="Common.SemanticObject" Qualifier="TechnicalObjectLinks">
+                    <String>MaintenanceObject</String>
+                </Annotation >
+            </Annotations> -->
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/Material">
+                <Annotation Term="Common.SemanticObject" Qualifier="MaterialLinks">
+                    <String>Material</String>
+                </Annotation>
+
+                <Annotation Term="Common.SemanticObjectUnavailableActions" Qualifier="MaterialLinks">
+                    <Collection>
+                        <String>displayInAssetViewer</String>
+                        <String>displayBreakdownAnalysis</String>
+                        <String>displayDamageAnalysis</String>
+                        <String>postprocessDataTransfer</String>
+                        <String>transferDataFromEquipment</String>
+                        <String>transferDataFromFunctionalLoc</String>
+                        <String>analyzeInventoryTurnover</String>
+                        <String>analyzeInventoryKPIsTimeseries</String>
+                        <String>analyzeStockinDateRange</String>
+                        <String>displayDeadStock</String>
+                        <String>displayMaterialDocuments</String>
+                        <String>displayOverdueGRBlockedStock</String>
+                        <String>displayOverdueStockInTransit</String>
+                        <String>displaySerialNumberInfo</String>
+                        <String>displaySerStockInfo</String>
+                        <String>displaySlowOrNonMoving</String>
+                        <String>displayStockForPostingDate</String>
+                        <String>displayStockInTransitInWebGUI</String>
+                        <String>displayStockMultipleMaterials</String>
+                        <String>displayStockOverview</String>
+                        <String>displayStockOverviewInWebGUI</String>
+                        <String>displayWarehouseStockInWebGUI</String>
+                        <String>manageBySubcontractingSupplier</String>
+                        <String>postGoodsIssueInWebGUI</String>
+                        <String>postGoodsMovementInWebGUI</String>
+                        <String>postGoodsReceiptInWebGUI</String>
+                        <String>postTransferPostingInWebGUI</String>
+                        <String>transferStock</String>
+                        <String>transferStockCrossPlant</String>
+                        <String>change</String>
+                        <String>create</String>
+                        <String>displayEquipment</String>
+                        <String>display</String>
+                        <String>displayFactSheet</String>
+                        <String>createMatlSerialNumber</String>
+                        <String>createMultipleMatlSerialNumber</String>
+                        <String>displayComplianceInfo</String>
+                        <String>activatePlannedChanges</String>
+                        <String>maintainCyCIndicator</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="Common.SemanticObjectMapping">
+                    <Collection>
+                        <Record Type="Common.SemanticObjectMappingType">
+                            <PropertyValue Property="LocalProperty" PropertyPath="TechnicalObject" />
+                            <PropertyValue Property="SemanticObjectProperty" String="Equipment" />
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/EquipmentName">
+                <Annotation Term="UI.Hidden">
+                    <If>
+                        <Eq>
+                            <Path>HasEquipmentData</Path>
+                            <Bool>false</Bool>
+                        </Eq>
+                        <Bool>true</Bool>
+                        <Bool>false</Bool>
+                    </If>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType/TechnicalObject">
+                <Annotation Term="Common.SemanticObjectUnavailableActions">
+                    <Collection>
+                        <String>displayInAssetViewer</String>
+                        <String>changeMatlSerialNumber</String>
+                        <String>createMatlSerialNumber</String>
+                        <String>createMultipleMatlSerialNumber</String>
+                        <String>displayMatlSerialNumberList</String>
+                        <String>displayMatlSerialNumber</String>
+                        <String>displayBreakdownAnalysis</String>
+                        <String>displayDamageAnalysis</String>
+                        <String>postprocessDataTransfer</String>
+                        <String>transferDataFromEquipment</String>
+                        <String>transferDataFromFunctionalLoc</String>
+                        <String>displayFactSheet</String>
+                        <String>createMatlSerialNumber</String>
+                        <String>createMultipleMatlSerialNumber</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="Common.SemanticObjectMapping">
+                    <Collection>
+                        <Record Type="Common.SemanticObjectMappingType">
+                            <PropertyValue Property="LocalProperty" PropertyPath="TechObjIsEquipOrFuncnlLoc" />
+                            <PropertyValue Property="SemanticObjectProperty" String="TechObjIsEquipOrFuncnlLoc" />
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMaterialSerialNumberTPType">
+                <Annotation Term="SAP__UI.SelectionFields">
+                    <Collection>
+                        <PropertyPath>Material</PropertyPath>
+                        <PropertyPath>SerialNumber</PropertyPath>
+                        <PropertyPath>Equipment</PropertyPath>
+                        <PropertyPath>ConcatenatedActiveSystStsName</PropertyPath>
+                        <PropertyPath>InventoryStockType</PropertyPath>
+                        <PropertyPath>EquipmentCategory</PropertyPath>
+                        <PropertyPath>Plant</PropertyPath>
+                        <PropertyPath>MaterialSerialNumberStockBatch</PropertyPath>
+                        <PropertyPath>StorageLocation</PropertyPath>
+                        <PropertyPath>Customer</PropertyPath>
+                        <PropertyPath>HasEquipmentData</PropertyPath>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataFieldForIntentBasedNavigation">
+                            <PropertyValue Property="Label" String="{@i18n>serialNumberHistory}" />
+                            <PropertyValue Property="SemanticObject" String="Material" />
+                            <PropertyValue Property="Action" String="displaySerHistoryInfo" />
+                            <PropertyValue Property="RequiresContext" Bool="false" />
+                            <PropertyValue Property="NavigationAvailable" Bool="true" />
+                            <Annotation Term="UI.Hidden">
+                                <If>
+                                    <Or>
+                                        <And>
+                                            <Eq>
+                                                <Path>HasActiveEntity</Path>
+                                                <Bool>false</Bool>
+                                            </Eq>
+                                            <Eq>
+                                                <Path>IsActiveEntity</Path>
+                                                <Bool>true</Bool>
+                                            </Eq>
+                                        </And>
+                                        <And>
+                                            <Eq>
+                                                <Path>HasActiveEntity</Path>
+                                                <Bool>true</Bool>
+                                            </Eq>
+                                            <Eq>
+                                                <Path>IsActiveEntity</Path>
+                                                <Bool>false</Bool>
+                                            </Eq>
+                                        </And>
+                                    </Or>
+                                    <Bool>false</Bool>
+                                    <Bool>true</Bool>
+                                </If>
+                            </Annotation>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>activateEquipmentView}" />
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ActvtSrlzdMatlItmEquipmentData(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)" />
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated" />
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>changeEquipmentCategory}" />
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeEquipmentCategory(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)" />
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated" />
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>changePlant}" />
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeMaintenancePlant(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)" />
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated" />
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <Annotation Term="UI.Hidden">
+                                <If>
+                                    <Eq>
+                                        <Path>IsCloudSystem</Path>
+                                        <Bool>true</Bool>
+                                    </Eq>
+                                    <Bool>true</Bool>
+                                    <Bool>false</Bool>
+                                </If>
+                            </Annotation>
+                            <PropertyValue Property="Label" String="{@i18n>changeUII}" />
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ChangeUniqueItemIdentifier(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)" />
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated" />
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>setMaterialItemInactive}" />
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)" />
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated" />
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>resetMaterialItemInactive}" />
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.RsetSrlzdMatlItemFromInactive(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)" />
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated" />
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>setMaterialItemDeletion}" />
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.SetSrlzdMaterialItemToDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)" />
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated" />
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="{@i18n>resetMaterialItemDeletion}" />
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.ResetSrlzdMatlItmFrmDeletion(com.sap.gateway.srvd.eam_materialserialnumber.v0001.C_EquipMaterialSerialNumberTPType)" />
+                            <PropertyValue Property="InvocationGrouping" EnumMember="SAP__UI.OperationGroupingType/Isolated" />
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.ConnectedFields" Qualifier="SalesOrder">
+                    <Record>
+                        <PropertyValue Property="Data">
+                            <Record>
+                                <PropertyValue Property="SalesOrder">
+                                    <Record Type="UI.DataField">
+                                        <PropertyValue Property="Value" Path="SalesOrder" />
+                                    </Record>
+                                </PropertyValue>
+                                <PropertyValue Property="SalesOrderItem">
+                                    <Record Type="UI.DataField">
+                                        <PropertyValue Property="Value" Path="SalesOrderItem" />
+                                    </Record>
+                                </PropertyValue>
+                            </Record>
+                        </PropertyValue>
+                        <PropertyValue Property="Label" String="{@i18n>salesOrder} / {@i18n>salesOrderItem}" />
+                        <PropertyValue Property="Template" String="{SalesOrder} / {SalesOrderItem}" />
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.HeaderFacets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="ID" String="General" />
+                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#HeaderFacetMain" />
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="HeaderFacetMain">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="EquipmentCategory" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="SerialNumber" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="UniqueItemIdentifierRespPlant" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="UniqueItemIdentifier" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="UniqueItemIdentifierStrucType" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="ConcatenatedActiveSystStsName" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.CollectionFacet">
+                            <PropertyValue Property="Label" String="{@i18n>serialNumberData}" />
+                            <PropertyValue Property="ID" String="SerialNumberData" />
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="Label" String="{@i18n>general}" />
+                                        <PropertyValue Property="ID" String="General" />
+                                        <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#General" />
+                                    </Record>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="Label" String="{@i18n>stockInformation}" />
+                                        <PropertyValue Property="ID" String="StockInformation" />
+                                        <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#StockInformation" />
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                        <Record Type="SAP__UI.CollectionFacet">
+                            <PropertyValue Property="Label" String="{@i18n>PartnersTable}" />
+                            <PropertyValue Property="ID" String="Partners" />
+                            <PropertyValue Property="Facets">-->
+                                <Collection>
+                                    <Record Type="SAP__UI.ReferenceFacet">
+                                        <!-- <PropertyValue Property="Label" String="{i18n>PartnersTable}" /> -->
+                                        <PropertyValue Property="ID" String="PartnersTable" />
+                                        <PropertyValue Property="Target" AnnotationPath="_Partner/@SAP__UI.LineItem#Partners" />
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                        <Record Type="UI.CollectionFacet">
+                            <PropertyValue Property="Label" String="{@i18n>WarrantySection}" />
+                            <PropertyValue Property="ID" String="WarrantySection" />
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <Record Type="SAP__UI.ReferenceFacet">
+                                        <!-- <PropertyValue Property="Label" String="{i18n>WarrantyTable}" /> -->
+                                        <PropertyValue Property="ID" String="WarrantyTable" />
+                                        <PropertyValue Property="Target" AnnotationPath="_Warranty/@SAP__UI.LineItem#WarrantyTable" />
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                        <Record Type="SAP__UI.CollectionFacet">
+                            <PropertyValue Property="Label" String="{@i18n>history}" />
+                            <PropertyValue Property="ID" String="History" />
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <Record Type="SAP__UI.ReferenceFacet">
+                                        <!-- <PropertyValue Property="Label" String="{@i18n>history}" /> -->
+                                        <PropertyValue Property="ID" String="History1" />
+                                        <PropertyValue Property="Target" AnnotationPath="_EquipMatlSrlNmbrChgHistory/@SAP__UI.LineItem#History" />
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                    </Collection>
+                </Annotation>
+
+                <Annotation Term="UI.FieldGroup" Qualifier="General">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="TechnicalObject" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="EquipMaterialLastSerialNumber" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="EquipmentName" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="StockInformation">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="InventoryStockType" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Plant" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="CompanyCode" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="StorageLocation" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="MatlSrlNmbrLastGdsMvtDte" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="MaterialSerialNumberStockBatch" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="InventorySpecialStockType" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="MatlSrlNmbrMasterBatch" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Customer" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="Supplier" />
+                                </Record>
+                                <Record Type="UI.DataFieldForAnnotation">
+                                    <PropertyValue Property="Target" AnnotationPath="@UI.ConnectedFields#SalesOrder" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="WBSElement" />
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="StockOwner" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+
+            <!-- <Annotations Target="SAP__self.CreateMassMaterialSerialNumber">
+                <Annotation Term="Common.DefaultValuesFunction" String="com.sap.gateway.srvd.eam_materialserialnumber.v0001.GetRefSerializedMaterialItem" />
+            </Annotations> -->
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/Material">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH" />
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="Material" />
+                                    <PropertyValue Property="ValueListProperty" String="Material" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="UniqueItemIdentifier" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.I_StorageLocationStdVH/StorageLocation">
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="C_EquipMaterialSerialNumberTPType" />
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterIn">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="StorageLocation" />
+                                    <PropertyValue Property="ValueListProperty" String="StorageLocation" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="Plant" />
+                                    <PropertyValue Property="ValueListProperty" String="Plant" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="StorageLocation" />
+                                    <PropertyValue Property="ValueListProperty" String="StorageLocation" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="Plant" />
+                                    <PropertyValue Property="ValueListProperty" String="Plant" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="StorageLocation" />
+                                    <PropertyValue Property="ValueListProperty" String="StorageLocation" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/SrlzdMatlItmReferenceMaterial">
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH" />
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SrlzdMatlItmReferenceMaterial" />
+                                    <PropertyValue Property="ValueListProperty" String="Material" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/EquipmentCategory">
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_EquipmentCategoryStdVH" />
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="EquipmentCategory" />
+                                    <PropertyValue Property="ValueListProperty" String="EquipmentCategory" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/SerialNumber">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH" />
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SerialNumber" />
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterIn">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="Material" />
+                                    <PropertyValue Property="ValueListProperty" String="Material" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/SrlzdMatlItmRefSerialNumber">
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH" />
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SrlzdMatlItmRefSerialNumber" />
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterIn">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SrlzdMatlItmReferenceMaterial" />
+                                    <PropertyValue Property="ValueListProperty" String="Material" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChgSrlzdMatlItemSerialNumber/SerialNumber">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+                <Annotation Term="Common.ValueList">
+                    <Record>
+                        <PropertyValue Property="CollectionPath" String="I_MaterialSerialNumberVH" />
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="SerialNumber" />
+                                    <PropertyValue Property="ValueListProperty" String="SerialNumber" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Material" />
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="Equipment_Text" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.CrteWthRefFrmSrlzdMaterialItem/UniqueItemIdentifierRespPlant">
+                <Annotation Term="UI.Hidden" Bool="true" />
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/UniqueItemIdentifierRespPlant">
+                <Annotation Term="UI.Hidden" Bool="true" />
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/Material">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/EquipmentCategory">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+            </Annotations>
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/EquipMaterialLastSerialNumber">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/ReadOnly" />
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaintenancePlant/MaintenancePlant">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+            </Annotations>
+            <!-- <Annotations Target="SAP__self.CreateMassMaterialSerialNumber/_SerialList">
+                <Annotation Term="UI.Hidden" Bool="true" />
+            </Annotations> -->
+            <Annotations Target="SAP__self.CreateMassMaterialSerialNumber(Collection(SAP__self.C_EquipMaterialSerialNumberTPType))/_SerialList">
+                <Annotation Term="UI.Hidden" Bool="true" />
+            </Annotations>
+            <Annotations Target="SAP__self.ActvtSrlzdMatlItmEquipmentData">
+                <Annotation Term="com.sap.vocabularies.Common.v1.IsActionCritical" Bool="true" />
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrPrtnTPType">
+                <Annotation Term="SAP__UI.LineItem" Qualifier="Partners">
+                    <Collection>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="PartnerFunctionForEdit" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="EquipmentPartner" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="PersonFullName" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="SearchTerm1" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="CityName" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="PostalCode" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="FaxAreaCodeSubscriberNumber" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="PhoneNumber" />
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.PresentationVariant">
+                    <Record>
+                        <PropertyValue Property="MaxItems" Int="2" />
+                        <PropertyValue Property="SortOrder">
+                            <Collection>
+                                <Record Type="Common.SortOrderType">
+                                    <PropertyValue Property="Property" PropertyPath="CreationDateTime" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="Visualizations">
+                            <Collection>
+                                <AnnotationPath>@UI.LineItem</AnnotationPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrWarrantyTPType">
+                <Annotation Term="SAP__UI.LineItem" Qualifier="WarrantyTable">
+                    <Collection>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="WarrantyType" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="WarrantyCategory" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MasterWarranty" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="WarrantyStartDate" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="WarrantyEndDate" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="WrntyIsInhtdFromSuperiorObject" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="WrntyIsPassedOnToChildObject" />
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.PresentationVariant">
+                    <Record>
+                        <PropertyValue Property="Visualizations">
+                            <Collection>
+                                <AnnotationPath>@UI.LineItem</AnnotationPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.C_EquipMatlSrlNmbrChgHistoryTPType">
+                <Annotation Term="SAP__UI.LineItem" Qualifier="History">
+                    <Collection>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="ChangeDocDatabaseTableField" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="ChangeDocItemChangeType" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="ChangeDocNewFieldValue" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="ChangeDocPreviousFieldValue" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="CreatedByUser" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="CreationDateTime" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="TechObjChgDocNewFldValueText" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="TechObjChgDocOldFldValueText" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaterialName" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaintObjectChangeTypeCodeText" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="MaintObjectChangeTypeCode" />
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Property="Value" Path="UserDescription" />
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.PresentationVariant">
+                    <Record>
+                        <PropertyValue Property="MaxItems" Int="2" />
+                        <PropertyValue Property="SortOrder">
+                            <Collection>
+                                <Record Type="Common.SortOrderType">
+                                    <PropertyValue Property="Property" PropertyPath="CreationDateTime" />
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="Visualizations">
+                            <Collection>
+                                <AnnotationPath>@UI.LineItem</AnnotationPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaterial(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChgSrlzdMatlItemSerialNumber(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeEquipmentCategory(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ChangeMaintenancePlant(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ActvtSrlzdMatlItmEquipmentData(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.SetSrlzdMaterialItemToInactive(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.RsetSrlzdMatlItemFromInactive(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.SetSrlzdMaterialItemToDeletion(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.ResetSrlzdMatlItmFrmDeletion(SAP__self.C_EquipMaterialSerialNumberTPType)">
+                <Annotation Term="Common.SideEffects">
+                    <Record Type="Common.SideEffectsType">
+                        <PropertyValue Property="TargetEntities">
+                            <Collection>
+                                <NavigationPropertyPath>_it/_EquipMatlSrlNmbrChgHistory</NavigationPropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/edmx-parser/test/parser.spec.ts
+++ b/packages/edmx-parser/test/parser.spec.ts
@@ -147,4 +147,10 @@ describe('Parser', function () {
         const schema: RawMetadata = parse(xmlFile);
         expect(schema).toMatchSnapshot();
     });
+
+    it('can parse an EDMX with comments inside', async () => {
+        const xmlFile = await loadFixture('inlineError.metadata.xml');
+        const schema: RawMetadata = parse(xmlFile);
+        expect(schema).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
In case some inline comments were left in the _text area, the parsing was failing for no reason