### PR TITLE
Fix Date transformation

### DIFF
--- a/packages/fe-mockserver-core/src/data/common.ts
+++ b/packages/fe-mockserver-core/src/data/common.ts
@@ -148,7 +148,7 @@ export class ExecutionError extends Error {
 
 export function _getDateTimeOffset(isV4: boolean) {
     const date = new Date();
-    return isV4 ? date.toISOString() : '/Date(' + date.getTime() + '/';
+    return isV4 ? date.toISOString() : '/Date(' + date.getTime() + ')/';
 }
 
 const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';


### PR DESCRIPTION
Add the missing closing parenthesis in the V2 date string format used by the mockserver.
