### PR TITLE
fix: `getData` throws `Error: Cannot read properties of undefined (reading 'forEach')` when the entity is a draft and `IsActiveEntity` is set to `false` for all mock data entries.

### DIFF
--- a/.changeset/gold-bears-rule.md
+++ b/.changeset/gold-bears-rule.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+`getData` throws `Error: Cannot read properties of undefined (reading 'forEach')` when the entity is a draft and `IsActiveEntity` is set to `false` for all mock data entries.

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -1304,7 +1304,7 @@ export class FileBasedMockData {
                 applyToActiveEntity
             );
             const sourceReference = this.getSourceReference(aggregationAnnotation);
-            const rootNodes = hierarchyNodes[''];
+            const rootNodes = hierarchyNodes[''] ?? [];
             rootNodes.forEach((rootNode: any) => {
                 this.buildTree(rootNode, hierarchyNodes, nodeProperty, 0, undefined);
             });
@@ -1475,7 +1475,7 @@ export class FileBasedMockData {
                 hierarchyDefinition,
                 applyToActiveEntity
             );
-            const rootNodes = hierarchyNodes[''];
+            const rootNodes = hierarchyNodes[''] ?? [];
             rootNodes.forEach((rootNode: any) => {
                 this.buildTree(rootNode, hierarchyNodes, nodeProperty, 0, undefined);
             });

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -1483,7 +1483,7 @@ export class FileBasedMockData {
             this._mockDataEntitySet.logRequest('Trying to find ancestors comparing ' + nodeProperty, _odataRequest);
             limitedHierarchy.forEach((item: any) => {
                 const parentNodeChildren = hierarchyNodes[getData(item, sourceReference) ?? ''];
-                const currentNode = parentNodeChildren.find((node: any) =>
+                const currentNode = parentNodeChildren?.find((node: any) =>
                     compareRowData(
                         node,
                         item,

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyDraftAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyDraftAccess.test.ts
@@ -462,4 +462,29 @@ describe('Hierarchy with draft', () => {
         );
         await dataAccess.deleteData(draftDeleteRequest);
     });
+
+    test('Draft entity and IsActiveEntity=false', async () => {
+        // Request the hierarchy - ancestors
+        const odataRequestAncestors = new ODataRequest(
+            {
+                method: 'GET',
+                url: "/SalesOrganizations?$apply=ancestors($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(IsActiveEntity eq false),keep start)/com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/SalesOrganizations,HierarchyQualifier='SalesOrgHierarchy',NodeProperty='ID',Levels=2)&$count=true&$select=LimitedDescendantCount,DistanceFromRoot,DrillState,ID,Name&$skip=0&$top=10",
+                tenantId: 'inactive'
+            },
+            dataAccess
+        );
+        const dataAncestors = await dataAccess.getData(odataRequestAncestors);
+        expect(dataAncestors).toEqual([]);
+        // Request the hierarchy - descendants
+        const odataRequestDescendants = new ODataRequest(
+            {
+                method: 'GET',
+                url: "/SalesOrganizations?$apply=descendants($root/SalesOrganizations,SalesOrgHierarchy,ID,filter(IsActiveEntity eq false),keep start)/com.sap.vocabularies.Hierarchy.v1.TopLevels(HierarchyNodes=$root/SalesOrganizations,HierarchyQualifier='SalesOrgHierarchy',NodeProperty='ID',Levels=2)&$count=true&$select=LimitedDescendantCount,DistanceFromRoot,DrillState,ID,Name&$skip=0&$top=10",
+                tenantId: 'inactive'
+            },
+            dataAccess
+        );
+        const dataDescendants = await dataAccess.getData(odataRequestDescendants);
+        expect(dataDescendants).toEqual([]);
+    });
 });

--- a/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/SalesOrganizations-inactive.json
+++ b/packages/fe-mockserver-core/test/unit/v4/services/hierarchy/SalesOrganizations-inactive.json
@@ -1,0 +1,49 @@
+[
+    {
+        "ID": "Sales",
+        "Name": "Corporate Sales",
+        "IsActiveEntity": false
+    },
+    {
+        "ID": "EMEA",
+        "Parent": "Sales",
+        "Name": "EMEA",
+        "IsActiveEntity": false
+    },
+    {
+        "ID": "EMEA Central",
+        "Parent": "EMEA",
+        "Name": "EMEA Central",
+        "IsActiveEntity": false
+    },
+    {
+        "ID": "US",
+        "Parent": "Sales",
+        "Name": "US",
+        "IsActiveEntity": false
+    },
+    {
+        "ID": "US West",
+        "Parent": "US",
+        "Name": "US West",
+        "IsActiveEntity": false
+    },
+    {
+        "ID": "US East",
+        "Parent": "US",
+        "Name": "US East",
+        "IsActiveEntity": false
+    },
+    {
+        "ID": "NY",
+        "Parent": "US East",
+        "Name": "New York State",
+        "IsActiveEntity": false
+    },
+    {
+        "ID": "NYC",
+        "Parent": "NY",
+        "Name": "New York City",
+        "IsActiveEntity": false
+    }
+]


### PR DESCRIPTION
Scenario to reproduce:
1. Entity marked as draft like:
```
<Annotation Term="SAP__common.DraftNode">
                    <Record />
                </Annotation>
```
2. All entries for entity in mock data is marked with `IsActiveEntity=false`, like:
```
[
{
        "name": "Dummy",
        "IsActiveEntity": false
    }
]
```
3. Then `getData` throws error in following line -> https://github.com/SAP/open-ux-odata/blob/main/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts#L1479:
```
Error: Cannot read properties of undefined (reading 'forEach')
```

reason is that `buildHierarchyTree` returns empty data if entity is draft and `IsActiveEntity=false`:
https://github.com/SAP/open-ux-odata/blob/main/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts#L906