### PR TITLE
Fix/sonar pr decoration

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -11,6 +11,8 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       actions: read # Required to download artifacts
+      pull-requests: write # Required for PR decoration comments
+      statuses: write # Required for SonarCloud to post quality gate commit status
     steps:
       - name: 'Checkout project'
         uses: actions/checkout@v5
@@ -21,7 +23,7 @@ jobs:
 
       - name: 'Download cacjed artifact'
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: sonar-artifact
           run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
based on 
https://github.com/SAP/open-ux-tools/pull/4571
https://github.com/SAP/open-ux-tools/pull/4574

# Fix SonarCloud PR Decoration Permissions and Downgrade Artifact Action

### Chore

🔧 Updated the SonarCloud workflow to resolve PR decoration issues by adding the required permission and correcting the artifact download action version.

### Changes

* `.github/workflows/sonar.yml`:
  - Added `pull-requests: write` permission to the `sonar` job, enabling SonarCloud to post PR decoration comments.
  - Downgraded `actions/download-artifact` from `v5` to `v4` to use the correct and stable action version.
