### PR TITLE
fix: wrong order for tree list

### DIFF
--- a/.changeset/late-impalas-act.md
+++ b/.changeset/late-impalas-act.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+ixed reverse ordering in tree list data returned by `getData`

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -1148,7 +1148,11 @@ export class FileBasedMockData {
                 );
                 return !parent || !parent.$inResultSet;
             });
-            allRootNodes.sort((a) => {
+            allRootNodes.sort((a, b) => {
+                if (a.$rootDistance === undefined && b.$rootDistance === undefined) {
+                    //  Do not change order if '$rootDistance' is undefined for both entries
+                    return 0;
+                }
                 if (a.$rootDistance === undefined) {
                     return -1;
                 }

--- a/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
+++ b/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts
@@ -1150,7 +1150,7 @@ export class FileBasedMockData {
             });
             allRootNodes.sort((a, b) => {
                 if (a.$rootDistance === undefined && b.$rootDistance === undefined) {
-                    //  Do not change order if '$rootDistance' is undefined for both entries
+                    // Preserve original order if '$rootDistance' is undefined for both entries
                     return 0;
                 }
                 if (a.$rootDistance === undefined) {

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyAccess.test.ts
@@ -1339,6 +1339,27 @@ describe('Hierarchy Access', () => {
               {
                 "DistanceFromRoot": 0,
                 "DrillState": "expanded",
+                "ID": "1",
+                "LimitedDescendantCount": 2,
+                "Name": "Waters",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "leaf",
+                "ID": "10",
+                "LimitedDescendantCount": 0,
+                "Name": "Still water",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "leaf",
+                "ID": "11",
+                "LimitedDescendantCount": 0,
+                "Name": "Sparkling water",
+              },
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
                 "ID": "2",
                 "LimitedDescendantCount": 3,
                 "Name": "Wines",
@@ -1363,27 +1384,6 @@ describe('Hierarchy Access', () => {
                 "ID": "22",
                 "LimitedDescendantCount": 0,
                 "Name": "Sparkling wines",
-              },
-              {
-                "DistanceFromRoot": 0,
-                "DrillState": "expanded",
-                "ID": "1",
-                "LimitedDescendantCount": 2,
-                "Name": "Waters",
-              },
-              {
-                "DistanceFromRoot": 1,
-                "DrillState": "leaf",
-                "ID": "10",
-                "LimitedDescendantCount": 0,
-                "Name": "Still water",
-              },
-              {
-                "DistanceFromRoot": 1,
-                "DrillState": "leaf",
-                "ID": "11",
-                "LimitedDescendantCount": 0,
-                "Name": "Sparkling water",
               },
             ]
         `);
@@ -1818,13 +1818,6 @@ describe('Hierarchy Access', () => {
             [
               {
                 "DistanceFromRoot": 0,
-                "DrillState": "leaf",
-                "ID": "NZL",
-                "LimitedDescendantCount": 0,
-                "Name": "NZL",
-              },
-              {
-                "DistanceFromRoot": 0,
                 "DrillState": "expanded",
                 "ID": "Sales",
                 "LimitedDescendantCount": 2,
@@ -1843,6 +1836,13 @@ describe('Hierarchy Access', () => {
                 "ID": "US",
                 "LimitedDescendantCount": 0,
                 "Name": "US",
+              },
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "leaf",
+                "ID": "NZL",
+                "LimitedDescendantCount": 0,
+                "Name": "NZL",
               },
             ]
         `);
@@ -1866,20 +1866,6 @@ describe('Hierarchy Access', () => {
               {
                 "DistanceFromRoot": 0,
                 "DrillState": "expanded",
-                "ID": "NZL",
-                "LimitedDescendantCount": 1,
-                "Name": "NZL",
-              },
-              {
-                "DistanceFromRoot": 1,
-                "DrillState": "leaf",
-                "ID": "NZL_C",
-                "LimitedDescendantCount": 0,
-                "Name": "NZL_C",
-              },
-              {
-                "DistanceFromRoot": 0,
-                "DrillState": "expanded",
                 "ID": "Sales",
                 "LimitedDescendantCount": 2,
                 "Name": "Corporate Sales",
@@ -1897,6 +1883,20 @@ describe('Hierarchy Access', () => {
                 "ID": "US",
                 "LimitedDescendantCount": 0,
                 "Name": "US",
+              },
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "ID": "NZL",
+                "LimitedDescendantCount": 1,
+                "Name": "NZL",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "leaf",
+                "ID": "NZL_C",
+                "LimitedDescendantCount": 0,
+                "Name": "NZL_C",
               },
             ]
         `);
@@ -2047,20 +2047,6 @@ describe('Hierarchy Access', () => {
               {
                 "DistanceFromRoot": 0,
                 "DrillState": "expanded",
-                "ID": "NY",
-                "LimitedDescendantCount": 1,
-                "Name": "New York State",
-              },
-              {
-                "DistanceFromRoot": 1,
-                "DrillState": "leaf",
-                "ID": "NYC",
-                "LimitedDescendantCount": 0,
-                "Name": "New York City",
-              },
-              {
-                "DistanceFromRoot": 0,
-                "DrillState": "expanded",
                 "ID": "Sales",
                 "LimitedDescendantCount": 2,
                 "Name": "Corporate Sales",
@@ -2078,6 +2064,20 @@ describe('Hierarchy Access', () => {
                 "ID": "US",
                 "LimitedDescendantCount": 0,
                 "Name": "US",
+              },
+              {
+                "DistanceFromRoot": 0,
+                "DrillState": "expanded",
+                "ID": "NY",
+                "LimitedDescendantCount": 1,
+                "Name": "New York State",
+              },
+              {
+                "DistanceFromRoot": 1,
+                "DrillState": "leaf",
+                "ID": "NYC",
+                "LimitedDescendantCount": 0,
+                "Name": "New York City",
               },
             ]
         `);

--- a/packages/fe-mockserver-core/test/unit/v4/hierarchyDraftAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/hierarchyDraftAccess.test.ts
@@ -319,6 +319,17 @@ describe('Hierarchy with draft', () => {
             [
               {
                 "DistanceFromRoot": 0,
+                "DrillState": "collapsed",
+                "HasActiveEntity": true,
+                "ID": "FUNC1",
+                "IsActiveEntity": true,
+                "LimitedDescendantCount": 0,
+                "employeeCount": 274,
+                "name": "Operations",
+                "nodeType": "Zone",
+              },
+              {
+                "DistanceFromRoot": 0,
                 "DrillState": "expanded",
                 "HasActiveEntity": true,
                 "ID": "FUNC2",
@@ -371,17 +382,6 @@ describe('Hierarchy with draft', () => {
                 "employeeCount": 8,
                 "name": "Insurance",
                 "nodeType": "Line",
-              },
-              {
-                "DistanceFromRoot": 0,
-                "DrillState": "collapsed",
-                "HasActiveEntity": true,
-                "ID": "FUNC1",
-                "IsActiveEntity": true,
-                "LimitedDescendantCount": 0,
-                "employeeCount": 274,
-                "name": "Operations",
-                "nodeType": "Zone",
               },
             ]
         `);


### PR DESCRIPTION
It was reported that wrong order is returned for tree table when mock server is used. It is ordered in oposite way.
During debugging source code - root issue is in code -> https://github.com/SAP/open-ux-odata/blob/main/packages/fe-mockserver-core/src/mockdata/fileBasedMockData.ts#L1151C13-L1156C16
```
allRootNodes.sort((a) => {
                if (a.$rootDistance === undefined) {
                    return -1;
                }
                return 1;
            });
```

for example, if property `$rootDistance` is `undefined` and sibling row/entry also has `$rootDistance` as `undefined`, then it shuffles array in reverse order, see screenshot with simple example:
<img width="674" height="662" alt="image" src="https://github.com/user-attachments/assets/81047a69-7016-4e5a-8ed2-ca2e8bebc9e3" />
