### PR TITLE
fix: sonar issue `Await or return this async assertion.` in test file

### DIFF
--- a/packages/fe-mockserver-core/test/unit/data/functionBasedMockData.test.ts
+++ b/packages/fe-mockserver-core/test/unit/data/functionBasedMockData.test.ts
@@ -65,7 +65,7 @@ describe('Function Based Mock Data', () => {
         expect(mockData.length).toBe(1);
         // Fake that in tenant 002 we throw an error
         fakeRequest.tenantId = 'tenant-002';
-        expect(() => {
+        await expect(() => {
             return myEntitySet.getMockData('tenant-002').getAllEntries(fakeRequest) as any;
         }).rejects.toThrow('This tenant is not allowed for you');
         await fakeRequest.handleRequest();


### PR DESCRIPTION
Fix for sonar issue `Await or return this async assertion.` in `packages/fe-mockserver-core/test/unit/data/functionBasedMockData.test.ts` file to avoid failure of quality gate.

No changelog as there is no any source code change