### PR TITLE
fix(fe-mockserver-core): include ETag header in 204 minimal representation responses

### DIFF
--- a/.changeset/etag-minimal-representation.md
+++ b/.changeset/etag-minimal-representation.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fe-mockserver-core": patch
+---
+
+Include ETag response header in 204 minimal representation responses. When a PATCH request is sent with `Prefer: return=minimal`, the mock server now returns the updated ETag in the response header, matching real backend behaviour and preventing false optimistic concurrency conflicts on subsequent requests in the same session.

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -611,6 +611,9 @@ export default class ODataRequest {
             if (this.isMinimalRepresentation) {
                 this.statusCode = 204;
                 this.addResponseHeader('preference-applied', 'return=minimal');
+                if (this.elementETag) {
+                    this.addResponseHeader('ETag', this.elementETag);
+                }
                 return null;
             } else {
                 this.addResponseHeader(

--- a/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
+++ b/packages/fe-mockserver-core/test/unit/request/odataRequest.test.ts
@@ -1051,6 +1051,39 @@ describe('OData Request', () => {
         });
     });
 
+    test('It includes ETag header in 204 minimal representation response', () => {
+        const request = new ODataRequest(
+            {
+                method: 'PATCH',
+                url: '/Countries(1)',
+                headers: { prefer: 'return=minimal' }
+            },
+            fakeDataAccess
+        );
+        request.setETag('"W/abc123"');
+        request.getResponseData();
+
+        expect(request.statusCode).toBe(204);
+        expect(request.responseHeaders['preference-applied']).toBe('return=minimal');
+        expect(request.responseHeaders['ETag']).toBe('"W/abc123"');
+    });
+
+    test('It does not include ETag header in 204 minimal representation response when no ETag is set', () => {
+        const request = new ODataRequest(
+            {
+                method: 'PATCH',
+                url: '/Countries(1)',
+                headers: { prefer: 'return=minimal' }
+            },
+            fakeDataAccess
+        );
+        request.getResponseData();
+
+        expect(request.statusCode).toBe(204);
+        expect(request.responseHeaders['preference-applied']).toBe('return=minimal');
+        expect(request.responseHeaders['ETag']).toBeUndefined();
+    });
+
     test('It can consider POST queries with x-http-method as their correct equivalent', async () => {
         const myRequest = new ODataRequest(
             {


### PR DESCRIPTION
## Summary

- When a PATCH is sent with `Prefer: return=minimal`, the mock server returns `204 No Content` but was not including the updated `ETag` header in the response
- This causes the client to retain a stale ETag, which then triggers a false optimistic concurrency conflict on the next field change in the same editing session
- OData V4 spec §11.4.3 explicitly allows `ETag` to be included in `204` responses — real backends (e.g. S/4HANA) already return it

## Change

In `packages/fe-mockserver-core/src/request/odataRequest.ts`, when `isMinimalRepresentation` is true, the updated `elementETag` is now echoed back as a response header (guarded by a null check so entities without ETags are unaffected).

```ts
if (this.isMinimalRepresentation) {
    this.statusCode = 204;
    this.addResponseHeader('preference-applied', 'return=minimal');
    if (this.elementETag) {
        this.addResponseHeader('ETag', this.elementETag);  // ← new
    }
    return null;
}
```

## Test plan

- [ ] Existing `fe-mockserver-core` unit tests pass
- [ ] The skipped test `"Second change in single session should not show an ETAG conflict"` in `BasicEtag.spec.ts` (SAP Fiori Elements testsuite) can be un-skipped and passes