### PR TITLE
fix: patch for keyed collection navigation

### DIFF
--- a/.changeset/angry-boxes-act.md
+++ b/.changeset/angry-boxes-act.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+fix: PATCH on a keyed collection navigation (e.g. `RootEntity(key)/_Child(childKey)`) now updates the addressed child entity in its own entity set instead of overwriting the parent's navigation property and ignoring the child key

--- a/packages/fe-mockserver-core/src/data/dataAccess.ts
+++ b/packages/fe-mockserver-core/src/data/dataAccess.ts
@@ -1122,12 +1122,33 @@ export class DataAccess implements DataAccessInterface {
     }
 
     public async updateData(odataRequest: ODataRequest, patchData: any) {
-        const entitySetName = odataRequest.queryPath[0].path;
-        if (odataRequest.queryPath.length > 1) {
+        let targetEntitySetName = odataRequest.queryPath[0].path;
+
+        // Re-base to the trailing entity that actually needs to be patched. For a path that addresses an
+        // entity through keyed navigation (e.g. RootEntity(key)/_Child(childKey)) the PATCH must
+        // target the child entity in its own entity set using the child key.
+        let targetEntitySet = this.metadata.getEntitySet(targetEntitySetName);
+        let targetKeys = odataRequest.queryPath[0].keys;
+        let lastResolvedIndex = 0;
+        for (let i = 1; i < odataRequest.queryPath.length; i++) {
+            const segment = odataRequest.queryPath[i];
+            targetEntitySet = targetEntitySet?.navigationPropertyBinding[segment.path] as EntitySet | undefined;
+            if (targetEntitySet && segment.keys && Object.keys(segment.keys).length > 0) {
+                targetEntitySetName = targetEntitySet.name;
+                targetKeys = segment.keys;
+                lastResolvedIndex = i;
+            } else {
+                // Keyless navigation/property segment: it (and everything after it) is patched
+                // as a sub-object of the entity resolved so far.
+                break;
+            }
+        }
+
+        if (odataRequest.queryPath.length - 1 > lastResolvedIndex) {
             // In this case we are updating a property or a sub object so let's create the appropriate structure
             let updateObject: any = {};
             const finalPatchObject = updateObject;
-            for (let i = 1; i < odataRequest.queryPath.length; i++) {
+            for (let i = lastResolvedIndex + 1; i < odataRequest.queryPath.length; i++) {
                 updateObject[odataRequest.queryPath[i].path] = {};
                 if (i === odataRequest.queryPath.length - 1) {
                     updateObject[odataRequest.queryPath[i].path] = patchData;
@@ -1136,16 +1157,16 @@ export class DataAccess implements DataAccessInterface {
             }
             patchData = finalPatchObject;
         }
-        const mockEntitySet = await this.getMockEntitySet(entitySetName);
-        this.logRequest(`Handling PATCH request for entity set: ${entitySetName}`, odataRequest);
+        const mockEntitySet = await this.getMockEntitySet(targetEntitySetName);
+        this.logRequest(`Handling PATCH request for entity set: ${targetEntitySetName}`, odataRequest);
         this.logRequest(
-            `PATCH details - Keys: ${JSON.stringify(odataRequest.queryPath[0].keys)}, Tenant: ${
+            `PATCH details - Keys: ${JSON.stringify(targetKeys)}, Tenant: ${
                 odataRequest.tenantId
             }, Data: ${JSON.stringify(patchData, null, 2)}`,
             odataRequest
         );
         const resultData = await mockEntitySet.performPATCH(
-            odataRequest.queryPath[0].keys,
+            targetKeys,
             patchData,
             odataRequest.tenantId,
             odataRequest,

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -1088,6 +1088,64 @@ describe('Data Access', () => {
         expect(formData[1]._OtherChild.length).toEqual(1);
     });
 
+    test('v4 PATCH via keyed collection navigation', async () => {
+        // Create FormRoot draft
+        const formRoot = await dataAccess.createData(
+            new ODataRequest({ method: 'POST', url: '/FormRoot', tenantId: 'patch-keyed-nav' }, dataAccess),
+            {
+                ID: 2,
+                FirstName: 'Bob'
+            }
+        );
+
+        // Create two child elements
+        await dataAccess.createData(
+            new ODataRequest(
+                { method: 'POST', url: '/FormRoot(ID=2,IsActiveEntity=false)/_Elements', tenantId: 'patch-keyed-nav' },
+                dataAccess
+            ),
+            {
+                ID: 10,
+                Name: 'ChildA'
+            }
+        );
+        await dataAccess.createData(
+            new ODataRequest(
+                { method: 'POST', url: '/FormRoot(ID=2,IsActiveEntity=false)/_Elements', tenantId: 'patch-keyed-nav' },
+                dataAccess
+            ),
+            {
+                ID: 20,
+                Name: 'ChildB'
+            }
+        );
+
+        // PATCH the specific child through the navigation, addressing it by its key:
+        await dataAccess.updateData(
+            new ODataRequest(
+                {
+                    method: 'PATCH',
+                    url: '/FormRoot(ID=2,IsActiveEntity=false)/_Elements(ID=10,IsActiveEntity=false)',
+                    tenantId: 'patch-keyed-nav'
+                },
+                dataAccess
+            ),
+            {
+                Name: 'ChildA-PATCHED'
+            }
+        );
+
+        const elements = await dataAccess.getData(
+            new ODataRequest(
+                { method: 'GET', url: '/FormRoot(ID=2,IsActiveEntity=false)/_Elements', tenantId: 'patch-keyed-nav' },
+                dataAccess
+            )
+        );
+        expect(elements.length).toEqual(2);
+        expect(elements.find((element: any) => element.ID === 20)?.Name).toEqual('ChildB');
+        expect(elements.find((element: any) => element.ID === 10)?.Name).toEqual('ChildA-PATCHED');
+    });
+
     test('v4metadata - generator', async () => {
         let part3Data = await dataAccess.getData(new ODataRequest({ method: 'GET', url: '/Part3' }, dataAccess));
         expect(part3Data.length).toEqual(150);


### PR DESCRIPTION
## Problem in fe-mockserver-core
`dataAccess.updateData` built a nested payload from the navigation segments and always applied the patch to the root entity using the root key. For a path like `RootEntity(key)/_Child(childKey)` this meant that the patch was written into the root entity instead of the child, so the targeted child entity was never actually updated.

## Fix
`dataAccess.updateData` now walks the query path and re-bases the patch target onto each navigation segment that carries its own key. Only trailing keyless segments (a property, or a single-valued navigation addressed without a key) are wrapped into the patch payload. Plain `RootEntity(key)`, `RootEntity(key)/property`, and to-one navigation updates behave exactly as before.