### PR TITLE
fix(fe-mockserver-core): propagate DraftAdministrativeData on draftEdit and return 200 for null nav properties

### DIFF
--- a/.changeset/draft-administrative-data-propagation.md
+++ b/.changeset/draft-administrative-data-propagation.md
@@ -1,0 +1,9 @@
+---
+'@sap-ux/fe-mockserver-core': patch
+---
+
+fix: propagate DraftAdministrativeData on draftEdit and return 200 for null navigation properties
+
+- draftEdit now copies DraftAdministrativeData onto the active entity so GET Active/DraftAdministrativeData returns data instead of null
+- draftDiscard now resets DraftAdministrativeData to null on the active entity
+- Navigation paths that resolve to null now return HTTP 200 instead of 404, consistent with the OData spec

--- a/packages/fe-mockserver-core/src/data/entitySets/draftEntitySet.ts
+++ b/packages/fe-mockserver-core/src/data/entitySets/draftEntitySet.ts
@@ -218,6 +218,7 @@ export class DraftMockEntitySet extends MockDataEntitySet {
                     LastChangedByUserDescription: 'nobody',
                     InProcessByUserDescription: 'nobody'
                 };
+                data.DraftAdministrativeData = duplicate.DraftAdministrativeData;
                 await currentMockData.addEntry(duplicate, odataRequest);
                 await this.createInactiveVersionForNavigations(data, tenantId, odataRequest);
             }
@@ -264,6 +265,7 @@ export class DraftMockEntitySet extends MockDataEntitySet {
             )) as DraftElement;
             if (newActiveData) {
                 newActiveData.HasDraftEntity = false;
+                newActiveData.DraftAdministrativeData = null;
             }
         }
         const activeVersionOfDeletedKeys: any = Object.assign({}, keyValues);

--- a/packages/fe-mockserver-core/src/request/odataRequest.ts
+++ b/packages/fe-mockserver-core/src/request/odataRequest.ts
@@ -513,7 +513,7 @@ export default class ODataRequest {
                     const actionResponse = await this.dataAccess.performAction(this);
                     if (actionResponse === null) {
                         const retrievedData = await this.dataAccess.getData(this);
-                        if (retrievedData === undefined || retrievedData === null) {
+                        if (retrievedData === undefined || (retrievedData === null && this.queryPath.length === 1)) {
                             this.statusCode = 404;
                             this.setResponseData('');
                         } else {

--- a/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
+++ b/packages/fe-mockserver-core/test/unit/v4/dataAccess.test.ts
@@ -1980,4 +1980,83 @@ describe('Data Access', () => {
             expect(formData.DraftAdministrativeData).toBeNull();
         });
     });
+
+    describe('draftEdit DraftAdministrativeData propagation', () => {
+        let freshDataAccess: DataAccess;
+
+        beforeAll(async () => {
+            const baseDir = join(__dirname, 'services', 'formSample');
+            const edmx = await metadataProvider.loadMetadata(join(baseDir, '/FormTemplate.cds'));
+            const freshMetadata = await ODataMetadata.parse(edmx, baseUrl + '/$metadata');
+            const serviceRegistry = {
+                getService: jest.fn(),
+                registerService: jest.fn(),
+                getServicesWithAliases: jest.fn()
+            } as any;
+            freshDataAccess = new DataAccess(
+                { mockdataPath: baseDir } as ServiceConfig,
+                freshMetadata,
+                fileLoader,
+                undefined,
+                serviceRegistry
+            );
+        });
+
+        test('draftEdit sets DraftAdministrativeData on the active entity', async () => {
+            await freshDataAccess.performAction(
+                new ODataRequest(
+                    { method: 'GET', url: '/FormRoot(ID=0,IsActiveEntity=true)/sap.fe.core.Form.draftEdit' },
+                    freshDataAccess
+                )
+            );
+
+            const activeEntity = await freshDataAccess.getData(
+                new ODataRequest(
+                    { method: 'GET', url: '/FormRoot(ID=0,IsActiveEntity=true)?$expand=DraftAdministrativeData' },
+                    freshDataAccess
+                )
+            );
+            expect(activeEntity.DraftAdministrativeData).not.toBeNull();
+            expect(activeEntity.DraftAdministrativeData.DraftUUID).toBeDefined();
+        });
+
+        test('navigating to a null DraftAdministrativeData nav property returns 200, not 404', async () => {
+            // Entity ID=0 already has a draft from the previous test; activate it so DraftAdministrativeData resets to null
+            await freshDataAccess.performAction(
+                new ODataRequest(
+                    { method: 'GET', url: '/FormRoot(ID=0,IsActiveEntity=false)/sap.fe.core.Form.draftActivate' },
+                    freshDataAccess
+                )
+            );
+
+            // Active entity now has DraftAdministrativeData = null
+            const request = new ODataRequest(
+                { method: 'GET', url: '/FormRoot(ID=0,IsActiveEntity=true)/DraftAdministrativeData' },
+                freshDataAccess
+            );
+            await request.handleRequest();
+            expect(request.statusCode).toEqual(200);
+        });
+
+        test('draftDiscard resets DraftAdministrativeData to null on the active entity', async () => {
+            await freshDataAccess.performAction(
+                new ODataRequest(
+                    { method: 'GET', url: '/FormRoot(ID=0,IsActiveEntity=true)/sap.fe.core.Form.draftEdit' },
+                    freshDataAccess
+                )
+            );
+
+            await freshDataAccess.deleteData(
+                new ODataRequest({ method: 'DELETE', url: '/FormRoot(ID=0,IsActiveEntity=false)' }, freshDataAccess)
+            );
+
+            const activeEntity = await freshDataAccess.getData(
+                new ODataRequest(
+                    { method: 'GET', url: '/FormRoot(ID=0,IsActiveEntity=true)?$expand=DraftAdministrativeData' },
+                    freshDataAccess
+                )
+            );
+            expect(activeEntity.DraftAdministrativeData).toBeNull();
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Fixes two gaps in `@sap-ux/fe-mockserver-core` that caused the **Discard Draft** flow to fail with _"Communication error: 404 Not Found"_ when running against the mock server (regression surfaced by a batching optimisation in UI5 1.136.1 that combined `SiblingEntity` and `DraftAdministrativeData` requests into a single `$batch`).

- **`draftEdit`**: after creating the draft copy, now copies `DraftAdministrativeData` from the draft onto the active entity — so `GET Active(key)/DraftAdministrativeData` returns the admin data instead of `null`, matching real CAP Java backend behaviour
- **`draftDiscard`**: now resets `DraftAdministrativeData = null` on the active entity alongside `HasDraftEntity = false`, keeping state consistent after a discard
- **`odataRequest` GET handler**: a `null` result from `getData()` on a multi-segment (navigation) path now returns `HTTP 200` instead of `404`, consistent with the OData spec for null single-valued navigation properties; single-segment direct entity lookups that return `null` (entity not found) continue to return `404`

## Test plan

- [ ] New `describe` block `draftEdit DraftAdministrativeData propagation` added to `test/unit/v4/dataAccess.test.ts` with three tests:
  - `draftEdit sets DraftAdministrativeData on the active entity`
  - `navigating to a null DraftAdministrativeData nav property returns 200, not 404`
  - `draftDiscard resets DraftAdministrativeData to null on the active entity`
- [ ] All 211 pre-existing tests continue to pass (206 snapshots pass)