### PR TITLE
feat: add possibility to cross change data between services

### DIFF
--- a/docs/CrossServiceCommunication.md
+++ b/docs/CrossServiceCommunication.md
@@ -1,0 +1,267 @@
+# Cross-Service Communication
+
+The SAP UI5 FE Mockserver supports cross-service communication, allowing entity sets in one service to interact with and modify data in other services. This feature is particularly useful for testing complex scenarios where multiple OData services need to coordinate with each other.
+
+## Overview
+
+By default, each mockserver service operates in isolation. With cross-service communication enabled, you can:
+
+- Update entities in other services from your action implementations
+- Read data from other services
+- Perform cross-service operations like cascading updates
+- Test complex business scenarios involving multiple services
+
+## Prerequisites
+
+Cross-service communication is automatically enabled when you configure multiple services in your mockserver setup. No additional configuration is required.
+
+## API Reference
+
+### getOtherServiceEntityInterface
+
+Access an entity interface from another service to perform operations.
+
+```javascript
+this.base.getOtherServiceEntityInterface(serviceName, entityName)
+```
+
+**Parameters:**
+- `serviceName: string` - The URL path of the target service (e.g., '/sap/opu/odata/sap/MY_SERVICE')
+- `entityName: string` - The name of the entity set in the target service
+
+**Returns:**
+- `Promise<FileBasedMockData | undefined>` - The entity interface for the target service's entity
+
+**Throws:**
+- Error if the service is not found
+- Error if the entity is not found in the target service
+- Error if cross-service communication is not enabled
+
+## Usage Examples
+
+### Basic Cross-Service Update
+
+Update an entity in another service when executing an action:
+
+```javascript
+// In RootEntity.js (first service)
+module.exports = {
+    executeAction: function (actionDefinition, actionData, keys) {
+        // Update current service
+        this.base.updateEntry(keys, { status: 'processed' });
+        
+        // Update corresponding entity in second service - works exactly like this.base.updateEntry!
+        this.base.getOtherServiceEntityInterface('/second/service', 'RelatedEntity')
+            .then(function(otherServiceEntity) {
+                if (otherServiceEntity) {
+                    // Same API as this.base.updateEntry - just pass keys and partial data
+                    // Automatically preserves existing fields (ID, name, etc.)
+                    return otherServiceEntity.updateEntry(keys, {
+                        lastModified: new Date().toISOString(),
+                        processedBy: 'FirstService'
+                    });
+                }
+            })
+            .then(function() {
+                console.log('Cross-service update completed');
+            })
+            .catch(function(error) {
+                console.error('Cross-service update failed:', error.message);
+            });
+    }
+};
+```
+
+### Cross-Service Data Creation
+
+Create new entries in other services:
+
+```javascript
+module.exports = {
+    executeAction: function (actionDefinition, actionData, keys) {
+        // Create audit entry in logging service
+        this.base.getOtherServiceEntityInterface('/audit/service', 'AuditLog')
+            .then(function(auditService) {
+                if (auditService) {
+                    return auditService.addEntry({
+                        entityId: keys.ID,
+                        action: actionDefinition.name,
+                        timestamp: new Date().toISOString(),
+                        source: 'MainService'
+                    });
+                }
+            })
+            .catch(function(error) {
+                console.error('Audit logging failed:', error.message);
+            });
+    }
+};
+```
+
+### Complex Cross-Service Workflow
+
+Implement complex business logic across multiple services:
+
+```javascript
+module.exports = {
+    executeAction: async function (actionDefinition, actionData, keys) {
+        try {
+            // Step 1: Update current service
+            this.base.updateEntry(keys, { status: 'processing' });
+            
+            // Step 2: Check inventory in another service
+            const inventoryService = await this.base.getOtherServiceEntityInterface(
+                '/inventory/service', 
+                'Stock'
+            );
+            
+            if (inventoryService) {
+                const stockItems = await inventoryService.fetchEntries(
+                    { productId: keys.productId }
+                );
+                
+                if (stockItems.length > 0 && stockItems[0].quantity > 0) {
+                    // Step 3: Reserve inventory - automatically preserves other fields
+                    await inventoryService.updateEntry(
+                        { productId: keys.productId },
+                        { 
+                            quantity: stockItems[0].quantity - 1,
+                            reserved: stockItems[0].reserved + 1
+                        }
+                    );
+                    
+                    // Step 4: Update order status
+                    this.base.updateEntry(keys, { status: 'confirmed' });
+                } else {
+                    // Step 5: Handle out of stock
+                    this.base.updateEntry(keys, { status: 'backordered' });
+                }
+            }
+        } catch (error) {
+            console.error('Cross-service workflow failed:', error.message);
+            this.base.updateEntry(keys, { status: 'error' });
+        }
+    }
+};
+```
+
+## Available Operations
+
+Once you obtain an entity interface from another service using `getOtherServiceEntityInterface`, you can perform all standard mockdata operations with the same simplified API as `this.base`:
+
+### Data Modification
+- `addEntry(mockEntry)` - Create new entries
+- `updateEntry(keyValues, patchData)` - **Update existing entries (automatically preserves existing fields)**
+- `removeEntry(keyValues)` - Delete entries
+
+### Data Retrieval
+- `fetchEntries(keyValues)` - Get specific entries by key
+- `getAllEntries()` - Get all entries
+- `hasEntry(keyValues)` - Check if entry exists
+
+### Utility Operations
+- `getEmptyObject()` - Get template object for the entity
+- `generateKey(property, lineIndex)` - Generate keys for new entries
+
+> **Note:** The cross-service interface has been enhanced to work exactly like `this.base` methods. The `updateEntry` method automatically fetches existing data and merges your changes, preserving all unmodified fields.
+
+## Error Handling
+
+Always implement proper error handling for cross-service operations:
+
+```javascript
+this.base.getOtherServiceEntityInterface('/other/service', 'Entity')
+    .then(function(otherService) {
+        if (!otherService) {
+            console.warn('Target service not available');
+            return;
+        }
+        // Perform operations...
+    })
+    .catch(function(error) {
+        if (error.message.includes('not found in registry')) {
+            console.error('Service not configured:', error.message);
+        } else if (error.message.includes('Entity') && error.message.includes('not found')) {
+            console.error('Target entity does not exist:', error.message);
+        } else {
+            console.error('Unexpected error:', error.message);
+        }
+    });
+```
+
+## Best Practices
+
+### 1. Service Dependencies
+- Document cross-service dependencies clearly
+- Ensure target services are properly configured
+- Handle cases where dependent services might be unavailable
+
+### 2. Error Resilience
+- Always use `.catch()` for promise-based operations
+- Implement fallback behavior when cross-service operations fail
+- Log errors appropriately for debugging
+
+### 3. Performance Considerations
+- Minimize cross-service calls where possible
+- Use asynchronous operations to avoid blocking
+- Consider caching frequently accessed data
+
+### 4. Testing
+- Test scenarios with all dependent services running
+- Test error scenarios (missing services, missing entities)
+- Verify data consistency across services
+
+## Limitations
+
+- Cross-service operations use a shared tenant context (empty tenant ID)
+- Circular dependencies between services should be avoided
+- Performance may be impacted by excessive cross-service calls
+- All target services must be configured in the same mockserver instance
+
+## Troubleshooting
+
+### Common Issues
+
+**Service not found error:**
+```
+Error: Service '/my/service' not found in registry
+```
+- Verify the service URL path matches your configuration
+- Check that the service is properly registered in your mockserver setup
+
+**Entity not found error:**
+```
+Error: Entity 'MyEntity' not found in service '/my/service'
+```
+- Verify the entity name exists in the target service's metadata
+- Check that the entity set is properly configured with mockdata
+
+**Cross-service access not enabled:**
+```
+Error: Cross-service access is not enabled. ServiceRegistry not available.
+```
+- Ensure you're using the latest version of the mockserver
+- Verify multiple services are configured in your setup
+
+### Debug Tips
+
+1. **Enable debug logging** to see service registration:
+   ```yaml
+   configuration:
+     debug: true
+   ```
+
+2. **List available services** in your action:
+   ```javascript
+   console.log('Available services:', Object.keys(serviceRegistry));
+   ```
+
+3. **Verify entity availability** before operations:
+   ```javascript
+   const entityInterface = await this.base.getOtherServiceEntityInterface(serviceName, entityName);
+   if (entityInterface) {
+       console.log('Entity interface available');
+   } else {
+       console.log('Entity interface not found');
+   }
+   ``` 

--- a/docs/DefiningMockdata.md
+++ b/docs/DefiningMockdata.md
@@ -12,6 +12,12 @@ In order to define your mockdata, you need to create a file with the name of the
 
 You can then implement some functions defined in the [API](./MockserverAPI.md) to add your custom logic.
 
+## Cross-Service Communication
+
+Starting with the latest version, the mockserver supports cross-service communication, allowing your entity sets to interact with and modify data in other services. This is particularly useful for testing complex business scenarios that involve multiple OData services.
+
+You can access entities from other services using the `base.getOtherServiceEntityInterface()` method. For detailed examples and best practices, see [Cross-Service Communication](./CrossServiceCommunication.md).
+
 ## Defining unbound actions
 
 Unbound actions are by definition specific to your application so the mockserver can't do much to help you there beside allowing you to implement whatever logic you need.

--- a/docs/MockserverAPI.md
+++ b/docs/MockserverAPI.md
@@ -152,11 +152,22 @@ Remove an entry from the data set
 
 #### getEntityInterface
 
-Retrieve the mockdata entity interface for a given entity set.
+Retrieve the mockdata entity interface for a given entity set within the current service.
 
 `getEntityInterface: (entityName: string) => Promise<FileBasedMockData | undefined>;`
 
 The entity interface allow you then to access the standard function (`addEntry`, `fetchEntries`, ...) to manipulate the mockdata of the application.
+
+#### getOtherServiceEntityInterface
+
+Retrieve the mockdata entity interface for an entity set from another service. This enables cross-service communication and data manipulation across multiple OData services.
+
+`getOtherServiceEntityInterface: (serviceName: string, entityName: string) => Promise<FileBasedMockData | undefined>;`
+
+- `serviceName` - The URL path of the target service (e.g., '/sap/opu/odata/sap/MY_OTHER_SERVICE')
+- `entityName` - The name of the entity set in the target service
+
+See [Cross-Service Communication](./CrossServiceCommunication.md) for detailed usage examples and best practices.
 
 #### example
 
@@ -179,6 +190,14 @@ The entity interface allow you then to access the standard function (`addEntry`,
         // For tenant-006 we will retrive the EntityInterface for a different entity and add a new entry there using addEntry
         const mySecondEntityInterface = await this.base.getEntityInterface('MySecondEntity');
         mySecondEntityInterface.addEntry({ Name: 'MySecondEntityName' });
+        return this.base.updateEntry(keyValues, newData);
+    } else if (odataRequest.tenantId === 'tenant-007') {
+        // For tenant-007 we will update an entity in a different service using cross-service communication
+        const otherServiceEntity = await this.base.getOtherServiceEntityInterface('/other/service', 'RelatedEntity');
+        if (otherServiceEntity) {
+            // Cross-service updateEntry works just like this.base.updateEntry - automatic data merging
+            await otherServiceEntity.updateEntry(keyValues, { status: 'updated_from_main_service' });
+        }
         return this.base.updateEntry(keyValues, newData);
     } else {
         return this.base.updateEntry(keyValues, newData);

--- a/packages/fe-mockserver-core/src/data/common.ts
+++ b/packages/fe-mockserver-core/src/data/common.ts
@@ -66,6 +66,7 @@ export interface EntitySetInterface {
     isV4(): boolean;
     shouldValidateETag(): boolean;
     isDraft(): boolean;
+    dataAccess: DataAccessInterface;
 }
 export interface DataAccessInterface {
     isV4(): boolean;
@@ -89,6 +90,11 @@ export interface DataAccessInterface {
     getData(odataRequest: ODataRequest): Promise<any>;
     getDraftRoot(keyValues: KeyDefinitions, _tenantId: string, entitySetDefinition: EntitySet): any;
     getMetadata(): ODataMetadata;
+    getOtherServiceEntityInterface(
+        serviceName: string,
+        entityName: string,
+        tenantId?: string
+    ): Promise<FileBasedMockData | undefined>;
     debug: boolean;
     fileLoader: IFileLoader;
     log: ILogger;

--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -33,6 +33,7 @@ import { DraftMockEntitySet } from './entitySets/draftEntitySet';
 import { MockDataEntitySet } from './entitySets/entitySet';
 import { StickyMockEntitySet } from './entitySets/stickyEntitySet';
 import type { ODataMetadata } from './metadata';
+import type { ServiceRegistry } from './serviceRegistry';
 
 type ApplyToExpandTreeFunction = (
     this: DataAccess,
@@ -65,7 +66,8 @@ export class DataAccess implements DataAccessInterface {
         private service: ServiceConfig,
         private metadata: ODataMetadata,
         public fileLoader: IFileLoader,
-        public logger?: ILogger
+        public logger?: ILogger,
+        private serviceRegistry?: ServiceRegistry
     ) {
         this.mockDataRootFolder = service.mockdataPath;
         this.metadata = metadata;
@@ -595,10 +597,56 @@ export class DataAccess implements DataAccessInterface {
         );
     }
 
+    /**
+     * Get the OData metadata for this service.
+     *
+     * @returns The OData metadata
+     */
     public getMetadata(): ODataMetadata {
         return this.metadata;
     }
 
+    /**
+     * Get access to an entity interface from another service.
+     *
+     * @param serviceName - The name/path of the service
+     * @param entityName - The name of the entity
+     * @param tenantId - The tenant ID to use for cross-service access (defaults to 'tenant-default')
+     * @returns The entity interface or undefined if not found
+     */
+    public async getOtherServiceEntityInterface(
+        serviceName: string,
+        entityName: string,
+        tenantId: string = 'tenant-default'
+    ): Promise<FileBasedMockData | undefined> {
+        if (!this.serviceRegistry) {
+            throw new Error('Cross-service access is not enabled. ServiceRegistry not available.');
+        }
+
+        const otherService = this.serviceRegistry.getService(serviceName);
+        if (!otherService) {
+            throw new Error(
+                `Service '${serviceName}' not found in registry. Available services: ${this.serviceRegistry
+                    .getServiceNames()
+                    .join(', ')}`
+            );
+        }
+
+        const entitySet = await otherService.getMockEntitySet(entityName);
+        if (!entitySet) {
+            throw new Error(`Entity '${entityName}' not found in service '${serviceName}'`);
+        }
+
+        return entitySet.getMockData(tenantId); // Use the provided tenant ID for cross-service access
+    }
+
+    /**
+     * Get data based on an OData request.
+     *
+     * @param odataRequest - The OData request
+     * @param dontClone - Whether to avoid cloning the data
+     * @returns The requested data
+     */
     public async getData(odataRequest: ODataRequest, dontClone: boolean = false): Promise<any> {
         this.log.info(`Retrieving data for ${JSON.stringify(odataRequest.queryPath)}`);
         let currentEntitySet: EntitySet | Singleton | undefined;

--- a/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/entitySet.ts
@@ -244,7 +244,7 @@ export class MockDataEntitySet implements EntitySetInterface {
     public readyPromise: Promise<EntitySetInterface>;
     protected entitySetDefinition: EntitySet | null;
     protected entityTypeDefinition: EntityType;
-    protected dataAccess: DataAccessInterface;
+    public dataAccess: DataAccessInterface;
     /**
      * @param rootFolder
      * @param entitySetDefinition

--- a/packages/fe-mockserver-core/src/data/serviceRegistry.ts
+++ b/packages/fe-mockserver-core/src/data/serviceRegistry.ts
@@ -1,0 +1,35 @@
+import type { DataAccessInterface } from './common';
+
+/**
+ * Registry for managing cross-service communication in the mockserver.
+ * Allows services to access entity interfaces from other services in a controlled manner.
+ */
+export class ServiceRegistry {
+    private readonly services: Map<string, DataAccessInterface> = new Map();
+
+    /**
+     * Register a service with its DataAccess instance
+     * @param serviceName - The name/path of the service
+     * @param dataAccess - The DataAccess instance for this service
+     */
+    public registerService(serviceName: string, dataAccess: DataAccessInterface): void {
+        this.services.set(serviceName, dataAccess);
+    }
+
+    /**
+     * Get a DataAccess instance for a specific service
+     * @param serviceName - The name/path of the service
+     * @returns The DataAccess instance or undefined if not found
+     */
+    public getService(serviceName: string): DataAccessInterface | undefined {
+        return this.services.get(serviceName);
+    }
+
+    /**
+     * Get all registered service names
+     * @returns Array of service names
+     */
+    public getServiceNames(): string[] {
+        return Array.from(this.services.keys());
+    }
+}

--- a/packages/fe-mockserver-core/src/middleware.ts
+++ b/packages/fe-mockserver-core/src/middleware.ts
@@ -6,6 +6,7 @@ import type { IRouter } from 'router';
 import Router from 'router';
 import { DataAccess } from './data/dataAccess';
 import { ODataMetadata } from './data/metadata';
+import { ServiceRegistry } from './data/serviceRegistry';
 import type { IFileLoader, IMetadataProcessor } from './index';
 import { getLogger } from './logger';
 import { getMetadataProcessor } from './pluginsManager';
@@ -81,6 +82,9 @@ export async function createMockMiddleware(
     if (newConfig.services.length === 0) {
         log.info('No services configured. Skipping mockserver setup.');
     }
+
+    // Create service registry for cross-service communication
+    const serviceRegistry = new ServiceRegistry();
     const oDataHandlerPromises = newConfig.services.map(async (mockServiceIn: ServiceConfig) => {
         const mockService = mockServiceIn as ServiceConfigEx;
         const splittedPath = mockService.urlPath.split('/');
@@ -109,7 +113,10 @@ export async function createMockMiddleware(
             }
 
             let metadata = await loadMetadata(mockService, processor);
-            const dataAccess = new DataAccess(mockService, metadata, fileLoader, newConfig.logger);
+            const dataAccess = new DataAccess(mockService, metadata, fileLoader, newConfig.logger, serviceRegistry);
+
+            // Register this service for cross-service access
+            serviceRegistry.registerService(mockService.urlPath, dataAccess);
 
             if (mockService.watch) {
                 const watchPath = [mockService.mockdataPath];

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -613,6 +613,13 @@ export class FileBasedMockData {
         return this._mockDataEntitySet.getEntityInterface(entitySetName, this._contextId);
     }
 
+    async getOtherServiceEntityInterface(
+        serviceName: string,
+        entityName: string
+    ): Promise<FileBasedMockData | undefined> {
+        return await this._mockDataEntitySet.dataAccess.getOtherServiceEntityInterface(serviceName, entityName);
+    }
+
     generateMockData() {
         const mockData: any[] = [];
         for (let i = 0; i < 150; i++) {

--- a/packages/fe-mockserver-core/test/unit/crossServiceCommunication.test.ts
+++ b/packages/fe-mockserver-core/test/unit/crossServiceCommunication.test.ts
@@ -1,0 +1,145 @@
+import type { ServiceConfig } from '../../src/api';
+import { DataAccess } from '../../src/data/dataAccess';
+import type { ODataMetadata } from '../../src/data/metadata';
+import { ServiceRegistry } from '../../src/data/serviceRegistry';
+import FileSystemLoader from '../../src/plugins/fileSystemLoader';
+
+describe('Cross-Service Communication', () => {
+    test('ServiceRegistry should register and retrieve services', () => {
+        const serviceRegistry = new ServiceRegistry();
+
+        // Mock DataAccess instances
+        const firstServiceDataAccess = {
+            isV4: () => true,
+            shouldValidateETag: () => false,
+            getNavigationPropertyKeys: jest.fn(),
+            getMockEntitySet: jest.fn(),
+            getData: jest.fn(),
+            getDraftRoot: jest.fn(),
+            getMetadata: jest.fn(),
+            getOtherServiceEntityInterface: jest.fn(),
+            debug: false,
+            fileLoader: {} as any,
+            log: {} as any
+        };
+
+        const secondServiceDataAccess = {
+            isV4: () => true,
+            shouldValidateETag: () => false,
+            getNavigationPropertyKeys: jest.fn(),
+            getMockEntitySet: jest.fn(),
+            getData: jest.fn(),
+            getDraftRoot: jest.fn(),
+            getMetadata: jest.fn(),
+            getOtherServiceEntityInterface: jest.fn(),
+            debug: false,
+            fileLoader: {} as any,
+            log: {} as any
+        };
+
+        // Register services
+        serviceRegistry.registerService('/firstService', firstServiceDataAccess);
+        serviceRegistry.registerService('/secondService', secondServiceDataAccess);
+
+        // Test retrieval
+        expect(serviceRegistry.getService('/firstService')).toBe(firstServiceDataAccess);
+        expect(serviceRegistry.getService('/secondService')).toBe(secondServiceDataAccess);
+        expect(serviceRegistry.getService('/nonExistentService')).toBeUndefined();
+
+        // Test service names
+        const serviceNames = serviceRegistry.getServiceNames();
+        expect(serviceNames).toContain('/firstService');
+        expect(serviceNames).toContain('/secondService');
+        expect(serviceNames).toHaveLength(2);
+    });
+
+    test('DataAccess should have getOtherServiceEntityInterface method', () => {
+        const serviceRegistry = new ServiceRegistry();
+        const fileLoader = new FileSystemLoader();
+
+        const mockService: ServiceConfig = {
+            urlPath: '/testService',
+            metadataPath: 'test.xml',
+            mockdataPath: 'testdata'
+        };
+
+        const mockMetadata = {
+            getEntitySet: jest.fn(),
+            getEntityType: jest.fn(),
+            getEntityContainerPath: jest.fn(),
+            getAction: jest.fn(),
+            getFunction: jest.fn(),
+            resolvePath: jest.fn(),
+            schema: {} as any,
+            getSingleton: jest.fn(),
+            references: [],
+            getVersion: jest.fn().mockReturnValue('4.0'),
+            getEntitySets: jest.fn().mockReturnValue([]), // Return empty array to avoid forEach error
+            getSingletons: jest.fn().mockReturnValue([]), // Return empty array to avoid forEach error
+            getMetadataUrl: jest.fn()
+        } as unknown as ODataMetadata;
+
+        const dataAccess = new DataAccess(mockService, mockMetadata, fileLoader, undefined, serviceRegistry);
+
+        // Verify the method exists
+        expect(typeof dataAccess.getOtherServiceEntityInterface).toBe('function');
+    });
+
+    test('Enhanced cross-service interface should have simplified updateEntry behavior', async () => {
+        // Create mock FileBasedMockData with test data
+        const mockRawInterface = {
+            fetchEntries: jest
+                .fn()
+                .mockResolvedValue([
+                    { ID: 1, name: 'Original Name', description: 'Original Description', status: 'active' }
+                ]),
+            updateEntry: jest.fn().mockResolvedValue(undefined)
+        };
+
+        // Mock getOtherServiceEntityInterface to return our enhanced interface
+        const mockGetOtherService = jest.fn().mockResolvedValue(mockRawInterface);
+
+        // Create a mock base object similar to what exists in FunctionBasedMockData
+        const mockBase = {
+            getOtherServiceEntityInterface: async (serviceName: string, entityName: string) => {
+                const rawInterface = await mockGetOtherService(serviceName, entityName);
+
+                if (!rawInterface) {
+                    return rawInterface;
+                }
+
+                // Apply the same enhancement as in the actual code
+                const enhancedInterface = Object.create(rawInterface);
+                enhancedInterface.updateEntry = async (keyValues: any, patchData: object) => {
+                    const existingData = (await rawInterface.fetchEntries(keyValues, {}))[0];
+                    const updatedData = Object.assign({}, existingData, patchData);
+                    return await rawInterface.updateEntry(keyValues, updatedData, patchData, {});
+                };
+
+                return enhancedInterface;
+            }
+        };
+
+        // Test the enhanced interface
+        const enhancedInterface = await mockBase.getOtherServiceEntityInterface('/other/service', 'TestEntity');
+
+        // Call updateEntry with only partial data (like this.base.updateEntry)
+        await enhancedInterface!.updateEntry({ ID: 1 }, { description: 'Updated Description' });
+
+        // Verify it fetched existing data first
+        expect(mockRawInterface.fetchEntries).toHaveBeenCalledWith({ ID: 1 }, {});
+
+        // Verify it called the raw updateEntry with merged data
+        expect(mockRawInterface.updateEntry).toHaveBeenCalledWith(
+            { ID: 1 },
+            {
+                ID: 1,
+                name: 'Original Name',
+                description: 'Updated Description', // Updated field
+                status: 'active' // Preserved field
+            },
+            { description: 'Updated Description' },
+            {}
+        );
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,7 +219,31 @@ importers:
         specifier: 3.0.2
         version: 3.0.2
 
+  samples/function-cross:
+    devDependencies:
+      '@sap-ux/ui5-middleware-fe-mockserver':
+        specifier: workspace:*
+        version: link:../../packages/ui5-middleware-fe-mockserver
+      '@ui5/cli':
+        specifier: 3.11.5
+        version: 3.11.5
+      rimraf:
+        specifier: 3.0.2
+        version: 3.0.2
+
   samples/function-import:
+    devDependencies:
+      '@sap-ux/ui5-middleware-fe-mockserver':
+        specifier: workspace:*
+        version: link:../../packages/ui5-middleware-fe-mockserver
+      '@ui5/cli':
+        specifier: 3.11.5
+        version: 3.11.5
+      rimraf:
+        specifier: 3.0.2
+        version: 3.0.2
+
+  samples/function-import-cross:
     devDependencies:
       '@sap-ux/ui5-middleware-fe-mockserver':
         specifier: workspace:*
@@ -376,10 +400,6 @@ packages:
     resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.24.8':
-    resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
@@ -411,11 +431,6 @@ packages:
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.25.3':
-    resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.26.2':
     resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
@@ -878,10 +893,6 @@ packages:
 
   '@babel/traverse@7.25.9':
     resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.25.2':
-    resolution: {integrity: sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.0':
@@ -4388,9 +4399,6 @@ packages:
   spdx-correct@3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
 
-  spdx-exceptions@2.3.0:
-    resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==}
-
   spdx-exceptions@2.5.0:
     resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
 
@@ -4399,9 +4407,6 @@ packages:
 
   spdx-expression-parse@4.0.0:
     resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
-
-  spdx-license-ids@3.0.11:
-    resolution: {integrity: sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==}
 
   spdx-license-ids@3.0.18:
     resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
@@ -4564,10 +4569,6 @@ packages:
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
-
-  to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5004,10 +5005,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
       '@babel/helpers': 7.25.0
-      '@babel/parser': 7.25.3
+      '@babel/parser': 7.26.2
       '@babel/template': 7.25.0
       '@babel/traverse': 7.25.3
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
       convert-source-map: 2.0.0
       debug: 4.3.6
       gensync: 1.0.0-beta.2
@@ -5018,7 +5019,7 @@ snapshots:
 
   '@babel/generator@7.25.0':
     dependencies:
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
@@ -5099,7 +5100,7 @@ snapshots:
   '@babel/helper-module-imports@7.24.7':
     dependencies:
       '@babel/traverse': 7.25.3
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5115,7 +5116,7 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-validator-identifier': 7.25.9
       '@babel/traverse': 7.25.3
     transitivePeerDependencies:
       - supports-color
@@ -5158,7 +5159,7 @@ snapshots:
   '@babel/helper-simple-access@7.24.7':
     dependencies:
       '@babel/traverse': 7.25.3
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5175,8 +5176,6 @@ snapshots:
       '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helper-string-parser@7.24.8': {}
 
   '@babel/helper-string-parser@7.25.9': {}
 
@@ -5199,7 +5198,7 @@ snapshots:
   '@babel/helpers@7.25.0':
     dependencies:
       '@babel/template': 7.25.0
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -5207,10 +5206,6 @@ snapshots:
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
-
-  '@babel/parser@7.25.3':
-    dependencies:
-      '@babel/types': 7.25.2
 
   '@babel/parser@7.26.2':
     dependencies:
@@ -5743,7 +5738,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
       esutils: 2.0.3
 
   '@babel/runtime@7.25.0':
@@ -5754,7 +5749,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/parser': 7.26.2
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
 
   '@babel/template@7.25.9':
     dependencies:
@@ -5768,7 +5763,7 @@ snapshots:
       '@babel/generator': 7.25.0
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.0
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
       debug: 4.3.6
       globals: 11.12.0
     transitivePeerDependencies:
@@ -5785,12 +5780,6 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.25.2':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
 
   '@babel/types@7.26.0':
     dependencies:
@@ -6163,7 +6152,7 @@ snapshots:
       jest-haste-map: 29.7.0
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pirates: 4.0.6
       slash: 3.0.0
       write-file-atomic: 4.0.2
@@ -6577,23 +6566,23 @@ snapshots:
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.26.2
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
 
   '@types/babel__template@7.4.4':
     dependencies:
       '@babel/parser': 7.26.2
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
 
   '@types/balanced-match@1.0.4': {}
 
@@ -6853,7 +6842,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       globby: 13.2.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       minimatch: 9.0.3
       pretty-hrtime: 1.0.3
       random-int: 3.0.0
@@ -7074,7 +7063,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.25.0
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
@@ -7874,7 +7863,7 @@ snapshots:
 
   execa@4.1.0:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 5.2.0
       human-signals: 1.1.1
       is-stream: 2.0.1
@@ -7886,7 +7875,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -7898,7 +7887,7 @@ snapshots:
 
   execa@7.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 4.3.1
       is-stream: 3.0.0
@@ -7977,7 +7966,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.7
+      micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -8065,7 +8054,7 @@ snapshots:
 
   find-yarn-workspace-root@2.0.0:
     dependencies:
-      micromatch: 4.0.7
+      micromatch: 4.0.8
 
   findit2@2.2.3: {}
 
@@ -8089,7 +8078,7 @@ snapshots:
 
   foreground-child@3.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       signal-exit: 4.0.2
 
   form-data-encoder@2.1.4: {}
@@ -8544,7 +8533,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/parser': 7.25.3
+      '@babel/parser': 7.26.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.6.3
@@ -8653,7 +8642,7 @@ snapshots:
       jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       parse-json: 5.2.0
       pretty-format: 29.7.0
       slash: 3.0.0
@@ -8706,7 +8695,7 @@ snapshots:
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       jest-worker: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -8825,7 +8814,7 @@ snapshots:
       '@babel/generator': 7.25.0
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.2)
       '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.25.2)
-      '@babel/types': 7.25.2
+      '@babel/types': 7.26.0
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -10094,23 +10083,19 @@ snapshots:
   spdx-correct@3.1.1:
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.11
-
-  spdx-exceptions@2.3.0: {}
+      spdx-license-ids: 3.0.18
 
   spdx-exceptions@2.5.0: {}
 
   spdx-expression-parse@3.0.1:
     dependencies:
-      spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.11
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.18
 
   spdx-expression-parse@4.0.0:
     dependencies:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.18
-
-  spdx-license-ids@3.0.11: {}
 
   spdx-license-ids@3.0.18: {}
 
@@ -10279,8 +10264,6 @@ snapshots:
       os-tmpdir: 1.0.2
 
   tmpl@1.0.5: {}
-
-  to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/samples/function-cross/.gitignore
+++ b/samples/function-cross/.gitignore
@@ -1,0 +1,17 @@
+# build results
+dist
+coverage
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependency directories
+node_modules/
+
+.DS_Store
+.env
+tmp/

--- a/samples/function-cross/README.md
+++ b/samples/function-cross/README.md
@@ -1,0 +1,87 @@
+# UI5 Application sap.fe.mockserver.functioncross
+
+Insert the purpose of this project and some interesting info here...
+
+## Description
+
+This app demonstrates a setup for developing UI5 applications.
+
+## Requirements
+
+Either [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/) for dependency management.
+
+## Preparation
+
+Use `npm` (or `yarn`) to install the dependencies:
+
+```sh
+npm install
+```
+
+(To use yarn, just do `yarn` instead.)
+
+## Run the App
+
+Execute the following command to run the app locally for development in watch mode (the browser reloads the app automatically when there are changes in the source code):
+
+```sh
+npm start
+```
+
+As shown in the terminal after executing this command, the app is then running on http://localhost:8080/index.html. A browser window with this URL should automatically open.
+
+(When using yarn, do `yarn start` instead.)
+
+## Build the App
+
+### Unoptimized (but quick)
+
+Execute the following command to build the project and get an app that can be deployed:
+
+```sh
+npm run build
+```
+
+The result is placed into the `dist` folder. To start the generated package, just run
+
+```sh
+npm run start:dist
+```
+
+Note that `index.html` still loads the UI5 framework from the relative URL `resources/...`, which does not physically exist, but is only provided dynamically by the UI5 tooling. So for an actual deployment you should change this URL to either [the CDN](https://sdk.openui5.org/#/topic/2d3eb2f322ea4a82983c1c62a33ec4ae) or your local deployment of UI5.
+
+(When using yarn, do `yarn build` and `yarn start:dist` instead.)
+
+### Optimized
+
+For an optimized self-contained build (takes longer because the UI5 resources are built, too), do:
+
+```sh
+npm run build:opt
+```
+
+To start the generated package, again just run:
+
+```sh
+npm run start:dist
+```
+
+In this case, all UI5 framework resources are also available within the `dist` folder, so the folder can be deployed as-is to any static web server, without changing the bootstrap URL.
+
+With the self-contained build, the bootstrap URL in `index.html` has already been modified to load the newly created `sap-ui-custom.js` for bootstrapping, which contains all app resources as well as all needed UI5 JavaScript resources. Most UI5 resources inside the `dist` folder are for this reason actually **not** needed to run the app. Only the non-JS-files, like translation texts and CSS files, are used and must also be deployed. (Only when for some reason JS files are missing from the optimized self-contained bundle, they are also loaded separately.)
+
+(When using yarn, do `yarn build:opt` and `yarn start:dist` instead.)
+
+## Check the Code
+
+To lint the code, do:
+
+```sh
+npm run lint
+```
+
+(Again, when using yarn, do `yarn lint` instead.)
+
+## License
+
+This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](LICENSE) file.

--- a/samples/function-cross/package.json
+++ b/samples/function-cross/package.json
@@ -5,7 +5,8 @@
     "author": "„marianfoo“",
     "license": "Apache-2.0",
     "scripts": {
-        "start": "ui5 serve --port 8080 -o index-cdn.html"
+        "start": "ui5 serve --port 8080 -o index-cdn.html",
+        "start:silent": "ui5 serve --port 8080"
     },
     "devDependencies": {
         "@sap-ux/ui5-middleware-fe-mockserver": "workspace:*",

--- a/samples/function-cross/package.json
+++ b/samples/function-cross/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "sap.fe.mockserver.functioncross",
+    "version": "1.0.0",
+    "description": "UI5 Application: sap.fe.mockserver.functioncross",
+    "author": "„marianfoo“",
+    "license": "Apache-2.0",
+    "scripts": {
+        "start": "ui5 serve --port 8080 -o index-cdn.html"
+    },
+    "devDependencies": {
+        "@sap-ux/ui5-middleware-fe-mockserver": "workspace:*",
+        "@ui5/cli": "3.11.5",
+        "rimraf": "3.0.2"
+    }
+}

--- a/samples/function-cross/ui5.yaml
+++ b/samples/function-cross/ui5.yaml
@@ -1,0 +1,20 @@
+specVersion: '2.4'
+metadata:
+    name: sap.fe.mockserver.functioncross
+type: application
+server:
+    customMiddleware:
+        - name: sap-fe-mockserver
+          beforeMiddleware: compression
+          configuration:
+              services:
+                  - urlBasePath: /here/goes/your/firstService
+                    name: ''
+                    generateMockData: false
+                    metadataPath: ./webapp/localService/firstService/metadata.xml
+                    mockdataPath: ./webapp/localService/firstService/mockdata
+                  - urlBasePath: /here/goes/your/secondService
+                    name: ''
+                    generateMockData: false
+                    metadataPath: ./webapp/localService/secondService/metadata.xml
+                    mockdataPath: ./webapp/localService/secondService/mockdata

--- a/samples/function-cross/webapp/Component.js
+++ b/samples/function-cross/webapp/Component.js
@@ -1,0 +1,44 @@
+sap.ui.define(['sap/ui/core/UIComponent', 'sap/ui/Device', './model/models'], function (UIComponent, Device, models) {
+    'use strict';
+
+    return UIComponent.extend('sap.fe.mockserver.functioncross.Component', {
+        metadata: {
+            manifest: 'json',
+            interfaces: ['sap.ui.core.IAsyncContentCreation']
+        },
+        init: function () {
+            // call the base component's init function
+            UIComponent.prototype.init.call(this); // create the views based on the url/hash
+
+            // create the device model
+            this.setModel(models.createDeviceModel(), 'device');
+
+            // create the views based on the url/hash
+            this.getRouter().initialize();
+        },
+        /**
+         * This method can be called to determine whether the sapUiSizeCompact or sapUiSizeCozy
+         * design mode class should be set, which influences the size appearance of some controls.
+         * @public
+         * @returns {string} css class, either 'sapUiSizeCompact' or 'sapUiSizeCozy' - or an empty string if no css class should be set
+         */
+        getContentDensityClass: function () {
+            if (this.contentDensityClass === undefined) {
+                // check whether FLP has already set the content density class; do nothing in this case
+                if (
+                    document.body.classList.contains('sapUiSizeCozy') ||
+                    document.body.classList.contains('sapUiSizeCompact')
+                ) {
+                    this.contentDensityClass = '';
+                } else if (!Device.support.touch) {
+                    // apply "compact" mode if touch is not supported
+                    this.contentDensityClass = 'sapUiSizeCompact';
+                } else {
+                    // "cozy" in case of touch support; default for most sap.m controls, but needed for desktop-first controls like sap.ui.table.Table
+                    this.contentDensityClass = 'sapUiSizeCozy';
+                }
+            }
+            return this.contentDensityClass;
+        }
+    });
+});

--- a/samples/function-cross/webapp/controller/App.controller.js
+++ b/samples/function-cross/webapp/controller/App.controller.js
@@ -1,0 +1,10 @@
+sap.ui.define(['./BaseController'], function (BaseController) {
+    'use strict';
+
+    return BaseController.extend('sap.fe.mockserver.functioncross.controller.App', {
+        onInit: function () {
+            // apply content density mode to root view
+            this.getView().addStyleClass(this.getOwnerComponent().getContentDensityClass());
+        }
+    });
+});

--- a/samples/function-cross/webapp/controller/BaseController.js
+++ b/samples/function-cross/webapp/controller/BaseController.js
@@ -1,0 +1,78 @@
+sap.ui.define(
+    ['sap/ui/core/mvc/Controller', 'sap/ui/core/UIComponent', 'sap/ui/core/routing/History'],
+    function (Controller, UIComponent, History) {
+        'use strict';
+
+        return Controller.extend('sap.fe.mockserver.functioncross.controller.BaseController', {
+            /**
+             * Convenience method for accessing the component of the controller's view.
+             * @returns {sap.ui.core.Component} The component of the controller's view
+             */
+            getOwnerComponent: function () {
+                return Controller.prototype.getOwnerComponent.call(this);
+            },
+
+            /**
+             * Convenience method to get the components' router instance.
+             * @returns {sap.m.routing.Router} The router instance
+             */
+            getRouter: function () {
+                return UIComponent.getRouterFor(this);
+            },
+
+            /**
+             * Convenience method for getting the i18n resource bundle of the component.
+             * @returns {Promise<sap.base.i18n.ResourceBundle>} The i18n resource bundle of the component
+             */
+            getResourceBundle: function () {
+                const oModel = this.getOwnerComponent().getModel('i18n');
+                return oModel.getResourceBundle();
+            },
+
+            /**
+             * Convenience method for getting the view model by name in every controller of the application.
+             * @param {string} [sName] The model name
+             * @returns {sap.ui.model.Model} The model instance
+             */
+            getModel: function (sName) {
+                return this.getView().getModel(sName);
+            },
+
+            /**
+             * Convenience method for setting the view model in every controller of the application.
+             * @param {sap.ui.model.Model} oModel The model instance
+             * @param {string} [sName] The model name
+             * @returns {sap.ui.core.mvc.Controller} The current base controller instance
+             */
+            setModel: function (oModel, sName) {
+                this.getView().setModel(oModel, sName);
+                return this;
+            },
+
+            /**
+             * Convenience method for triggering the navigation to a specific target.
+             * @public
+             * @param {string} sName Target name
+             * @param {object} [oParameters] Navigation parameters
+             * @param {boolean} [bReplace] Defines if the hash should be replaced (no browser history entry) or set (browser history entry)
+             */
+            navTo: function (sName, oParameters, bReplace) {
+                this.getRouter().navTo(sName, oParameters, undefined, bReplace);
+            },
+
+            /**
+             * Convenience event handler for navigating back.
+             * It there is a history entry we go one step back in the browser history
+             * If not, it will replace the current entry of the browser history with the main route.
+             */
+            onNavBack: function () {
+                const sPreviousHash = History.getInstance().getPreviousHash();
+                if (sPreviousHash !== undefined) {
+                    window.history.go(-1);
+                } else {
+                    this.getRouter().navTo('main', {}, undefined, true);
+                }
+            }
+        });
+    }
+);

--- a/samples/function-cross/webapp/controller/Main.controller.js
+++ b/samples/function-cross/webapp/controller/Main.controller.js
@@ -15,6 +15,11 @@ sap.ui.define(['./BaseController', 'sap/m/MessageToast'], function (BaseControll
                 .invoke()
                 .then(() => {
                     MessageToast.show('Action executed successfully on First Service');
+                    // update both tables
+                    const table1 = this.getView().byId('table1');
+                    const table2 = this.getView().byId('table2');
+                    table1.getBinding('items').refresh();
+                    table2.getBinding('items').refresh();
                 })
                 .catch((error) => {
                     MessageToast.show('Action failed on First Service: ' + error.message);

--- a/samples/function-cross/webapp/controller/Main.controller.js
+++ b/samples/function-cross/webapp/controller/Main.controller.js
@@ -1,0 +1,45 @@
+sap.ui.define(['./BaseController', 'sap/m/MessageToast'], function (BaseController, MessageToast) {
+    'use strict';
+
+    return BaseController.extend('sap.fe.mockserver.functioncross.controller.Main', {
+        /**
+         * Execute action on first service (default model)
+         */
+        onExecuteFirstServiceAction: function () {
+            const oModel = this.getView().getModel(); // Default model = first service
+            const actionPath = '/RootEntity(ID=1,IsActiveEntity=true)/sap.fe.test.TestService.myCustomAction(...)';
+
+            const actionBinding = oModel.bindContext(actionPath);
+
+            actionBinding
+                .invoke()
+                .then(() => {
+                    MessageToast.show('Action executed successfully on First Service');
+                })
+                .catch((error) => {
+                    MessageToast.show('Action failed on First Service: ' + error.message);
+                    console.error('First service action error:', error);
+                });
+        },
+
+        /**
+         * Execute action on second service (secondService model)
+         */
+        onExecuteSecondServiceAction: function () {
+            const oModel = this.getView().getModel('secondService'); // Named model = second service
+            const actionPath = '/RootEntity(ID=1,IsActiveEntity=true)/sap.fe.test.TestService.myCustomAction(...)';
+
+            const actionBinding = oModel.bindContext(actionPath);
+
+            actionBinding
+                .invoke()
+                .then(() => {
+                    MessageToast.show('Action executed successfully on Second Service');
+                })
+                .catch((error) => {
+                    MessageToast.show('Action failed on Second Service: ' + error.message);
+                    console.error('Second service action error:', error);
+                });
+        }
+    });
+});

--- a/samples/function-cross/webapp/i18n/i18n.properties
+++ b/samples/function-cross/webapp/i18n/i18n.properties
@@ -1,0 +1,3 @@
+appTitle=sap.fe.mockserver.functioncross
+appDescription=UI5 Application sap.fe.mockserver.functioncross
+btnText=Say Hello

--- a/samples/function-cross/webapp/i18n/i18n_de.properties
+++ b/samples/function-cross/webapp/i18n/i18n_de.properties
@@ -1,0 +1,3 @@
+appTitle=sap.fe.mockserver.functioncross
+appDescription=UI5 Application sap.fe.mockserver.functioncross
+btnText=Sag Hallo

--- a/samples/function-cross/webapp/i18n/i18n_en.properties
+++ b/samples/function-cross/webapp/i18n/i18n_en.properties
@@ -1,0 +1,3 @@
+appTitle=sap.fe.mockserver.functioncross
+appDescription=UI5 Application sap.fe.mockserver.functioncross
+btnText=Say Hello

--- a/samples/function-cross/webapp/index-cdn.html
+++ b/samples/function-cross/webapp/index-cdn.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate" />
+        <meta http-equiv="Pragma" content="no-cache" />
+        <meta http-equiv="expires" content="0" />
+        <meta charset="utf-8" />
+
+        <title>UI5 Application: sap.fe.mockserver.functioncross</title>
+
+        <script
+            id="sap-ui-bootstrap"
+            src="https://ui5.sap.com/1.138.1/resources/sap-ui-core.js"
+            data-sap-ui-resourceroots='{
+				"sap.fe.mockserver.functioncross": "./"
+			}'
+            data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
+            data-sap-ui-async="true"
+            data-sap-ui-compatVersion="edge"
+            data-sap-ui-frameOptions="trusted"></script>
+    </head>
+
+    <body class="sapUiBody">
+        <div data-sap-ui-component data-name="sap.fe.mockserver.functioncross"></div>
+    </body>
+</html>

--- a/samples/function-cross/webapp/index.html
+++ b/samples/function-cross/webapp/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate" />
+        <meta http-equiv="Pragma" content="no-cache" />
+        <meta http-equiv="expires" content="0" />
+        <meta charset="utf-8" />
+
+        <title>UI5 Application: sap.fe.mockserver.functioncross</title>
+
+        <script
+            id="sap-ui-bootstrap"
+            src="resources/sap-ui-core.js"
+            data-sap-ui-resourceroots='{
+				"sap.fe.mockserver.functioncross": "./"
+			}'
+            data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
+            data-sap-ui-async="true"
+            data-sap-ui-compatVersion="edge"
+            data-sap-ui-frameOptions="trusted"></script>
+    </head>
+
+    <body class="sapUiBody">
+        <div data-sap-ui-component data-name="sap.fe.mockserver.functioncross"></div>
+    </body>
+</html>

--- a/samples/function-cross/webapp/localService/firstService/metadata.xml
+++ b/samples/function-cross/webapp/localService/firstService/metadata.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+    <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="sap.fe.test.TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="RootEntity" EntityType="sap.fe.test.TestService.RootEntity">
+          <NavigationPropertyBinding Path="SiblingEntity" Target="RootEntity"/>
+        </EntitySet>
+      </EntityContainer>
+      <EntityType Name="RootEntity">
+        <Key>
+          <PropertyRef Name="ID"/>
+          <PropertyRef Name="IsActiveEntity"/>
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="name" Type="Edm.String"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+        <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+        <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="sap.fe.test.TestService.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="sap.fe.test.TestService.RootEntity"/>
+      </EntityType>
+
+      <EntityType Name="DraftAdministrativeData">
+        <Key>
+          <PropertyRef Name="DraftUUID"/>
+        </Key>
+        <Property Name="DraftUUID" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="CreationDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+        <Property Name="CreatedByUser" Type="Edm.String" MaxLength="256"/>
+        <Property Name="DraftIsCreatedByMe" Type="Edm.Boolean"/>
+        <Property Name="LastChangeDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+        <Property Name="LastChangedByUser" Type="Edm.String" MaxLength="256"/>
+        <Property Name="InProcessByUser" Type="Edm.String" MaxLength="256"/>
+        <Property Name="DraftIsProcessedByMe" Type="Edm.Boolean"/>
+      </EntityType>
+      <Action Name="myCustomAction" IsBound="true" EntitySetPath="in">
+        <Parameter Name="in" Type="sap.fe.test.TestService.RootEntity"/>
+      </Action>
+      <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+        <Parameter Name="in" Type="sap.fe.test.TestService.RootEntity"/>
+        <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+        <ReturnType Type="sap.fe.test.TestService.RootEntity"/>
+      </Action>
+      <Action Name="draftActivate" IsBound="true" EntitySetPath="in">
+        <Parameter Name="in" Type="sap.fe.test.TestService.RootEntity"/>
+        <ReturnType Type="sap.fe.test.TestService.RootEntity"/>
+      </Action>
+      <Action Name="draftEdit" IsBound="true" EntitySetPath="in">
+        <Parameter Name="in" Type="sap.fe.test.TestService.RootEntity"/>
+        <Parameter Name="PreserveChanges" Type="Edm.Boolean"/>
+        <ReturnType Type="sap.fe.test.TestService.RootEntity"/>
+      </Action>
+      <Annotations Target="sap.fe.test.TestService.RootEntity">
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="name"/>
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+                <PropertyValue Property="Label" String="Change Description"/>
+                <PropertyValue Property="Action" String="sap.fe.test.TestService.myCustomAction"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="description"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.EntityContainer/RootEntity">
+        <Annotation Term="Common.DraftRoot">
+          <Record Type="Common.DraftRootType">
+            <PropertyValue Property="ActivationAction" String="sap.fe.test.TestService.draftActivate"/>
+            <PropertyValue Property="EditAction" String="sap.fe.test.TestService.draftEdit"/>
+            <PropertyValue Property="PreparationAction" String="sap.fe.test.TestService.draftPrepare"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/ID">
+        <Annotation Term="Common.Text" Path="name">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextOnly"/>
+        </Annotation>
+        <Annotation Term="Common.Label" String="ID"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/name">
+        <Annotation Term="Common.Label" String="Name"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/description">
+        <Annotation Term="Common.Label" String="Description"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/IsActiveEntity">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/HasActiveEntity">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/HasDraftEntity">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/DraftAdministrativeData">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData">
+        <Annotation Term="Common.Label" String="{i18n>Draft_DraftAdministrativeData}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/DraftUUID">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+        <Annotation Term="Common.Label" String="{i18n>Draft_DraftUUID}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/CreationDateTime">
+        <Annotation Term="Common.Label" String="{i18n>Draft_CreationDateTime}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/CreatedByUser">
+        <Annotation Term="Common.Label" String="{i18n>Draft_CreatedByUser}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/DraftIsCreatedByMe">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+        <Annotation Term="Common.Label" String="{i18n>Draft_DraftIsCreatedByMe}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/LastChangeDateTime">
+        <Annotation Term="Common.Label" String="{i18n>Draft_LastChangeDateTime}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/LastChangedByUser">
+        <Annotation Term="Common.Label" String="{i18n>Draft_LastChangedByUser}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/InProcessByUser">
+        <Annotation Term="Common.Label" String="{i18n>Draft_InProcessByUser}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/DraftIsProcessedByMe">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+        <Annotation Term="Common.Label" String="{i18n>Draft_DraftIsProcessedByMe}"/>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/samples/function-cross/webapp/localService/firstService/mockdata/RootEntity.js
+++ b/samples/function-cross/webapp/localService/firstService/mockdata/RootEntity.js
@@ -1,0 +1,7 @@
+module.exports = {
+    executeAction: function (actionDefinition, actionData, keys) {
+        console.log('Updating the data for ' + JSON.stringify(keys));
+        this.base.updateEntry(keys, { description: 'My Custom Description' });
+        // update a entry from second service, is it possible?
+    }
+};

--- a/samples/function-cross/webapp/localService/firstService/mockdata/RootEntity.js
+++ b/samples/function-cross/webapp/localService/firstService/mockdata/RootEntity.js
@@ -1,7 +1,24 @@
 module.exports = {
     executeAction: function (actionDefinition, actionData, keys) {
+        'use strict';
         console.log('Updating the data for ' + JSON.stringify(keys));
         this.base.updateEntry(keys, { description: 'My Custom Description' });
-        // update a entry from second service, is it possible?
+
+        // Cross-service update - update an entry in the second service
+        this.base
+            .getOtherServiceEntityInterface('/here/goes/your/secondService/', 'RootEntity')
+            .then(function (secondServiceEntityInterface) {
+                if (secondServiceEntityInterface) {
+                    return secondServiceEntityInterface.updateEntry(keys, {
+                        description: 'Updated from First Service at ' + new Date().toISOString()
+                    });
+                }
+            })
+            .then(function () {
+                console.log('Successfully updated entity in second service');
+            })
+            .catch(function (error) {
+                console.error('Error updating second service:', error.message);
+            });
     }
 };

--- a/samples/function-cross/webapp/localService/firstService/mockdata/RootEntity.json
+++ b/samples/function-cross/webapp/localService/firstService/mockdata/RootEntity.json
@@ -1,0 +1,12 @@
+[
+    {
+        "ID": 1,
+        "name": "First element",
+        "description": "First description"
+    },
+    {
+        "ID": 2,
+        "name": "Second element",
+        "description": "Second description"
+    }
+]

--- a/samples/function-cross/webapp/localService/secondService/metadata.xml
+++ b/samples/function-cross/webapp/localService/secondService/metadata.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+    <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="sap.fe.test.TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="RootEntity" EntityType="sap.fe.test.TestService.RootEntity">
+          <NavigationPropertyBinding Path="SiblingEntity" Target="RootEntity"/>
+        </EntitySet>
+      </EntityContainer>
+      <EntityType Name="RootEntity">
+        <Key>
+          <PropertyRef Name="ID"/>
+          <PropertyRef Name="IsActiveEntity"/>
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="name" Type="Edm.String"/>
+        <Property Name="description" Type="Edm.String"/>
+        <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+        <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+        <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+        <NavigationProperty Name="DraftAdministrativeData" Type="sap.fe.test.TestService.DraftAdministrativeData" ContainsTarget="true"/>
+        <NavigationProperty Name="SiblingEntity" Type="sap.fe.test.TestService.RootEntity"/>
+      </EntityType>
+
+      <EntityType Name="DraftAdministrativeData">
+        <Key>
+          <PropertyRef Name="DraftUUID"/>
+        </Key>
+        <Property Name="DraftUUID" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="CreationDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+        <Property Name="CreatedByUser" Type="Edm.String" MaxLength="256"/>
+        <Property Name="DraftIsCreatedByMe" Type="Edm.Boolean"/>
+        <Property Name="LastChangeDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+        <Property Name="LastChangedByUser" Type="Edm.String" MaxLength="256"/>
+        <Property Name="InProcessByUser" Type="Edm.String" MaxLength="256"/>
+        <Property Name="DraftIsProcessedByMe" Type="Edm.Boolean"/>
+      </EntityType>
+      <Action Name="myCustomAction" IsBound="true" EntitySetPath="in">
+        <Parameter Name="in" Type="sap.fe.test.TestService.RootEntity"/>
+      </Action>
+      <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+        <Parameter Name="in" Type="sap.fe.test.TestService.RootEntity"/>
+        <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+        <ReturnType Type="sap.fe.test.TestService.RootEntity"/>
+      </Action>
+      <Action Name="draftActivate" IsBound="true" EntitySetPath="in">
+        <Parameter Name="in" Type="sap.fe.test.TestService.RootEntity"/>
+        <ReturnType Type="sap.fe.test.TestService.RootEntity"/>
+      </Action>
+      <Action Name="draftEdit" IsBound="true" EntitySetPath="in">
+        <Parameter Name="in" Type="sap.fe.test.TestService.RootEntity"/>
+        <Parameter Name="PreserveChanges" Type="Edm.Boolean"/>
+        <ReturnType Type="sap.fe.test.TestService.RootEntity"/>
+      </Action>
+      <Annotations Target="sap.fe.test.TestService.RootEntity">
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="name"/>
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+                <PropertyValue Property="Label" String="Change Description"/>
+                <PropertyValue Property="Action" String="sap.fe.test.TestService.myCustomAction"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="description"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.EntityContainer/RootEntity">
+        <Annotation Term="Common.DraftRoot">
+          <Record Type="Common.DraftRootType">
+            <PropertyValue Property="ActivationAction" String="sap.fe.test.TestService.draftActivate"/>
+            <PropertyValue Property="EditAction" String="sap.fe.test.TestService.draftEdit"/>
+            <PropertyValue Property="PreparationAction" String="sap.fe.test.TestService.draftPrepare"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/ID">
+        <Annotation Term="Common.Text" Path="name">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextOnly"/>
+        </Annotation>
+        <Annotation Term="Common.Label" String="ID"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/name">
+        <Annotation Term="Common.Label" String="Name"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/description">
+        <Annotation Term="Common.Label" String="Description"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/IsActiveEntity">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/HasActiveEntity">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/HasDraftEntity">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.RootEntity/DraftAdministrativeData">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData">
+        <Annotation Term="Common.Label" String="{i18n>Draft_DraftAdministrativeData}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/DraftUUID">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+        <Annotation Term="Common.Label" String="{i18n>Draft_DraftUUID}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/CreationDateTime">
+        <Annotation Term="Common.Label" String="{i18n>Draft_CreationDateTime}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/CreatedByUser">
+        <Annotation Term="Common.Label" String="{i18n>Draft_CreatedByUser}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/DraftIsCreatedByMe">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+        <Annotation Term="Common.Label" String="{i18n>Draft_DraftIsCreatedByMe}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/LastChangeDateTime">
+        <Annotation Term="Common.Label" String="{i18n>Draft_LastChangeDateTime}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/LastChangedByUser">
+        <Annotation Term="Common.Label" String="{i18n>Draft_LastChangedByUser}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/InProcessByUser">
+        <Annotation Term="Common.Label" String="{i18n>Draft_InProcessByUser}"/>
+      </Annotations>
+      <Annotations Target="sap.fe.test.TestService.DraftAdministrativeData/DraftIsProcessedByMe">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+        <Annotation Term="Common.Label" String="{i18n>Draft_DraftIsProcessedByMe}"/>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/samples/function-cross/webapp/localService/secondService/mockdata/RootEntity.js
+++ b/samples/function-cross/webapp/localService/secondService/mockdata/RootEntity.js
@@ -1,0 +1,6 @@
+module.exports = {
+    executeAction: function (actionDefinition, actionData, keys) {
+        console.log('Updating the data for ' + JSON.stringify(keys));
+        this.base.updateEntry(keys, { description: 'My Custom Description' });
+    }
+};

--- a/samples/function-cross/webapp/localService/secondService/mockdata/RootEntity.json
+++ b/samples/function-cross/webapp/localService/secondService/mockdata/RootEntity.json
@@ -1,0 +1,12 @@
+[
+    {
+        "ID": 1,
+        "name": "First element",
+        "description": "First description"
+    },
+    {
+        "ID": 2,
+        "name": "Second element",
+        "description": "Second description"
+    }
+]

--- a/samples/function-cross/webapp/manifest.json
+++ b/samples/function-cross/webapp/manifest.json
@@ -1,0 +1,124 @@
+{
+    "_version": "1.12.0",
+
+    "sap.app": {
+        "id": "sap.fe.mockserver.functioncross",
+        "type": "application",
+        "i18n": "i18n/i18n.properties",
+        "title": "{{appTitle}}",
+        "description": "{{appDescription}}",
+        "dataSources": {
+            "mainService": {
+                "uri": "/here/goes/your/firstService/",
+                "type": "OData",
+                "settings": {
+                    "annotations": ["annotation"],
+                    "odataVersion": "4.0",
+                    "localUri": "localService/firstService/metadata.xml"
+                }
+            },
+            "secondService": {
+                "uri": "/here/goes/your/secondService/",
+                "type": "OData",
+                "settings": {
+                    "annotations": ["annotation"],
+                    "odataVersion": "4.0",
+                    "localUri": "localService/secondService/metadata.xml"
+                }
+            }
+        },
+        "applicationVersion": {
+            "version": "${version}"
+        },
+        "sourceTemplate": {
+            "id": "generator-ui5-app",
+            "version": "1.1.0"
+        }
+    },
+
+    "sap.ui": {
+        "technology": "UI5",
+        "icons": {},
+        "deviceTypes": {
+            "desktop": true,
+            "tablet": true,
+            "phone": true
+        }
+    },
+
+    "sap.ui5": {
+        "rootView": {
+            "viewName": "sap.fe.mockserver.functioncross.view.App",
+            "type": "XML",
+            "id": "app"
+        },
+
+        "dependencies": {
+            "minUI5Version": "1.138.1",
+            "libs": {
+                "sap.ui.core": {},
+                "sap.m": {}
+            }
+        },
+
+        "handleValidation": true,
+
+        "contentDensities": {
+            "compact": true,
+            "cozy": true
+        },
+
+        "models": {
+            "": {
+                "dataSource": "mainService",
+                "type": "sap.ui.model.odata.v4.ODataModel",
+                "settings": {
+                    "operationMode": "Server",
+                    "autoExpandSelect": true,
+                    "earlyRequests": true
+                }
+            },
+            "secondService": {
+                "dataSource": "secondService",
+                "type": "sap.ui.model.odata.v4.ODataModel",
+                "settings": {
+                    "operationMode": "Server",
+                    "autoExpandSelect": true,
+                    "earlyRequests": true
+                }
+            },
+            "i18n": {
+                "type": "sap.ui.model.resource.ResourceModel",
+                "settings": {
+                    "bundleName": "sap.fe.mockserver.functioncross.i18n.i18n",
+                    "supportedLocales": ["en", "de"],
+                    "fallbackLocale": "en",
+                    "async": true
+                }
+            }
+        },
+
+        "routing": {
+            "config": {
+                "routerClass": "sap.m.routing.Router",
+                "viewType": "XML",
+                "viewPath": "sap.fe.mockserver.functioncross.view",
+                "controlId": "app",
+                "controlAggregation": "pages"
+            },
+            "routes": [
+                {
+                    "pattern": "",
+                    "name": "main",
+                    "target": "main"
+                }
+            ],
+            "targets": {
+                "main": {
+                    "viewId": "main",
+                    "viewName": "Main"
+                }
+            }
+        }
+    }
+}

--- a/samples/function-cross/webapp/model/formatter.js
+++ b/samples/function-cross/webapp/model/formatter.js
@@ -1,0 +1,9 @@
+sap.ui.define(function () {
+    'use strict';
+
+    return {
+        formatValue: function (value) {
+            return value && value.toUpperCase();
+        }
+    };
+});

--- a/samples/function-cross/webapp/model/models.js
+++ b/samples/function-cross/webapp/model/models.js
@@ -1,0 +1,14 @@
+sap.ui.define(
+    ['sap/ui/model/json/JSONModel', 'sap/ui/model/BindingMode', 'sap/ui/Device'],
+    function (JSONModel, BindingMode, Device) {
+        'use strict';
+
+        return {
+            createDeviceModel: function () {
+                const oModel = new JSONModel(Device);
+                oModel.setDefaultBindingMode(BindingMode.OneWay);
+                return oModel;
+            }
+        };
+    }
+);

--- a/samples/function-cross/webapp/view/App.view.xml
+++ b/samples/function-cross/webapp/view/App.view.xml
@@ -1,0 +1,9 @@
+<mvc:View
+	controllerName="sap.fe.mockserver.functioncross.controller.App"
+	displayBlock="true"
+	xmlns="sap.m"
+	xmlns:mvc="sap.ui.core.mvc">
+
+	<App id="app" />
+
+</mvc:View>

--- a/samples/function-cross/webapp/view/Main.view.xml
+++ b/samples/function-cross/webapp/view/Main.view.xml
@@ -1,0 +1,78 @@
+<mvc:View
+	controllerName="sap.fe.mockserver.functioncross.controller.Main"
+	displayBlock="true"
+	xmlns="sap.m"
+	xmlns:mvc="sap.ui.core.mvc">
+
+	<Page
+		title="{i18n>appTitle}"
+		id="page">
+        <content>
+            <VBox class="sapUiMediumMargin">
+                
+                <!-- Simple Action Testing Panel -->
+                <Panel headerText="Test Actions on Both Services" class="sapUiResponsiveMargin">
+                    <content>
+                        <VBox class="sapUiSmallMargin">
+                            <Text text="Click the buttons below to test the myCustomAction on both services:" class="sapUiTinyMarginBottom"/>
+                            <HBox class="sapUiSmallMarginTop">
+                                <Button text="Execute Action on First Service" 
+                                        type="Emphasized" 
+                                        press="onExecuteFirstServiceAction" 
+                                        class="sapUiTinyMarginEnd"/>
+                                <Button text="Execute Action on Second Service" 
+                                        type="Emphasized" 
+                                        press="onExecuteSecondServiceAction"/>
+                            </HBox>
+                        </VBox>
+                    </content>
+                </Panel>
+
+                <!-- Data Display Panel -->
+                <Panel headerText="Service Data" class="sapUiResponsiveMargin">
+                    <content>
+                        <VBox class="sapUiSmallMargin">
+                            <Text text="First Service Data:" class="sapUiTinyMarginBottom"/>
+                            <Table items="{/RootEntity}" class="sapUiTinyMarginBottom">
+                                <columns>
+                                    <Column><Text text="ID"/></Column>
+                                    <Column><Text text="Name"/></Column>
+                                    <Column><Text text="Description"/></Column>
+                                </columns>
+                                <items>
+                                    <ColumnListItem>
+                                        <cells>
+                                            <Text text="{ID}"/>
+                                            <Text text="{name}"/>
+                                            <Text text="{description}"/>
+                                        </cells>
+                                    </ColumnListItem>
+                                </items>
+                            </Table>
+
+                            <Text text="Second Service Data:" class="sapUiSmallMarginTop sapUiTinyMarginBottom"/>
+                            <Table items="{secondService>/RootEntity}">
+                                <columns>
+                                    <Column><Text text="ID"/></Column>
+                                    <Column><Text text="Name"/></Column>
+                                    <Column><Text text="Description"/></Column>
+                                </columns>
+                                <items>
+                                    <ColumnListItem>
+                                        <cells>
+                                            <Text text="{secondService>ID}"/>
+                                            <Text text="{secondService>name}"/>
+                                            <Text text="{secondService>description}"/>
+                                        </cells>
+                                    </ColumnListItem>
+                                </items>
+                            </Table>
+                        </VBox>
+                    </content>
+                </Panel>
+
+            </VBox>
+        </content>
+	</Page>
+
+</mvc:View>

--- a/samples/function-cross/webapp/view/Main.view.xml
+++ b/samples/function-cross/webapp/view/Main.view.xml
@@ -33,7 +33,7 @@
                     <content>
                         <VBox class="sapUiSmallMargin">
                             <Text text="First Service Data:" class="sapUiTinyMarginBottom"/>
-                            <Table items="{/RootEntity}" class="sapUiTinyMarginBottom">
+                            <Table items="{/RootEntity}" id="table1" class="sapUiTinyMarginBottom">
                                 <columns>
                                     <Column><Text text="ID"/></Column>
                                     <Column><Text text="Name"/></Column>
@@ -51,7 +51,7 @@
                             </Table>
 
                             <Text text="Second Service Data:" class="sapUiSmallMarginTop sapUiTinyMarginBottom"/>
-                            <Table items="{secondService>/RootEntity}">
+                            <Table items="{secondService>/RootEntity}" id="table2">
                                 <columns>
                                     <Column><Text text="ID"/></Column>
                                     <Column><Text text="Name"/></Column>


### PR DESCRIPTION
This PR aims to support cross-service updates allowing updating data in secondService from a action in firstService 

## Changes

Introducing the Service Registry that contains a map of services, so i introduce the saving and discovery of other services without changing something in the core logic.  
In `dataAccess.ts`is a new method is introduced to get the other Service from the registry. 
In 

Added tests
Added and updated documentation
Added test sample with a new app

Is this in general the right approach?

