### PR TITLE
fix: use unencoded paths for external service registration

### DIFF
--- a/.changeset/matrix-parameter-parsing-fix.md
+++ b/.changeset/matrix-parameter-parsing-fix.md
@@ -1,0 +1,26 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+Fix matrix parameter parsing and routing for external service references in OData URLs
+
+This change fixes a regression where value help data from external services was not loading correctly when using UI5 1.144+. The issue occurred because UI5 1.144+ stopped URL-encoding single quotes in matrix parameters (semicolon-separated parameters like `;ps='value';va='value'`), but the mockserver was not handling the unencoded format correctly for routing and request parsing.
+
+**Changes:**
+- Updated `QueryPath` type to include optional `matrixParameters` field
+- Enhanced `parsePath()` method to detect and parse matrix parameters from path segments
+- Added support for both encoded (`%27`) and unencoded (`'`) single quote formats in request parsing
+- Fixed external service registration to use unencoded paths, allowing the router to handle both encoded and unencoded requests
+- Removed obsolete `encode()` function that was pre-encoding external service paths
+- Added comprehensive test cases covering both UI5 1.142 (encoded) and UI5 1.144+ (unencoded) formats
+
+**Impact:**
+- Value help dialogs for external service references now work correctly with UI5 1.144+
+- External services with matrix parameters are now accessible via both encoded and unencoded URLs
+- Maintains backward compatibility with UI5 1.142 and earlier versions
+- Resolves ServiceNow incident where Agency ID value help was not displaying values 60001, 60002, and 60003
+
+**Example URLs now handled:**
+- Encoded (UI5 1.142): `/service/0001;ps=%27srvd-name%27;va=%27path%27/$metadata`
+- Unencoded (UI5 1.144+): `/service/0001;ps='srvd-name';va='path'/$metadata`
+

--- a/packages/fe-mockserver-core/src/data/metadata.ts
+++ b/packages/fe-mockserver-core/src/data/metadata.ts
@@ -264,7 +264,7 @@ export class ODataMetadata {
 
                     references.push({
                         rootPath,
-                        externalServiceMetadataPath: encode(externalServicePath),
+                        externalServiceMetadataPath: externalServicePath,
                         localPath: localPath,
                         dataPath: serviceRoot
                     });
@@ -292,17 +292,13 @@ export class ODataMetadata {
 
             references.push({
                 rootPath,
-                externalServiceMetadataPath: encode(externalServicePath),
+                externalServiceMetadataPath: externalServicePath,
                 localPath: localPath,
                 dataPath: serviceRoot
             });
         }
         return references;
     }
-}
-
-function encode(str: string): string {
-    return str.replaceAll("'", '%27').replaceAll('*', '%2A');
 }
 
 function getServiceRoot(metadataPath: string, pathWithParameters: string, rootPath: string): string {


### PR DESCRIPTION
This allows the router to handle both encoded and unencoded matrix parameter formats. Previously, external service paths were pre-encoded, which prevented the router's automatic encoding/decoding from working correctly for UI5 1.144+ requests.