### PR TITLE
chore: update vocabularies-types to latest published vocabularies

### DIFF
--- a/.changeset/update-vocabularies-types.md
+++ b/.changeset/update-vocabularies-types.md
@@ -1,0 +1,11 @@
+---
+'@sap-ux/vocabularies-types': minor
+---
+
+Update vocabularies types to the latest published vocabularies. Notable changes:
+
+- **UI**: add `UI.CardItem` term and `CardItemType` (card structure for Grid List visualization)
+- **Capabilities**: add `ExpandCollectionRestrictionsType`, `ExpandByKeyRestrictionsBase` and `ExpandByKeyRestrictionsType`
+- **PersonalData**: add `RelatedDataCategoryID` term
+- **Common**: rework revision info (`SourceEntitiesInserted`/`SourceEntitiesUpdated`/`SourceEntitiesDeleted`)
+- **Core**: documentation wording fixes


### PR DESCRIPTION
## What

Regenerates `@sap-ux/vocabularies-types` from the latest published OData vocabularies (the unversioned OASIS/SAP source URLs in `utils/config.json`) and adds a `minor` changeset to trigger a republish.

## Notable vocabulary changes since 0.15.0

- **UI**: add `UI.CardItem` term and `CardItemType` (card structure for Grid List visualization)
- **Capabilities**: add `ExpandCollectionRestrictionsType`, `ExpandByKeyRestrictionsBase`, `ExpandByKeyRestrictionsType`
- **PersonalData**: add `RelatedDataCategoryID` term
- **Common**: rework revision info (`SourceEntitiesInserted`/`SourceEntitiesUpdated`/`SourceEntitiesDeleted`)
- **Core**: documentation wording fixes

## Verification

- `pnpm build` — all packages compile with regenerated types
- Tests green: edmx-parser 614/614, annotation-converter 152/152

## Note

The generated `.d.ts` files are gitignored; only the changeset is committed. On release, CI regenerates from the **live** vocabulary URLs, so the published snapshot reflects whatever is live at merge time.