### PR TITLE
fix: maxLength can have the value `max` which we currently interpret as NaN

### DIFF
--- a/.changeset/strange-wasps-shout.md
+++ b/.changeset/strange-wasps-shout.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/edmx-parser': patch
+---
+
+Fix for maxLength = 'max'

--- a/packages/edmx-parser/src/parser.ts
+++ b/packages/edmx-parser/src/parser.ts
@@ -100,7 +100,10 @@ function parseProperties(
                 type: unaliasType(entityProperty._attributes.Type).type
             };
             if (entityProperty._attributes.MaxLength) {
-                edmProperty.maxLength = parseInt(entityProperty._attributes.MaxLength, 10);
+                edmProperty.maxLength =
+                    entityProperty._attributes.MaxLength === 'max'
+                        ? 5000
+                        : parseInt(entityProperty._attributes.MaxLength, 10);
             }
             if (entityProperty._attributes.Precision) {
                 edmProperty.precision = parseInt(entityProperty._attributes.Precision, 10);
@@ -523,7 +526,8 @@ function parseActions(actions: (EDMX.Action | EDMX.Function)[], namespace: strin
                     isCollection
                 };
                 if (param._attributes.MaxLength) {
-                    edmActionParameter.maxLength = parseInt(param._attributes.MaxLength, 10);
+                    edmActionParameter.maxLength =
+                        param._attributes.MaxLength === 'max' ? 5000 : parseInt(param._attributes.MaxLength, 10);
                 }
                 if (param._attributes.Precision) {
                     edmActionParameter.precision = parseInt(param._attributes.Precision, 10);

--- a/packages/edmx-parser/test/__snapshots__/parser.spec.ts.snap
+++ b/packages/edmx-parser/test/__snapshots__/parser.spec.ts.snap
@@ -66431,7 +66431,7 @@ MergedRawMetadata {
         {
           "_type": "Property",
           "fullyQualifiedName": "com.c_salesordermanage_sd.BusinessPartner/SalesDocument",
-          "maxLength": 10,
+          "maxLength": 5000,
           "name": "SalesDocument",
           "nullable": false,
           "type": "Edm.String",
@@ -66498,7 +66498,7 @@ MergedRawMetadata {
         {
           "_type": "Property",
           "fullyQualifiedName": "com.c_salesordermanage_sd.BusinessPartner/SalesDocument",
-          "maxLength": 10,
+          "maxLength": 5000,
           "name": "SalesDocument",
           "nullable": false,
           "type": "Edm.String",
@@ -87085,7 +87085,7 @@ MergedRawMetadata {
               {
                 "_type": "Property",
                 "fullyQualifiedName": "com.c_salesordermanage_sd.BusinessPartner/SalesDocument",
-                "maxLength": 10,
+                "maxLength": 5000,
                 "name": "SalesDocument",
                 "nullable": false,
                 "type": "Edm.String",
@@ -87152,7 +87152,7 @@ MergedRawMetadata {
               {
                 "_type": "Property",
                 "fullyQualifiedName": "com.c_salesordermanage_sd.BusinessPartner/SalesDocument",
-                "maxLength": 10,
+                "maxLength": 5000,
                 "name": "SalesDocument",
                 "nullable": false,
                 "type": "Edm.String",

--- a/packages/edmx-parser/test/fixtures/v4/sdMeta.xml
+++ b/packages/edmx-parser/test/fixtures/v4/sdMeta.xml
@@ -156,7 +156,7 @@
           <PropertyRef Name="SalesDocument"/>
           <PropertyRef Name="PartnerFunction"/>
         </Key>
-        <Property Name="SalesDocument" Type="Edm.String" MaxLength="10" Nullable="false"/>
+        <Property Name="SalesDocument" Type="Edm.String" MaxLength="max" Nullable="false"/>
         <Property Name="PartnerFunction" Type="Edm.String" MaxLength="2" Nullable="false"/>
         <Property Name="BusinessPartner" Type="Edm.String" MaxLength="10"/>
         <Property Name="FullName" Type="Edm.String" MaxLength="80"/>

--- a/packages/edmx-parser/test/parser.spec.ts
+++ b/packages/edmx-parser/test/parser.spec.ts
@@ -6,6 +6,13 @@ describe('Parser', function () {
     it('can parse an edmx file', async () => {
         const xmlFile = await loadFixture('v4/sdMeta.xml');
         const schema: RawMetadata = parse(xmlFile);
+        expect(
+            (
+                schema.schema.entityTypes
+                    .find((e) => e.name === 'BusinessPartner')
+                    ?.entityProperties.find(((p) => p.name === 'SalesDocument')!) as any
+            ).maxLength
+        ).toBe(5000);
         const annoFile = await loadFixture('v4/sdAnno.xml');
         const annoSchema: RawMetadata = parse(annoFile, 'annoFile');
         const mergeSchema = merge(schema, annoSchema);


### PR DESCRIPTION
Fix for #936