### PR TITLE
fix: use GitHub App token to push changeset version commits

### DIFF
--- a/.github/workflows/lockfiles-command.yml
+++ b/.github/workflows/lockfiles-command.yml
@@ -5,6 +5,7 @@ on:
 jobs:
     lockfiles:
         runs-on: ubuntu-latest
+        environment: release
         timeout-minutes: 15
         steps:
             - name: Generate app token

--- a/.github/workflows/lockfiles-command.yml
+++ b/.github/workflows/lockfiles-command.yml
@@ -27,7 +27,7 @@ jobs:
                   node-version: 22.x
 
             - name: Setup PNPM
-              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
               if: success()
               with:
                   run_install: false

--- a/.github/workflows/lockfiles-command.yml
+++ b/.github/workflows/lockfiles-command.yml
@@ -5,30 +5,37 @@ on:
 jobs:
     lockfiles:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v3
+            - name: Generate app token
+              id: app-token
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.ACCESS_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
 
-            - name: Use Node.js 20.x
+            - name: Use Node.js 22.x
               if: success()
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.x
 
             - name: Setup PNPM
-              uses: pnpm/action-setup@v2.2.4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
               if: success()
               with:
                   run_install: false
 
             - name: Pnpm Install recursive
               if: success()
-              # as CI is defined then frozen lockfile is always used
               run: pnpm install --frozen-lockfile=false
 
-            - uses: stefanzweifel/git-auto-commit-action@v4
+            - uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4
               if: success()
               with:
                   commit_message: Update lockfiles

--- a/.github/workflows/lockfiles-command.yml
+++ b/.github/workflows/lockfiles-command.yml
@@ -5,7 +5,7 @@ on:
 jobs:
     lockfiles:
         runs-on: ubuntu-latest
-        environment: release
+        environment: automation
         timeout-minutes: 15
         steps:
             - name: Generate app token

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -67,10 +67,6 @@ jobs:
                       output.tar
                   if-no-files-found: error
                   retention-days: 1
-              #uses: sonarsource/sonarcloud-github-action@master
-              #env:
-              #GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
-              #SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     version:
         # Run version job only on pushes to the main branch. The job depends on completion of the build job.

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,24 +11,24 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                node-version: [20.x, 22.x]
+                node-version: [22.x, 24.x]
         runs-on: ${{ matrix.os }}
         timeout-minutes: 15
         steps:
             - name: Checkout code repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
               with:
                   run_install: true
             - name: Cache pnpm modules
-              uses: actions/cache@v3
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               env:
                   cache-name: cache-pnpm-modules
               with:
@@ -37,7 +37,7 @@ jobs:
                   restore-keys: |
                       ${{ matrix.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
             - name: Install pnpm modules
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
             - name: Run build
               run: pnpm run build
             - name: Run linting
@@ -45,21 +45,25 @@ jobs:
             - name: Run unit tests
               run: pnpm run test
             - name: Run SonarCloud scan
-              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
+              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '22.x'
               shell: bash
+              env:
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+                  PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
               run: |
-                  echo ${{ github.event.pull_request.number }} >> pr-event.txt
-                  echo ${{ github.event.pull_request.head.ref }} >> pr-event.txt
-                  echo ${{ github.event.pull_request.base.ref }} >> pr-event.txt
+                  echo "$PR_NUMBER" >> pr-event.txt
+                  echo "$PR_HEAD_REF" >> pr-event.txt
+                  echo "$PR_BASE_REF" >> pr-event.txt
 
             - name: 'Prepare output artifact'
-              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
+              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '22.x'
               shell: bash
               run: touch output.tar && tar --exclude='./node_modules' --exclude='./dist' --exclude='./**/node_modules/**' --exclude='./**/dist/**' --exclude='./.git' --exclude 'output.tar' -czf output.tar .
 
             - name: 'Upload sonar artifact'
-              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
-              uses: actions/upload-artifact@v4
+              if: matrix.os == 'ubuntu-latest' && matrix.node-version == '22.x'
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: sonar-artifact
                   path: |
@@ -74,6 +78,7 @@ jobs:
         runs-on: ubuntu-latest
         needs: build
         environment: release
+        timeout-minutes: 15
         permissions:
             contents: write
             id-token: write
@@ -82,25 +87,25 @@ jobs:
         steps:
             - name: Generate app token
               id: app-token
-              uses: actions/create-github-app-token@v1
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
               with:
                   app-id: ${{ secrets.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
             - name: Checkout code repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
                   token: ${{ steps.app-token.outputs.token }}
-            - name: Use Node.js 20.x
-              uses: actions/setup-node@v3
+            - name: Use Node.js 22.x
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.x
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
               with:
                   run_install: true
             - name: Cache pnpm modules
-              uses: actions/cache@v3
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               env:
                   cache-name: cache-pnpm-modules
               with:
@@ -110,7 +115,7 @@ jobs:
                       ${{ runner.os }}-build-${{ env.cache-name }}-
 
             - name: Install pnpm modules
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
             - name: Apply changesets
               id: changesetVersion
               run: |
@@ -134,22 +139,23 @@ jobs:
         if: github.repository == 'SAP/open-ux-odata' && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.version.outputs.changes == 'false'
         runs-on: ubuntu-latest
         needs: version
+        timeout-minutes: 15
         permissions:
             contents: write
             id-token: write
         steps:
             - name: Checkout code repository
-              uses: actions/checkout@v3
-            - name: Use Node.js 20.x
-              uses: actions/setup-node@v3
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - name: Use Node.js 22.x
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
-                  node-version: 20.x
+                  node-version: 22.x
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
               with:
                   run_install: true
             - name: Cache pnpm modules
-              uses: actions/cache@v3
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               env:
                   cache-name: cache-pnpm-modules
               with:
@@ -159,13 +165,13 @@ jobs:
                       ${{ runner.os }}-build-${{ env.cache-name }}-
 
             - name: Install pnpm modules
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
             - name: Run build
               run: pnpm run build
             - name: Setup npmrc with npmjs.com token
               run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_TOKEN }}" > .npmrc
             - name: 'Publish to npmjs'
-              uses: changesets/action@v1.4.1
+              uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
               with:
                   publish: pnpm ci:publish
               env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -48,43 +48,53 @@ jobs:
               if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
               shell: bash
               run: |
-                echo ${{ github.event.pull_request.number }} >> pr-event.txt
-                echo ${{ github.event.pull_request.head.ref }} >> pr-event.txt
-                echo ${{ github.event.pull_request.base.ref }} >> pr-event.txt
-        
+                  echo ${{ github.event.pull_request.number }} >> pr-event.txt
+                  echo ${{ github.event.pull_request.head.ref }} >> pr-event.txt
+                  echo ${{ github.event.pull_request.base.ref }} >> pr-event.txt
+
             - name: 'Prepare output artifact'
               if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
               shell: bash
               run: touch output.tar && tar --exclude='./node_modules' --exclude='./dist' --exclude='./**/node_modules/**' --exclude='./**/dist/**' --exclude='./.git' --exclude 'output.tar' -czf output.tar .
-        
+
             - name: 'Upload sonar artifact'
               if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
               uses: actions/upload-artifact@v4
               with:
-                name: sonar-artifact
-                path: |
-                  pr-event.txt
-                  output.tar
-                if-no-files-found: error
-                retention-days: 1
+                  name: sonar-artifact
+                  path: |
+                      pr-event.txt
+                      output.tar
+                  if-no-files-found: error
+                  retention-days: 1
               #uses: sonarsource/sonarcloud-github-action@master
               #env:
-                  #GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
-                  #SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+              #GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
+              #SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     version:
         # Run version job only on pushes to the main branch. The job depends on completion of the build job.
         if: github.repository == 'SAP/open-ux-odata' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         needs: build
+        environment: release
+        permissions:
+            contents: write
+            id-token: write
         outputs:
             changes: ${{ steps.changesetVersion.outputs.changes }} # map step output to job output
         steps:
+            - name: Generate app token
+              id: app-token
+              uses: actions/create-github-app-token@v1
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
             - name: Checkout code repository
               uses: actions/checkout@v3
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.ACCESS_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
             - name: Use Node.js 20.x
               uses: actions/setup-node@v3
               with:
@@ -102,7 +112,7 @@ jobs:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
                   restore-keys: |
                       ${{ runner.os }}-build-${{ env.cache-name }}-
-            
+
             - name: Install pnpm modules
               run: pnpm install
             - name: Apply changesets
@@ -128,6 +138,9 @@ jobs:
         if: github.repository == 'SAP/open-ux-odata' && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.version.outputs.changes == 'false'
         runs-on: ubuntu-latest
         needs: version
+        permissions:
+            contents: write
+            id-token: write
         steps:
             - name: Checkout code repository
               uses: actions/checkout@v3
@@ -148,7 +161,7 @@ jobs:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
                   restore-keys: |
                       ${{ runner.os }}-build-${{ env.cache-name }}-
-           
+
             - name: Install pnpm modules
               run: pnpm install
             - name: Run build
@@ -160,4 +173,4 @@ jobs:
               with:
                   publish: pnpm ci:publish
               env:
-                  GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -24,7 +24,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Setup pnpm
-              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
               with:
                   run_install: true
             - name: Cache pnpm modules
@@ -101,7 +101,7 @@ jobs:
               with:
                   node-version: 22.x
             - name: Setup pnpm
-              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
               with:
                   run_install: true
             - name: Cache pnpm modules
@@ -151,7 +151,7 @@ jobs:
               with:
                   node-version: 22.x
             - name: Setup pnpm
-              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
               with:
                   run_install: true
             - name: Cache pnpm modules

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -7,16 +7,24 @@ jobs:
     slashCommandDispatch:
         runs-on: ubuntu-latest
         steps:
-            - uses: xt0rted/pull-request-comment-branch@v1
+            - uses: xt0rted/pull-request-comment-branch@653a7d5ca8bd91d3c5cb83286063314d0b063b8e # v1
               id: comment-branch
               continue-on-error: true
 
+            - name: Generate app token
+              id: app-token
+              if: success() && steps.comment-branch.outputs.head_ref
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
             - name: Slash Command Dispatch
-              uses: peter-evans/slash-command-dispatch@v3
+              uses: peter-evans/slash-command-dispatch@f996d7b7aae9059759ac55e978cff76d91853301 # v3
               if: success() && steps.comment-branch.outputs.head_ref
               id: slash-command
               with:
-                  token: ${{ secrets.ACCESS_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   commands: |
                       lockfiles
                   permission: write

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     slashCommandDispatch:
         runs-on: ubuntu-latest
-        environment: release
+        environment: automation
         steps:
             - uses: xt0rted/pull-request-comment-branch@653a7d5ca8bd91d3c5cb83286063314d0b063b8e # v1
               id: comment-branch

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -6,6 +6,7 @@ on:
 jobs:
     slashCommandDispatch:
         runs-on: ubuntu-latest
+        environment: release
         steps:
             - uses: xt0rted/pull-request-comment-branch@653a7d5ca8bd91d3c5cb83286063314d0b063b8e # v1
               id: comment-branch

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -8,6 +8,7 @@ jobs:
   sonar:
     name: 'Sonar analysis'
     runs-on: ubuntu-latest
+    environment: sonar
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       actions: read # Required to download artifacts
@@ -15,19 +16,19 @@ jobs:
       statuses: write # Required for SonarCloud to post quality gate commit status
     steps:
       - name: 'Checkout project'
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of Sonar analysis
 
-      - name: 'Download cacjed artifact'
+      - name: 'Download cached artifact'
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sonar-artifact
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.ACCESS_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           merge-multiple: true
 
       - name: 'Extract output artifact'
@@ -45,7 +46,7 @@ jobs:
 
       - name: 'Run SonarCloud scan'
         if: github.event_name == 'workflow_run'
-        uses: SonarSource/sonarqube-scan-action@v6.0.0
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         with:
           args: >
             ${{ github.event.workflow_run.event == 'pull_request' && format('{0}{1}', '-Dsonar.scm.revision=', github.event.workflow_run.head_sha) || '' }}
@@ -53,5 +54,5 @@ jobs:
             ${{ github.event.workflow_run.event == 'pull_request' && format('{0}{1}', '-Dsonar.pullrequest.branch=', env.pr_head_ref) || '' }}
             ${{ github.event.workflow_run.event == 'pull_request' && format('{0}{1}', '-Dsonar.pullrequest.base=', env.pr_base_ref) || '' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
-save-prefix=''
 stream=true
-engine-strict=true
-link-workspace-packages=true

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "engines": {
         "npm": "please-use-pnpm",
         "yarn": "please-use-pnpm",
-        "pnpm": "9",
+        "pnpm": "11",
         "node": ">=18.x"
     },
-    "packageManager": "pnpm@9.7.0"
+    "packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 packages:
     - 'packages/**'
     - 'samples/**'
+
+pnpm:
+    saveExact: true
+    engineStrict: true
+    linkWorkspacePackages: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,11 @@
 packages:
-    - 'packages/**'
-    - 'samples/**'
+  - 'packages/**'
+  - 'samples/**'
+
+allowBuilds:
+  '@zowe/secrets-for-zowe-sdk': true
 
 pnpm:
-    saveExact: true
-    engineStrict: true
-    linkWorkspacePackages: true
+  saveExact: true
+  engineStrict: true
+  linkWorkspacePackages: true


### PR DESCRIPTION
Fixes version job failure (GH006 protected branch). Switches from ACCESS_PAT to GitHub App token, mirroring the open-ux-tools pipeline pattern.

## Changes
- `version` job: add `environment: release`, explicit `permissions`, new `Generate app token` step using `actions/create-github-app-token@v1`, checkout now uses the app token instead of `ACCESS_PAT`
- `release` job: add explicit `permissions: contents: write`, switch `GITHUB_TOKEN` from `ACCESS_PAT` to `GITHUB_TOKEN`

## Required secrets setup
Before this can work, a repo admin must:
1. Create a `release` environment in repo Settings → Environments
2. Add `APP_ID` and `APP_PRIVATE_KEY` secrets to that environment (same GitHub App used by `open-ux-tools`)
3. Ensure the GitHub App is installed on this repo with bypass branch protection rights