### PR TITLE
fix: calling loadServices should also open the service to be called back

### DIFF
--- a/.changeset/violet-pans-fry.md
+++ b/.changeset/violet-pans-fry.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+fix: calling loadServices should also open the service to be called back


### PR DESCRIPTION
Registering a new service didn't register the middleware